### PR TITLE
feat(seo): SEO/GEO 5-phase upgrade — entity content, capability-aware landing, compound URLs, related books, UGC infrastructure

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1533,6 +1533,79 @@ def list_books_for_mind(mind_id: str, limit: int = 12) -> list[dict[str, Any]]:
         return out
 
 
+def list_questions_batch(agent_ids: list[str]) -> dict[str, list[str]]:
+    """Fetch the question texts for many agents in one query — used by
+    sitemap rendering, which would otherwise issue N round-trips.
+
+    Returns {agent_id: [question_text, ...]}. Agents with no questions
+    are omitted from the result, so callers can `.get(id, [])` safely.
+    """
+    if not agent_ids:
+        return {}
+    placeholders = ",".join(["?"] * len(agent_ids))
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            f"""SELECT agent_id, text FROM questions
+                WHERE agent_id IN ({placeholders})
+                ORDER BY agent_id, created_at ASC"""
+        ), tuple(agent_ids))
+    out: dict[str, list[str]] = {}
+    for r in rows:
+        out.setdefault(r["agent_id"], []).append(r["text"])
+    return out
+
+
+def list_books_by_topic(topic: str, limit: int = 30) -> list[dict[str, Any]]:
+    """Books tagged with a given topic via ``meta.category`` (set by
+    ``create_catalog_agent`` during topic-driven discovery).
+
+    Implementation note: agents.meta is JSON-stringified text, and we have
+    no JSON-aware index on it. We could push the predicate down with
+    ``json_extract`` / ``jsonb->>'category'`` but the corpus is small
+    (~hundreds) and the call site is cached by the page handler with a
+    long TTL, so an in-Python filter is fast enough and portable across
+    SQLite/Postgres without dialect branching.
+    """
+    if not topic:
+        return []
+    out = []
+    for agent in list_agents(limit=2000):
+        if agent.get("status") not in ("ready", "catalog"):
+            continue
+        meta = agent.get("meta") or {}
+        if not isinstance(meta, dict):
+            continue
+        if (meta.get("category") or "").strip().lower() == topic.strip().lower():
+            out.append({
+                "id": agent["id"],
+                "name": agent.get("name", ""),
+                "type": agent.get("type", ""),
+                "author": meta.get("author", ""),
+            })
+            if len(out) >= limit:
+                break
+    return out
+
+
+def list_minds_by_topic(topic: str, limit: int = 12) -> list[dict[str, Any]]:
+    """Minds whose ``domain`` (comma-separated) contains the given topic
+    as a substring. ``domain`` was designed for human-readable tag
+    display; matching is intentionally loose so 'Economics' picks up
+    'Economics, Moral Philosophy' too.
+    """
+    if not topic:
+        return []
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            """SELECT id, name, era, domain
+               FROM minds
+               WHERE domain LIKE ?
+               ORDER BY chat_count DESC, name ASC
+               LIMIT ?"""
+        ), (f"%{topic}%", limit))
+        return [dict(r) for r in rows]
+
+
 def list_related_minds(mind_id: str, domain: str, limit: int = 6) -> list[dict[str, Any]]:
     """Other minds sharing at least one domain tag with this mind. Domain is
     a comma-separated string in the schema, so we match by substring on any

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1482,6 +1482,77 @@ def get_mind_work_ids(mind_id: str) -> list[str]:
         return [r["agent_id"] for r in rows]
 
 
+# ─── SEO/landing-page helpers (cheap read-only queries used by SSR) ───
+#
+# These power the per-entity landing pages (/book/{id}, /mind/{id}). They are
+# called on every crawler/share visit, so they must stay O(small) and avoid
+# vector blob egress. All queries are bounded by an explicit LIMIT.
+
+def list_minds_for_agent(agent_id: str, limit: int = 12) -> list[dict[str, Any]]:
+    """Minds whose work corpus includes this book — used to render the
+    "Discussed by Great Minds" section on /book/{id} and drive internal
+    PageRank from book pages → mind pages."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            """SELECT m.id, m.name, m.era, m.domain
+               FROM mind_works mw
+               JOIN minds m ON m.id = mw.mind_id
+               WHERE mw.agent_id = ?
+               ORDER BY m.name ASC
+               LIMIT ?"""
+        ), (agent_id, limit))
+        return [dict(r) for r in rows]
+
+
+def list_books_for_mind(mind_id: str, limit: int = 12) -> list[dict[str, Any]]:
+    """Books in this mind's corpus, with enough fields to render link text
+    on /mind/{id}. Filters to ready agents only — drafts shouldn't appear
+    on a public landing page."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            """SELECT a.id, a.name, a.type, a.meta
+               FROM mind_works mw
+               JOIN agents a ON a.id = mw.agent_id
+               WHERE mw.mind_id = ? AND a.status = 'ready'
+               ORDER BY a.name ASC
+               LIMIT ?"""
+        ), (mind_id, limit))
+        out = []
+        for r in rows:
+            meta_raw = r.get("meta") if isinstance(r, dict) else r["meta"]
+            try:
+                meta = json.loads(meta_raw) if isinstance(meta_raw, str) else (meta_raw or {})
+            except Exception:
+                meta = {}
+            out.append({
+                "id": r["id"],
+                "name": r["name"],
+                "type": r["type"],
+                "author": meta.get("author", ""),
+            })
+        return out
+
+
+def list_related_minds(mind_id: str, domain: str, limit: int = 6) -> list[dict[str, Any]]:
+    """Other minds sharing at least one domain tag with this mind. Domain is
+    a comma-separated string in the schema, so we match by substring on any
+    token. Excludes the mind itself."""
+    if not domain:
+        return []
+    primary = domain.split(",")[0].strip()
+    if not primary:
+        return []
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            """SELECT id, name, era, domain
+               FROM minds
+               WHERE id <> ? AND domain LIKE ?
+               ORDER BY chat_count DESC, name ASC
+               LIMIT ?"""
+        ), (mind_id, f"%{primary}%", limit))
+        return [dict(r) for r in rows]
+
+
 # ─── Mind memories ───
 
 def add_mind_memory(mind_id: str, summary: str, topic: str = "", user_id: str | None = None) -> None:

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -384,6 +384,29 @@ def init_db() -> None:
             except Exception:
                 _execute(conn, "ROLLBACK TO SAVEPOINT sp_chat_sessions_uid")
 
+            # Migration: UGC / public-discussions columns on chat_sessions.
+            # All additive + defaulted to the most private value so existing
+            # rows keep their privacy. The whole feature surface is gated
+            # in main.py by ENABLE_PUBLIC_DISCUSSIONS (default False), so
+            # adding these columns does NOT expose any conversation until
+            # both (a) a user opts in via the /share API AND (b) the env
+            # flag is flipped.
+            for col, col_type, default in [
+                ("public_status", "TEXT", "'private'"),
+                ("public_handle", "TEXT", "NULL"),
+                ("public_title", "TEXT", "NULL"),
+                ("consent_at", "TIMESTAMPTZ", "NULL"),
+                ("approved_at", "TIMESTAMPTZ", "NULL"),
+                ("approved_by", "TEXT", "NULL"),
+            ]:
+                try:
+                    _execute(conn, f"SAVEPOINT sp_cs_{col}")
+                    null_clause = "" if default == "NULL" else f" NOT NULL DEFAULT {default}"
+                    _execute(conn, f"ALTER TABLE chat_sessions ADD COLUMN {col} {col_type}{null_clause}")
+                    _execute(conn, f"RELEASE SAVEPOINT sp_cs_{col}")
+                except Exception:
+                    _execute(conn, f"ROLLBACK TO SAVEPOINT sp_cs_{col}")
+
             # ── Now safe to create indexes on migrated columns ──
             _execute(conn, "CREATE INDEX IF NOT EXISTS idx_agents_user ON agents(user_id)")
             _execute(conn, "CREATE INDEX IF NOT EXISTS idx_messages_user ON messages(agent_id, user_id)")
@@ -752,6 +775,22 @@ def init_db() -> None:
                 _execute(conn, "DELETE FROM chat_sessions WHERE user_id IS NULL")
             except Exception:
                 pass  # column already exists
+
+            # Migration: UGC / public-discussions columns. Mirrors the PG
+            # branch above. See that comment for the privacy + feature-flag
+            # safety story.
+            for col_sql in [
+                "ALTER TABLE chat_sessions ADD COLUMN public_status TEXT NOT NULL DEFAULT 'private'",
+                "ALTER TABLE chat_sessions ADD COLUMN public_handle TEXT",
+                "ALTER TABLE chat_sessions ADD COLUMN public_title TEXT",
+                "ALTER TABLE chat_sessions ADD COLUMN consent_at TEXT",
+                "ALTER TABLE chat_sessions ADD COLUMN approved_at TEXT",
+                "ALTER TABLE chat_sessions ADD COLUMN approved_by TEXT",
+            ]:
+                try:
+                    _execute(conn, col_sql)
+                except Exception:
+                    pass  # column already exists
 
             # Migration: add user_id to messages table
             try:
@@ -1584,6 +1623,254 @@ def list_books_by_topic(topic: str, limit: int = 30) -> list[dict[str, Any]]:
             })
             if len(out) >= limit:
                 break
+    return out
+
+
+# ─── UGC / public-discussion queries (Phase 6) ───────────────────────
+#
+# All read helpers filter on `public_status = 'approved'` — they cannot
+# return private or pending sessions even if a caller forgets to check
+# the feature flag. The write helpers enforce session ownership for
+# user-initiated state changes and only an admin caller (verified by
+# the route handler) should hit `approve_chat_session_public`.
+
+def get_chat_session_with_public_status(session_id: str) -> dict[str, Any] | None:
+    """Fetch a chat session including the UGC columns. Used by the
+    moderation API and ownership checks. Returns None if the session
+    doesn't exist."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            """SELECT id, user_id, title, session_type, mind_id,
+                      public_status, public_handle, public_title,
+                      consent_at, approved_at, approved_by,
+                      updated_at, created_at
+               FROM chat_sessions WHERE id = ?"""
+        ), (session_id,))
+        if not row:
+            return None
+        return dict(row)
+
+
+def request_chat_session_share(
+    session_id: str, user_id: str, handle: str | None = None,
+) -> dict[str, Any] | None:
+    """User opts in to making this session public. Sets status to
+    'opted_in' (awaiting moderation) and stamps consent_at. Returns the
+    updated session row, or None if the session doesn't exist / user
+    doesn't own it / withdrawn-by-admin (rejected can't re-share).
+    """
+    sess = get_chat_session_with_public_status(session_id)
+    if not sess or sess.get("user_id") != user_id:
+        return None
+    # Rejected sessions can't re-share — admin already declined. User
+    # can still chat in them; they just can't be public.
+    if sess.get("public_status") == "rejected":
+        return None
+    with get_conn() as conn:
+        _execute(conn, _q(
+            """UPDATE chat_sessions
+               SET public_status = 'opted_in',
+                   public_handle = ?,
+                   consent_at = ?
+               WHERE id = ? AND user_id = ?"""
+        ), (handle, _utcnow(), session_id, user_id))
+    return get_chat_session_with_public_status(session_id)
+
+
+def withdraw_chat_session_share(
+    session_id: str, user_id: str,
+) -> dict[str, Any] | None:
+    """User withdraws consent — flips status to 'withdrawn'. Works at
+    any prior status (opted_in or already approved). Returns updated
+    row or None if not found / not owned."""
+    sess = get_chat_session_with_public_status(session_id)
+    if not sess or sess.get("user_id") != user_id:
+        return None
+    with get_conn() as conn:
+        _execute(conn, _q(
+            "UPDATE chat_sessions SET public_status = 'withdrawn' WHERE id = ? AND user_id = ?"
+        ), (session_id, user_id))
+    return get_chat_session_with_public_status(session_id)
+
+
+def approve_chat_session_public(
+    session_id: str, admin_user_id: str, public_title: str | None = None,
+) -> dict[str, Any] | None:
+    """Admin approves an opted-in session for public display. Caller
+    must have verified admin status (route handler responsibility).
+    Sets status to 'approved' and stamps approval audit fields."""
+    sess = get_chat_session_with_public_status(session_id)
+    if not sess:
+        return None
+    # Only opted-in sessions can be approved. Won't accidentally
+    # re-approve a withdrawn or rejected session.
+    if sess.get("public_status") != "opted_in":
+        return None
+    with get_conn() as conn:
+        _execute(conn, _q(
+            """UPDATE chat_sessions
+               SET public_status = 'approved',
+                   approved_at = ?,
+                   approved_by = ?,
+                   public_title = COALESCE(?, public_title)
+               WHERE id = ?"""
+        ), (_utcnow(), admin_user_id, public_title, session_id))
+    return get_chat_session_with_public_status(session_id)
+
+
+def reject_chat_session_public(
+    session_id: str, admin_user_id: str,
+) -> dict[str, Any] | None:
+    """Admin rejects an opted-in session. Status -> 'rejected'."""
+    sess = get_chat_session_with_public_status(session_id)
+    if not sess or sess.get("public_status") != "opted_in":
+        return None
+    with get_conn() as conn:
+        _execute(conn, _q(
+            """UPDATE chat_sessions
+               SET public_status = 'rejected',
+                   approved_at = ?,
+                   approved_by = ?
+               WHERE id = ?"""
+        ), (_utcnow(), admin_user_id, session_id))
+    return get_chat_session_with_public_status(session_id)
+
+
+def list_public_sessions_for_agent(
+    agent_id: str, limit: int = 12,
+) -> list[dict[str, Any]]:
+    """Approved public chat sessions for a book (session_type='book',
+    `mind_id` column stores the agent id in this schema overload).
+    Ordered by approval recency."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            """SELECT id, user_id, title, public_handle, public_title,
+                      approved_at, created_at
+               FROM chat_sessions
+               WHERE session_type = 'book'
+                 AND mind_id = ?
+                 AND public_status = 'approved'
+               ORDER BY approved_at DESC, created_at DESC
+               LIMIT ?"""
+        ), (agent_id, limit))
+        return [dict(r) for r in rows]
+
+
+def list_public_sessions_for_mind(
+    mind_id: str, limit: int = 12,
+) -> list[dict[str, Any]]:
+    """Approved public chat sessions for a mind. Uses the canonical
+    session_type='chat' + mind_id binding."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            """SELECT id, user_id, title, public_handle, public_title,
+                      approved_at, created_at
+               FROM chat_sessions
+               WHERE session_type IN ('chat', 'mind')
+                 AND mind_id = ?
+                 AND public_status = 'approved'
+               ORDER BY approved_at DESC, created_at DESC
+               LIMIT ?"""
+        ), (mind_id, limit))
+        return [dict(r) for r in rows]
+
+
+def list_messages_for_public_session(
+    session_id: str, limit: int = 12,
+) -> list[dict[str, Any]]:
+    """Read messages for public display. SAFETY-CRITICAL:
+    only returns rows if the session's public_status is 'approved'.
+    Caller (the /discussions page renderer) must still PII-scrub the
+    text before display — this function does not scrub, only gates."""
+    with get_conn() as conn:
+        # Single round-trip: gate on approved status by joining the
+        # parent session row.
+        rows = _fetchall(conn, _q(
+            """SELECT sm.id, sm.role, sm.content, sm.created_at
+               FROM session_messages sm
+               JOIN chat_sessions cs ON cs.id = sm.session_id
+               WHERE sm.session_id = ?
+                 AND cs.public_status = 'approved'
+               ORDER BY sm.created_at ASC
+               LIMIT ?"""
+        ), (session_id, limit))
+        return [dict(r) for r in rows]
+
+
+def count_pending_public_sessions() -> int:
+    """How many sessions are awaiting moderation. Used by admin endpoints
+    and dashboards (the moderation queue size)."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT COUNT(*) AS n FROM chat_sessions WHERE public_status = 'opted_in'"
+        ))
+        return int(row["n"]) if row else 0
+
+
+def list_related_books(
+    exclude_agent_id: str,
+    topic: str = "",
+    author: str = "",
+    limit: int = 6,
+) -> list[dict[str, Any]]:
+    """Books related to one we're already rendering. Prefers same-topic,
+    then same-author, excluding the source book itself. Used for the
+    "Related Books" section on /book/{id} (Phase 5 — closes the
+    book↔book half of the internal linking graph).
+
+    Same in-Python filter pattern as list_books_by_topic — corpus is
+    small, queries are cached at the page handler level."""
+    if not exclude_agent_id:
+        return []
+    topic_lower = topic.strip().lower() if topic else ""
+    author_lower = author.strip().lower() if author else ""
+
+    # Two passes: topic matches first (higher relevance), then author
+    # matches that we haven't already picked. Stable ordering by name
+    # to keep the rendered list deterministic between cache misses.
+    seen: set[str] = {exclude_agent_id}
+    out: list[dict[str, Any]] = []
+
+    def _push(agent: dict[str, Any]) -> None:
+        if agent["id"] in seen:
+            return
+        meta = agent.get("meta") or {}
+        if not isinstance(meta, dict):
+            meta = {}
+        out.append({
+            "id": agent["id"],
+            "name": agent.get("name", ""),
+            "type": agent.get("type", ""),
+            "author": meta.get("author", ""),
+        })
+        seen.add(agent["id"])
+
+    all_agents = list_agents(limit=2000)
+
+    if topic_lower:
+        for a in all_agents:
+            if len(out) >= limit:
+                break
+            if a.get("status") not in ("ready", "catalog"):
+                continue
+            meta = a.get("meta") or {}
+            if not isinstance(meta, dict):
+                continue
+            if (meta.get("category") or "").strip().lower() == topic_lower:
+                _push(a)
+
+    if author_lower and len(out) < limit:
+        for a in all_agents:
+            if len(out) >= limit:
+                break
+            if a.get("status") not in ("ready", "catalog"):
+                continue
+            meta = a.get("meta") or {}
+            if not isinstance(meta, dict):
+                continue
+            if (meta.get("author") or "").strip().lower() == author_lower:
+                _push(a)
+
     return out
 
 

--- a/app/core/qa.py
+++ b/app/core/qa.py
@@ -1,0 +1,265 @@
+"""Grounded Q&A generation for /book/{id}/q/{slug} compound pages.
+
+The compound URL pattern (Phase 4A of the SEO/GEO plan) creates one
+indexable URL per popular question per book — 5 questions × hundreds of
+books = thousands of new long-tail entry points. Each page needs an
+answer that's:
+
+  * Grounded in the book's own chunks (no hallucination — every claim
+    traces back to a retrieved passage).
+  * Cheap enough to generate at crawler request time without bankrupting
+    us if Googlebot decides to enumerate everything in a day.
+  * Cacheable across requests so the second hit on a popular page is free.
+
+We use the existing RAG `retrieve()` pipeline to fetch the top passages,
+then call the LLM with a strict "synthesize ONLY from these passages"
+prompt. Answers are cached in-process; a missed cache (cold start, new
+URL) costs ~1 LLM round trip. Cache key is content-addressable on
+(agent_id, question) so renaming a question naturally invalidates the
+old answer.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+from .providers import chat_with_fallback, ProviderError
+from .rag import retrieve, build_context
+
+log = logging.getLogger(__name__)
+
+
+# Kill switch — set ENABLE_QA_LLM=false in env to render Q&A pages with
+# passages only (no synthesized answer). Useful if cost gets unexpectedly
+# high or if we want to A/B test the LLM contribution to ranking.
+_QA_LLM_ENABLED = os.getenv("ENABLE_QA_LLM", "true").strip().lower() not in (
+    "0", "false", "no", "off",
+)
+
+# Maximum chunks fed to the answer-synthesis prompt. Keep small to bound
+# both token cost and the chance the model wanders off into adjacent
+# material that doesn't address the question.
+_QA_RAG_TOP_K = 5
+
+# Hard cap on synthesized answer length so we don't render an essay where
+# we promised a paragraph.
+_QA_ANSWER_MAX_CHARS = 1200
+
+
+def is_llm_enabled() -> bool:
+    """Whether the module will attempt LLM synthesis. Handlers should still
+    render passages even if this is False — the page degrades to a
+    "question + sources" view, which is also valuable."""
+    return _QA_LLM_ENABLED
+
+
+# Kill switch for the mind-on-topic generator (Phase 4B). Separate flag
+# from QA so we can run book Q&A in prod and stage mind essays behind
+# an opt-in until we're confident about quality.
+_MIND_ESSAY_ENABLED = os.getenv("ENABLE_MIND_ESSAY", "true").strip().lower() not in (
+    "0", "false", "no", "off",
+)
+
+_MIND_ESSAY_MAX_CHARS = 1800
+_MIND_ESSAY_MIN_DOMAIN_OVERLAP_CHARS = 3
+
+
+def is_mind_essay_enabled() -> bool:
+    return _MIND_ESSAY_ENABLED
+
+
+def _morphological_stem(word: str) -> str:
+    """Lightweight suffix-stripping so 'Economics' ↔ 'Economy' ↔
+    'Economic' all collapse to a common 'econom' base. Not a real
+    stemmer — enough for the 15 hand-picked TOPIC_TAGS vs the ~50
+    hand-curated mind domains. False positives are acceptable; we'd
+    rather generate one borderline-relevant essay than skip a real
+    match."""
+    w = word.lower()
+    for suffix in ("ical", "ics", "ing", "ed", "al", "ly", "es", "s", "y"):
+        if len(w) > len(suffix) + 3 and w.endswith(suffix):
+            return w[: -len(suffix)]
+    return w
+
+
+def is_mind_topic_relevant(mind: dict[str, Any], topic: str) -> bool:
+    """Cheap pre-flight check: does this mind have any plausible connection
+    to this topic? Skips generation for nonsensical pairs (e.g. Confucius
+    on Computer Science) before we spend an LLM call on slop.
+
+    Matching is morphologically loose: 'Economics' picks up 'Political
+    Economy', 'Philosophy' picks up 'Philosophical', etc. False positives
+    are acceptable — the LLM essay prompt will still produce something
+    coherent for a borderline match — but obvious mismatches still 404.
+    """
+    if not mind or not topic:
+        return False
+    domain = (mind.get("domain") or "").lower()
+    if not domain:
+        return False
+    # Stem each domain token once
+    domain_stems = [_morphological_stem(t) for t in re.split(r"[,\s]+", domain) if t]
+    domain_blob = " ".join(domain_stems)
+
+    topic_lower = topic.lower()
+    # Whole-topic substring check on raw text — fast path for exact matches
+    if topic_lower in domain:
+        return True
+
+    # Tokenize topic, stem each, check against the stemmed domain blob.
+    skip = {"and", "the", "of", "in", "on", "for", "to", "&"}
+    for raw_token in re.split(r"[,\s&]+", topic_lower):
+        if len(raw_token) < _MIND_ESSAY_MIN_DOMAIN_OVERLAP_CHARS or raw_token in skip:
+            continue
+        stem = _morphological_stem(raw_token)
+        if len(stem) < _MIND_ESSAY_MIN_DOMAIN_OVERLAP_CHARS:
+            continue
+        if stem in domain_blob:
+            return True
+    return False
+
+
+def generate_mind_on_topic_essay(
+    mind: dict[str, Any], topic: str
+) -> dict[str, Any]:
+    """Generate a short essay framed as the mind's perspective on the
+    topic. Grounded in the mind's persona / thinking_style / typical
+    phrases, not free-form invention.
+
+    Returns {essay, provider}. essay may be empty if disabled or failed —
+    callers should not render an empty essay (handle 404 or fall back).
+    """
+    result: dict[str, Any] = {"essay": "", "provider": ""}
+    if not _MIND_ESSAY_ENABLED:
+        return result
+    if not mind or not topic:
+        return result
+    if not is_mind_topic_relevant(mind, topic):
+        return result
+
+    name = (mind.get("name") or "").strip()
+    bio = (mind.get("bio_summary") or "").strip()
+    thinking_style = (mind.get("thinking_style") or "").strip()
+    persona = (mind.get("persona") or "").strip()[:1500]
+    phrases = mind.get("typical_phrases") or []
+    if not isinstance(phrases, list):
+        phrases = []
+    phrases_str = "\n".join(f"- \"{p}\"" for p in phrases[:5] if p)
+
+    system = (
+        "You are writing a short imagined-perspective essay in the voice "
+        "of a specific historical or contemporary thinker. Stay strictly "
+        "in their authentic frame — use the methods, values, and concerns "
+        "their actual work exhibits. Do not put modern slang or modern "
+        "specific facts in their mouth they could not know. Begin "
+        "immediately with the essay — no preamble like 'Sure, here is...'."
+    )
+    user = (
+        f"Thinker: {name}\n"
+        f"Brief bio: {bio}\n"
+        f"Thinking style: {thinking_style}\n"
+        f"Characteristic phrases:\n{phrases_str}\n"
+        f"Persona notes:\n{persona}\n\n"
+        f"Write a 200-350 word essay imagining how {name} would approach "
+        f"the topic of \"{topic}\". Stay in their voice and methodology. "
+        f"If their era didn't have this framing, address it through the "
+        f"underlying problem they would have recognized."
+    )
+    try:
+        chat_result, provider_obj = chat_with_fallback(system=system, user=user)
+        text = (chat_result.content or "").strip()
+        provider_name = getattr(provider_obj, "name", "") or ""
+    except ProviderError as exc:
+        log.warning("Mind essay failed for %s on %s: %s", name, topic, exc)
+        return result
+    except Exception as exc:
+        log.warning("Mind essay unexpected error %s/%s: %s", name, topic, exc)
+        return result
+
+    if not text:
+        return result
+    if len(text) > _MIND_ESSAY_MAX_CHARS:
+        text = text[:_MIND_ESSAY_MAX_CHARS].rsplit(" ", 1)[0] + "…"
+    result["essay"] = text
+    result["provider"] = provider_name
+    return result
+
+
+def generate_grounded_answer(
+    agent_id: str,
+    question: str,
+    *,
+    book_title: str = "",
+) -> dict[str, Any]:
+    """Synthesize a short answer to ``question`` using only RAG-retrieved
+    chunks from the given book.
+
+    Returns a dict with:
+      * ``answer``    — string (may be empty if generation failed or
+                         LLM disabled; caller decides whether to render).
+      * ``passages``  — list of chunk dicts {chunk_index, text} used as
+                         sources; always populated when chunks exist.
+      * ``provider``  — name of the provider that answered, or "".
+
+    Never raises — failures degrade to empty answer + whatever passages
+    we did manage to retrieve. The Q&A page handler decides how to render."""
+    result: dict[str, Any] = {"answer": "", "passages": [], "provider": ""}
+    if not question or not agent_id:
+        return result
+
+    # ── Retrieve grounding passages ────────────────────────────────
+    try:
+        passages = retrieve(agent_id, question, top_k=_QA_RAG_TOP_K)
+    except Exception as exc:
+        log.warning("QA retrieve failed for agent=%s: %s", agent_id, exc)
+        passages = []
+    # Strip vector/score fields we don't need downstream
+    result["passages"] = [
+        {"chunk_index": p.get("chunk_index"), "text": (p.get("text") or "").strip()}
+        for p in passages
+        if (p.get("text") or "").strip()
+    ]
+    if not result["passages"]:
+        return result
+
+    if not _QA_LLM_ENABLED:
+        return result
+
+    # ── Synthesize answer ───────────────────────────────────────────
+    context = build_context(passages)
+    title_hint = f" from the book \"{book_title}\"" if book_title else ""
+    system = (
+        "You are a careful reader who answers questions strictly using the "
+        "provided book passages. If the passages do not contain the answer, "
+        "say so plainly. Never invent details. Never reference outside "
+        "sources. Cite chapter numbers using the bracket notation [n] that "
+        "appears in the passages."
+    )
+    user = (
+        f"Question{title_hint}:\n{question}\n\n"
+        f"Passages:\n{context}\n\n"
+        "Write a concise answer (2-3 short paragraphs, max ~250 words). "
+        "Ground every claim in the passages and use [n] citations. "
+        "If the passages don't contain enough to answer the question fully, "
+        "say what they do say and what's missing."
+    )
+    try:
+        chat_result, provider_obj = chat_with_fallback(system=system, user=user)
+        text = (chat_result.content or "").strip()
+        provider_name = getattr(provider_obj, "name", "") or ""
+    except ProviderError as exc:
+        log.warning("QA chat failed for agent=%s: %s", agent_id, exc)
+        return result
+    except Exception as exc:
+        log.warning("QA chat unexpected error agent=%s: %s", agent_id, exc)
+        return result
+
+    if not text:
+        return result
+    if len(text) > _QA_ANSWER_MAX_CHARS:
+        text = text[:_QA_ANSWER_MAX_CHARS].rsplit(" ", 1)[0] + "…"
+    result["answer"] = text
+    result["provider"] = provider_name
+    return result

--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -491,6 +491,149 @@ def render_related_minds(minds: list[dict[str, Any]], site_url: str) -> str:
     )
 
 
+# ─── Capability detection + CTA matrix (Phase 3a) ───────────────────
+#
+# Not every "book" in our catalog supports every action. Specifically:
+#   * AI-written books with full chapters → read + chat + preview
+#   * Uploads / URL imports with substantial chunks → read + chat
+#   * Catalog stubs (discovered titles with no fetched content) → chat only
+#   * Books mid-write or partially indexed → preview + chat (not read)
+#
+# Before this code, every /book/{id} blindly redirected to /#/read/{id}.
+# Catalog books rendered an empty reader, users bounced, Google noticed.
+# These helpers feed the capability-aware CTA matrix on the landing page.
+
+# Below this word count, "Read this book" is misleading — that much text
+# is really only useful as a preview or as RAG fuel for chat. 500 words is
+# roughly two pages of a real book; pages with less are stubs.
+_READ_MIN_WORDS = 500
+
+
+def detect_capabilities(agent: dict[str, Any] | None, book: dict[str, Any] | None) -> dict[str, bool]:
+    """Decide which CTAs this entity legitimately supports.
+
+    Inputs:
+      * agent — the row from `agents` (always required; the landing page
+        wouldn't have been hit without it).
+      * book — the row from `ai_books` for the agent, or None if this isn't
+        an AI-written book.
+
+    Returns a dict with three bools: ``read``, ``preview``, ``chat``. The
+    caller turns these into rendered buttons via ``render_cta_matrix``.
+    """
+    if not agent:
+        return {"read": False, "preview": False, "chat": False}
+    status = (agent.get("status") or "").lower()
+    if status in ("failed", "cancelled", "error"):
+        return {"read": False, "preview": False, "chat": False}
+
+    total_words = 0
+    chapter_count = 0
+    book_status = ""
+    if book:
+        total_words = int(book.get("total_words") or 0)
+        book_status = (book.get("status") or "").lower()
+        outline = book.get("outline")
+        if isinstance(outline, dict):
+            chapter_count = len(outline.get("chapters") or [])
+
+    agent_type = (agent.get("type") or "").lower()
+
+    # Read: has enough body text AND the body is structured enough to read
+    # straight through. Uploads/URLs without chapter structure can still be
+    # "read" because their chunks reassemble into linear prose.
+    can_read = total_words >= _READ_MIN_WORDS and (
+        chapter_count > 0 or agent_type in ("upload", "url")
+    )
+
+    # Preview: there's *something* to look at but it's not a full read.
+    # Books mid-write count as preview-able even if chapter structure is
+    # incomplete — the partial outline is itself useful.
+    can_preview = (
+        (0 < total_words < _READ_MIN_WORDS)
+        or (book_status == "writing" and chapter_count > 0)
+    )
+    # If we can read, we can preview (read implies preview). Keep them
+    # mutually distinct in the rendered CTA though — see render_cta_matrix.
+
+    # Chat: virtually always available. Catalog stubs chat via RAG over the
+    # title + web-fetched sources + LLM knowledge. Only fully-failed entities
+    # are chat-incapable.
+    can_chat = True
+
+    return {"read": can_read, "preview": can_preview, "chat": can_chat}
+
+
+def render_cta_matrix(
+    caps: dict[str, bool],
+    *,
+    entity_id: str,
+    entity_name: str,
+    base: str,
+) -> str:
+    """Render the action buttons matching detected capabilities.
+
+    Buttons land users on the SPA hash routes that actually work for this
+    entity. All actions for one book share the same on-page section so the
+    user sees one row of clear choices instead of a misleading single CTA.
+
+    When ``read`` is available we don't render a separate Preview button —
+    "Read" subsumes preview, and showing both creates decision friction.
+    """
+    if not (caps.get("read") or caps.get("preview") or caps.get("chat")):
+        return ""
+
+    buttons: list[str] = []
+    name = _esc(entity_name or "this book")
+    eid = _esc(entity_id)
+
+    if caps.get("read"):
+        buttons.append(
+            f'<a class="cta-btn cta-read" href="{_esc(base)}/#/read/{eid}">'
+            f'Read {name}</a>'
+        )
+    elif caps.get("preview"):
+        # Preview surfaces the same reader URL — the reader UI decides what
+        # to show based on what content exists. The CTA wording manages
+        # expectation: "Preview" implies partial.
+        buttons.append(
+            f'<a class="cta-btn cta-preview" href="{_esc(base)}/#/read/{eid}">'
+            f'Preview {name}</a>'
+        )
+
+    if caps.get("chat"):
+        buttons.append(
+            f'<a class="cta-btn cta-chat" href="{_esc(base)}/#/chat/{eid}">'
+            f'Chat about {name}</a>'
+        )
+
+    return f'<p class="cta-row">{" ".join(buttons)}</p>'
+
+
+# ─── Referer-based redirect gating ────────────────────────────────────
+#
+# In-product clicks (Referer: feynman.wiki/…) preserve the old "redirect
+# straight to reader" flow so the product UX is unchanged. Search results,
+# share links, and direct visits (no Referer, or Referer from another
+# origin) get the landing page and decide for themselves what to do —
+# fixing the "Google sends user to empty reader → user bounces" bug.
+
+def is_internal_referer(referer: str, site_url: str) -> bool:
+    """True if the request came from our own site. Used to decide whether
+    to JS-redirect humans straight to the SPA action (preserving in-product
+    flow) or to stop on the landing page (preserving search/share UX).
+
+    Missing referer is treated as external. The cost of false-negative
+    (an in-product visitor accidentally landing) is small — they click
+    one button. The cost of false-positive (an external visitor getting
+    redirected to an empty reader) is the SEO bounce-rate bug we're fixing."""
+    if not referer or not site_url:
+        return False
+    site_host = site_url.rstrip("/").split("://", 1)[-1].split("/", 1)[0].lower()
+    referer_host = referer.split("://", 1)[-1].split("/", 1)[0].lower()
+    return bool(site_host) and referer_host == site_host
+
+
 # ─── Word/structure counters (used by tests to enforce density floors) ─
 
 _TAG_RE = re.compile(r"<[^>]+>")

--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -1,0 +1,510 @@
+"""SEO/GEO rendering helpers for per-entity landing pages.
+
+Centralizes the content-composition and structured-data work that used to live
+inline in main.py's book_page / mind_page handlers. Keeping it here means:
+
+  * Handlers stay small and focused on routing/caching/auth.
+  * Tests can exercise the rendered content without spinning up FastAPI.
+  * Future Phase 3+ work (URL slugs, compound /q/ and /on/ pages) reuses
+    the same composition primitives instead of growing a second copy.
+
+Design rules:
+  * Every helper takes already-loaded data and returns escaped HTML or
+    JSON-serializable dicts. No DB calls, no LLM calls, no I/O.
+  * All user-controllable strings are html-escaped at the boundary.
+  * Sections gracefully return "" when their input is empty — callers can
+    join the list without worrying about gaps.
+"""
+from __future__ import annotations
+
+import json
+import re
+from html import escape as _esc
+from typing import Any, Iterable
+
+
+# ─── Slug generation (Phase 3 prep — used now for compound URL anchors,
+#     promoted to canonical URLs once the redirect path is built) ─────
+
+_SLUG_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_SLUG_TRIM = re.compile(r"^-+|-+$")
+
+
+def slugify(text: str, max_len: int = 80) -> str:
+    """Convert a title or name into a URL-safe kebab-case slug. Deterministic
+    and ASCII-only — non-Latin scripts collapse to dashes, which is acceptable
+    because the canonical URL still carries a UUID suffix for disambiguation.
+
+    Examples:
+        "How to Win Friends and Influence People" -> "how-to-win-friends-and-influence-people"
+        "Karl Marx"                                -> "karl-marx"
+        ""                                         -> "untitled"
+    """
+    if not text:
+        return "untitled"
+    s = text.lower().strip()
+    # Drop diacritics by best-effort ASCII fold (without pulling in unicodedata
+    # for one call site we keep it simple — non-ASCII just becomes dashes)
+    s = s.encode("ascii", "ignore").decode("ascii")
+    s = _SLUG_NON_ALNUM.sub("-", s)
+    s = _SLUG_TRIM.sub("", s)
+    if not s:
+        return "untitled"
+    if len(s) > max_len:
+        s = s[:max_len].rsplit("-", 1)[0] or s[:max_len]
+    return s
+
+
+# ─── JSON-LD schema builders ──────────────────────────────────────────
+
+def breadcrumb_jsonld(items: list[tuple[str, str]]) -> dict[str, Any]:
+    """BreadcrumbList schema. `items` is [(name, absolute_url), ...] in
+    crumb order (root first, current page last)."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {
+                "@type": "ListItem",
+                "position": i + 1,
+                "name": name,
+                "item": url,
+            }
+            for i, (name, url) in enumerate(items)
+        ],
+    }
+
+
+def faq_jsonld(qa_pairs: list[tuple[str, str]]) -> dict[str, Any]:
+    """FAQPage schema. `qa_pairs` is [(question, answer), ...].
+
+    Google requires real answer text — empty answers (which we use as
+    placeholders linking to chat) are still acceptable per spec as long
+    as the answer string is non-empty. We always include a deflection
+    answer that nudges to chat with the book."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": q,
+                "acceptedAnswer": {"@type": "Answer", "text": a},
+            }
+            for q, a in qa_pairs
+        ],
+    }
+
+
+def book_jsonld(
+    *,
+    title: str,
+    description: str,
+    author: str,
+    url: str,
+    image: str,
+    word_count: int | None,
+    chapters: list[dict[str, Any]] | None,
+    site_url: str,
+) -> dict[str, Any]:
+    """Schema.org/Book — corrected to omit `numberOfPages` (we don't have
+    physical pages; previous code mis-mapped chapter count here). Chapter
+    structure goes in `hasPart` where it belongs."""
+    out: dict[str, Any] = {
+        "@context": "https://schema.org",
+        "@type": "Book",
+        "name": title,
+        "description": description,
+        "url": url,
+        "image": image,
+        "publisher": {"@type": "Organization", "name": "Feynman", "url": site_url},
+    }
+    if author:
+        out["author"] = {"@type": "Person", "name": author}
+    if word_count:
+        out["wordCount"] = word_count
+    if chapters:
+        out["hasPart"] = [
+            {"@type": "Chapter", "name": c.get("title", ""), "position": i + 1}
+            for i, c in enumerate(chapters)
+        ]
+    return out
+
+
+# Hardcoded Wikipedia/Wikidata URLs for the most-trafficked named minds.
+# Populating `sameAs` is the single biggest signal we can send Google's
+# Knowledge Graph that "our Karl Marx page is THE Karl Marx" — without it
+# the page floats as an entity-of-unknown-identity. Curated by hand because
+# heuristic name→Wikipedia lookup occasionally picks the wrong "John Smith".
+#
+# Add a row here as a mind crosses our top-traffic threshold; the lookup
+# is case-insensitive by mind name. The full schema also accepts Wikidata
+# (https://www.wikidata.org/wiki/Q…) and we include both where possible
+# because Wikidata is the LLM-friendly canonical identifier.
+FAMOUS_MIND_SAMEAS: dict[str, list[str]] = {
+    "karl marx": [
+        "https://en.wikipedia.org/wiki/Karl_Marx",
+        "https://www.wikidata.org/wiki/Q9061",
+    ],
+    "friedrich engels": [
+        "https://en.wikipedia.org/wiki/Friedrich_Engels",
+        "https://www.wikidata.org/wiki/Q33760",
+    ],
+    "adam smith": [
+        "https://en.wikipedia.org/wiki/Adam_Smith",
+        "https://www.wikidata.org/wiki/Q9381",
+    ],
+    "john maynard keynes": [
+        "https://en.wikipedia.org/wiki/John_Maynard_Keynes",
+        "https://www.wikidata.org/wiki/Q9317",
+    ],
+    "richard feynman": [
+        "https://en.wikipedia.org/wiki/Richard_Feynman",
+        "https://www.wikidata.org/wiki/Q39246",
+    ],
+    "albert einstein": [
+        "https://en.wikipedia.org/wiki/Albert_Einstein",
+        "https://www.wikidata.org/wiki/Q937",
+    ],
+    "isaac newton": [
+        "https://en.wikipedia.org/wiki/Isaac_Newton",
+        "https://www.wikidata.org/wiki/Q935",
+    ],
+    "charles darwin": [
+        "https://en.wikipedia.org/wiki/Charles_Darwin",
+        "https://www.wikidata.org/wiki/Q1035",
+    ],
+    "sigmund freud": [
+        "https://en.wikipedia.org/wiki/Sigmund_Freud",
+        "https://www.wikidata.org/wiki/Q9215",
+    ],
+    "carl jung": [
+        "https://en.wikipedia.org/wiki/Carl_Jung",
+        "https://www.wikidata.org/wiki/Q41532",
+    ],
+    "friedrich nietzsche": [
+        "https://en.wikipedia.org/wiki/Friedrich_Nietzsche",
+        "https://www.wikidata.org/wiki/Q1141",
+    ],
+    "aristotle": [
+        "https://en.wikipedia.org/wiki/Aristotle",
+        "https://www.wikidata.org/wiki/Q868",
+    ],
+    "plato": [
+        "https://en.wikipedia.org/wiki/Plato",
+        "https://www.wikidata.org/wiki/Q859",
+    ],
+    "socrates": [
+        "https://en.wikipedia.org/wiki/Socrates",
+        "https://www.wikidata.org/wiki/Q913",
+    ],
+    "confucius": [
+        "https://en.wikipedia.org/wiki/Confucius",
+        "https://www.wikidata.org/wiki/Q4604",
+    ],
+    "immanuel kant": [
+        "https://en.wikipedia.org/wiki/Immanuel_Kant",
+        "https://www.wikidata.org/wiki/Q9312",
+    ],
+    "g.w.f. hegel": [
+        "https://en.wikipedia.org/wiki/Georg_Wilhelm_Friedrich_Hegel",
+        "https://www.wikidata.org/wiki/Q9235",
+    ],
+    "warren buffett": [
+        "https://en.wikipedia.org/wiki/Warren_Buffett",
+        "https://www.wikidata.org/wiki/Q47213",
+    ],
+    "charlie munger": [
+        "https://en.wikipedia.org/wiki/Charlie_Munger",
+        "https://www.wikidata.org/wiki/Q1066368",
+    ],
+    "peter drucker": [
+        "https://en.wikipedia.org/wiki/Peter_Drucker",
+        "https://www.wikidata.org/wiki/Q57139",
+    ],
+    "carl sagan": [
+        "https://en.wikipedia.org/wiki/Carl_Sagan",
+        "https://www.wikidata.org/wiki/Q34943",
+    ],
+    "stephen hawking": [
+        "https://en.wikipedia.org/wiki/Stephen_Hawking",
+        "https://www.wikidata.org/wiki/Q17714",
+    ],
+    "marie curie": [
+        "https://en.wikipedia.org/wiki/Marie_Curie",
+        "https://www.wikidata.org/wiki/Q7186",
+    ],
+    "nikola tesla": [
+        "https://en.wikipedia.org/wiki/Nikola_Tesla",
+        "https://www.wikidata.org/wiki/Q9036",
+    ],
+}
+
+
+def lookup_same_as(mind_name: str) -> list[str] | None:
+    """Return curated authoritative URLs for a famous mind, or None."""
+    if not mind_name:
+        return None
+    return FAMOUS_MIND_SAMEAS.get(mind_name.strip().lower())
+
+
+def person_jsonld(
+    *,
+    name: str,
+    description: str,
+    domain: str,
+    url: str,
+    image: str,
+    same_as: list[str] | None = None,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": name,
+        "description": description,
+        "url": url,
+        "image": image,
+    }
+    if domain:
+        out["knowsAbout"] = [d.strip() for d in domain.split(",") if d.strip()] or domain
+    if same_as:
+        out["sameAs"] = same_as
+    return out
+
+
+def jsonld_script(payload: dict[str, Any]) -> str:
+    """Wrap a JSON-LD dict into a <script> tag, dropping null leaves so
+    schema validators don't choke on `numberOfPages: null` etc."""
+    cleaned = _drop_nulls(payload)
+    return f'<script type="application/ld+json">{json.dumps(cleaned, ensure_ascii=False)}</script>'
+
+
+def _drop_nulls(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: _drop_nulls(v) for k, v in obj.items() if v not in (None, "", [])}
+    if isinstance(obj, list):
+        return [_drop_nulls(x) for x in obj]
+    return obj
+
+
+# ─── Book page section builders ───────────────────────────────────────
+
+def render_book_about(subtitle: str, author: str) -> str:
+    """Top-of-page 1-2 sentence summary. The subtitle (from outline) is the
+    best signal we have for what the book is *about* in the author's own
+    framing."""
+    if not subtitle and not author:
+        return ""
+    parts = []
+    if subtitle:
+        parts.append(f'<p class="book-about">{_esc(subtitle)}</p>')
+    return "\n".join(parts)
+
+
+def render_stats(total_words: int, chapter_count: int) -> str:
+    if not total_words and not chapter_count:
+        return ""
+    bits = []
+    if total_words:
+        bits.append(f"{total_words:,} words")
+        bits.append(f"~{max(1, total_words // 250)} min read")
+    if chapter_count:
+        bits.append(f"{chapter_count} chapters")
+    return f'<p class="book-stats">{" · ".join(_esc(b) for b in bits)}</p>'
+
+
+def render_toc(chapters: list[dict[str, Any]]) -> str:
+    if not chapters:
+        return ""
+    items = "".join(f"<li>{_esc(c.get('title', ''))}</li>" for c in chapters if c.get("title"))
+    if not items:
+        return ""
+    return f'<section><h2>Table of Contents</h2><ol class="toc">{items}</ol></section>'
+
+
+def render_sample_passages(chunks: list[dict[str, Any]], count: int = 3, max_chars: int = 800) -> str:
+    """Render the first `count` chunks verbatim as "What this book covers".
+
+    These are real content from the book — Google rewards original text, and
+    LLMs get something concrete to cite. Default ``max_chars=800`` gives ~130
+    words per blockquote × 3 ≈ 400 words of unique on-page text, which is the
+    bulk of the SEO weight on a book page."""
+    if not chunks:
+        return ""
+    samples = chunks[:count]
+    items = []
+    for c in samples:
+        text = (c.get("text") or "").strip()
+        if not text:
+            continue
+        if len(text) > max_chars:
+            text = text[:max_chars].rsplit(" ", 1)[0] + "…"
+        items.append(f"<blockquote>{_esc(text)}</blockquote>")
+    if not items:
+        return ""
+    return f'<section><h2>From the book</h2>{"".join(items)}</section>'
+
+
+def render_popular_questions(questions: list[str], chat_url: str) -> str:
+    """Render the auto-generated study questions as a visible FAQ-style
+    list. Companion FAQPage JSON-LD is emitted separately via faq_jsonld."""
+    if not questions:
+        return ""
+    items = "".join(
+        f'<li><a href="{_esc(chat_url)}">{_esc(q)}</a></li>'
+        for q in questions
+        if q
+    )
+    if not items:
+        return ""
+    return (
+        '<section><h2>Popular questions readers ask</h2>'
+        f'<ul class="popular-questions">{items}</ul></section>'
+    )
+
+
+def render_minds_for_book(minds: list[dict[str, Any]], site_url: str) -> str:
+    """Cross-links from /book/{id} → /mind/{id}. The single biggest
+    internal-link source we have."""
+    if not minds:
+        return ""
+    items = "".join(
+        f'<li><a href="{_esc(site_url)}/mind/{_esc(m["id"])}">{_esc(m.get("name", ""))}</a>'
+        f'{(" — " + _esc(m["domain"])) if m.get("domain") else ""}</li>'
+        for m in minds
+    )
+    return (
+        '<section><h2>Great minds who discuss this book</h2>'
+        f'<ul class="related-minds">{items}</ul></section>'
+    )
+
+
+# ─── Mind page section builders ───────────────────────────────────────
+
+def render_mind_bio(bio: str) -> str:
+    if not bio:
+        return ""
+    return f'<section><h2>About</h2><p>{_esc(bio)}</p></section>'
+
+
+def render_mind_thinking_style(thinking_style: str) -> str:
+    if not thinking_style:
+        return ""
+    return (
+        f'<section><h2>How they think</h2>'
+        f'<p>{_esc(thinking_style)}</p></section>'
+    )
+
+
+def render_mind_phrases(phrases: list[str], limit: int = 6) -> str:
+    """Render typical_phrases as a quote-card list. These are GEO gold —
+    LLMs love distinctive, attributable short text."""
+    if not phrases:
+        return ""
+    items = "".join(
+        f'<li><q>{_esc(p)}</q></li>' for p in phrases[:limit] if p
+    )
+    if not items:
+        return ""
+    return (
+        '<section><h2>Characteristic phrases</h2>'
+        f'<ul class="characteristic-phrases">{items}</ul></section>'
+    )
+
+
+def render_mind_persona_excerpt(persona: str, max_chars: int = 900) -> str:
+    """Render a condensed snippet of the persona as 'Core approach'. The
+    full persona is often 1500+ chars of system-prompt-style description
+    not suited to public display, so we take an excerpt. 900 chars ≈ 150
+    words — substantial enough to register as real content, short enough
+    to read in 30 seconds."""
+    if not persona:
+        return ""
+    p = persona.strip()
+    if len(p) > max_chars:
+        p = p[:max_chars].rsplit(" ", 1)[0] + "…"
+    return (
+        '<section><h2>Core approach</h2>'
+        f'<p>{_esc(p)}</p></section>'
+    )
+
+
+def render_mind_works(works: list[str], linked_books: list[dict[str, Any]], site_url: str) -> str:
+    """Notable Works — link to /book/{id} where mind_works maps the title to
+    one of our agents, otherwise plain text. Matching is by case-insensitive
+    title substring to handle minor variations (subtitles, edition suffixes)."""
+    if not works:
+        return ""
+    link_index = {
+        (b.get("name") or "").lower(): b["id"]
+        for b in (linked_books or [])
+        if b.get("id")
+    }
+    items = []
+    for w in works[:20]:
+        if not w:
+            continue
+        wl = w.lower()
+        match_id = link_index.get(wl)
+        if not match_id:
+            for n, bid in link_index.items():
+                if n and (n in wl or wl in n):
+                    match_id = bid
+                    break
+        if match_id:
+            items.append(f'<li><a href="{_esc(site_url)}/book/{_esc(match_id)}">{_esc(w)}</a></li>')
+        else:
+            items.append(f'<li>{_esc(w)}</li>')
+    if not items:
+        return ""
+    return f'<section><h2>Notable works</h2><ul class="works">{"".join(items)}</ul></section>'
+
+
+def render_books_for_mind(books: list[dict[str, Any]], site_url: str) -> str:
+    """Cross-links to books in this mind's corpus that aren't already covered
+    by Notable Works (the works list comes from the mind persona; mind_works
+    can include additional reference material). Skipped if empty."""
+    if not books:
+        return ""
+    items = "".join(
+        f'<li><a href="{_esc(site_url)}/book/{_esc(b["id"])}">{_esc(b.get("name", ""))}</a>'
+        f'{(" — by " + _esc(b["author"])) if b.get("author") else ""}</li>'
+        for b in books
+    )
+    return (
+        '<section><h2>Books in this mind\'s library</h2>'
+        f'<ul class="related-books">{items}</ul></section>'
+    )
+
+
+def render_related_minds(minds: list[dict[str, Any]], site_url: str) -> str:
+    if not minds:
+        return ""
+    items = "".join(
+        f'<li><a href="{_esc(site_url)}/mind/{_esc(m["id"])}">{_esc(m.get("name", ""))}</a>'
+        f'{(" — " + _esc(m["era"])) if m.get("era") else ""}</li>'
+        for m in minds
+    )
+    return (
+        '<section><h2>Related minds</h2>'
+        f'<ul class="related-minds">{items}</ul></section>'
+    )
+
+
+# ─── Word/structure counters (used by tests to enforce density floors) ─
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_SCRIPT_RE = re.compile(r"<script[^>]*>.*?</script>", re.S | re.I)
+_STYLE_RE = re.compile(r"<style[^>]*>.*?</style>", re.S | re.I)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def visible_word_count(html: str) -> int:
+    """Count visible words in an HTML document — the same metric our SEO
+    diagnostic uses. Strips scripts, styles, and tags. Useful for tests
+    that assert a content-density floor."""
+    stripped = _SCRIPT_RE.sub("", html)
+    stripped = _STYLE_RE.sub("", stripped)
+    text = _TAG_RE.sub(" ", stripped)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return len(text.split()) if text else 0

--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -345,21 +345,37 @@ def render_sample_passages(chunks: list[dict[str, Any]], count: int = 3, max_cha
     return f'<section><h2>From the book</h2>{"".join(items)}</section>'
 
 
-def render_popular_questions(questions: list[str], chat_url: str) -> str:
+def render_popular_questions(
+    questions: list[str],
+    fallback_url: str,
+    *,
+    book_id: str = "",
+    site_url: str = "",
+) -> str:
     """Render the auto-generated study questions as a visible FAQ-style
-    list. Companion FAQPage JSON-LD is emitted separately via faq_jsonld."""
+    list. Companion FAQPage JSON-LD is emitted separately via faq_jsonld.
+
+    When ``book_id`` and ``site_url`` are provided, each question links to
+    its own compound /book/{id}/q/{slug} page (the SEO play — every
+    question becomes a discoverable long-tail URL). Otherwise all
+    questions link to ``fallback_url`` (typically the book's chat URL).
+    """
     if not questions:
         return ""
-    items = "".join(
-        f'<li><a href="{_esc(chat_url)}">{_esc(q)}</a></li>'
-        for q in questions
-        if q
-    )
-    if not items:
+    items_html: list[str] = []
+    for q in questions:
+        if not q:
+            continue
+        if book_id and site_url:
+            href = f"{site_url}/book/{book_id}/q/{slugify(q)}"
+        else:
+            href = fallback_url
+        items_html.append(f'<li><a href="{_esc(href)}">{_esc(q)}</a></li>')
+    if not items_html:
         return ""
     return (
         '<section><h2>Popular questions readers ask</h2>'
-        f'<ul class="popular-questions">{items}</ul></section>'
+        f'<ul class="popular-questions">{"".join(items_html)}</ul></section>'
     )
 
 
@@ -489,6 +505,324 @@ def render_related_minds(minds: list[dict[str, Any]], site_url: str) -> str:
         '<section><h2>Related minds</h2>'
         f'<ul class="related-minds">{items}</ul></section>'
     )
+
+
+# ─── Mind-on-topic compound-page helpers (Phase 4B) ──────────────────
+#
+# /mind/{mind_id}/on/{topic_slug} renders an imagined-perspective essay
+# of how this mind would think about this topic. Relevance is pre-filtered
+# in qa.is_mind_topic_relevant — non-relevant pairs 404 rather than
+# generate slop. Each rendered page is labelled as imagined dialogue to
+# avoid misrepresenting historical figures.
+
+
+def render_mind_on_topic_essay(essay: str, mind_name: str, topic: str) -> str:
+    """Render the imagined essay with an explicit disclosure label."""
+    if not essay:
+        return ""
+    paragraphs = [p.strip() for p in essay.split("\n\n") if p.strip()]
+    if not paragraphs:
+        return ""
+    body = "".join(f"<p>{_esc(p)}</p>" for p in paragraphs)
+    return (
+        '<section class="mind-essay">'
+        f'<h2>How {_esc(mind_name)} might approach {_esc(topic)}</h2>'
+        f'{body}'
+        '<p class="essay-attribution"><small>Imagined perspective — '
+        f'an AI synthesis grounded in {_esc(mind_name)}\'s recorded ideas '
+        'and methods, not a quote.</small></p>'
+        '</section>'
+    )
+
+
+def mind_essay_jsonld(
+    *,
+    mind_name: str,
+    topic: str,
+    essay: str,
+    url: str,
+    mind_url: str,
+    image: str = "",
+) -> dict[str, Any]:
+    """Schema.org/Article. We mark the author as an Organization (Feynman)
+    rather than the mind itself — the essay is an imagined perspective
+    we authored, not something the mind actually wrote. Including the
+    mind as the about-entity preserves topical clarity."""
+    out: dict[str, Any] = {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": f"How {mind_name} might approach {topic}",
+        "description": (essay[:200].rsplit(" ", 1)[0] + "…") if len(essay) > 200 else essay,
+        "url": url,
+        "author": {"@type": "Organization", "name": "Feynman", "url": mind_url.split("/mind/")[0]},
+        "about": {"@type": "Person", "name": mind_name, "url": mind_url},
+        "publisher": {
+            "@type": "Organization",
+            "name": "Feynman",
+            "url": mind_url.split("/mind/")[0],
+        },
+    }
+    if image:
+        out["image"] = image
+    return out
+
+
+# ─── Book Q&A compound-page helpers (Phase 4A) ───────────────────────
+#
+# Each indexed book has up to 5 popular questions in the `questions`
+# table. We expose each as its own URL `/book/{id}/q/{slug}`. The slug
+# is derived from the question text via slugify, so URLs are stable as
+# long as the question text doesn't change.
+
+def find_question_by_slug(questions: list[str], slug: str) -> str | None:
+    """Match a URL slug back to the original question text. Linear scan —
+    questions per book is bounded to ~5, no need for an index."""
+    if not questions or not slug:
+        return None
+    target = slug.strip().lower()
+    for q in questions:
+        if slugify(q) == target:
+            return q
+    return None
+
+
+def render_qa_answer(answer: str) -> str:
+    """Render the synthesized LLM answer as a labelled section. We label
+    it explicitly because the answer is AI-generated grounded synthesis —
+    transparency about authorship is required by Google's helpful-content
+    guidance and avoids misleading citations downstream."""
+    if not answer:
+        return ""
+    # Preserve paragraph breaks the LLM emitted; escape everything else.
+    paragraphs = [p.strip() for p in answer.split("\n\n") if p.strip()]
+    if not paragraphs:
+        return ""
+    body = "".join(f"<p>{_esc(p)}</p>" for p in paragraphs)
+    return (
+        '<section class="qa-answer"><h2>Synthesized answer</h2>'
+        f'{body}'
+        '<p class="qa-attribution"><small>Synthesized from the book passages '
+        'below. Chat with the book on Feynman for follow-up.</small></p>'
+        '</section>'
+    )
+
+
+def render_qa_passages(passages: list[dict[str, Any]], max_chars: int = 600) -> str:
+    """Render the supporting RAG passages with chapter attribution.
+    Even when LLM synthesis fails or is disabled, this section alone
+    gives the page real content — Google sees ~5 substantial blockquotes
+    of original book text grouped under the question."""
+    if not passages:
+        return ""
+    items = []
+    for p in passages:
+        text = (p.get("text") or "").strip()
+        if not text:
+            continue
+        if len(text) > max_chars:
+            text = text[:max_chars].rsplit(" ", 1)[0] + "…"
+        attr = ""
+        idx = p.get("chunk_index")
+        if idx is not None:
+            attr = f'<footer><small>Passage [{int(idx) + 1}]</small></footer>'
+        items.append(f"<blockquote>{_esc(text)}{attr}</blockquote>")
+    if not items:
+        return ""
+    return (
+        '<section class="qa-passages"><h2>From the book</h2>'
+        f'{"".join(items)}</section>'
+    )
+
+
+def render_sibling_questions(
+    siblings: list[str],
+    book_id: str,
+    site_url: str,
+    current_question: str = "",
+) -> str:
+    """Cross-link to the book's other Q&A pages. Skip the current
+    question (would be a self-link)."""
+    if not siblings:
+        return ""
+    items = []
+    current_slug = slugify(current_question) if current_question else ""
+    for q in siblings:
+        if not q:
+            continue
+        slug = slugify(q)
+        if slug == current_slug:
+            continue
+        items.append(
+            f'<li><a href="{_esc(site_url)}/book/{_esc(book_id)}/q/{_esc(slug)}">'
+            f'{_esc(q)}</a></li>'
+        )
+    if not items:
+        return ""
+    return (
+        '<section><h2>More questions about this book</h2>'
+        f'<ul class="sibling-questions">{"".join(items)}</ul></section>'
+    )
+
+
+def qa_page_jsonld(
+    *,
+    question: str,
+    answer: str,
+    url: str,
+    book_title: str,
+    book_url: str,
+) -> dict[str, Any]:
+    """Schema.org/QAPage with acceptedAnswer. Google supports this rich
+    result; LLMs use it as a clean enumerable signal.
+
+    If we don't have an LLM-synthesized answer yet, we still emit the
+    schema with a deflection answer pointing to the chat — better than
+    omitting the schema entirely (which would forfeit the rich-result
+    eligibility) and Google accepts non-empty deflection text."""
+    answer_text = (answer or "").strip()
+    if not answer_text:
+        answer_text = (
+            f"Open Feynman to chat with the book \"{book_title}\" and explore "
+            f"the answer in depth: {book_url}"
+        )
+    return {
+        "@context": "https://schema.org",
+        "@type": "QAPage",
+        "mainEntity": {
+            "@type": "Question",
+            "name": question,
+            "url": url,
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": answer_text,
+                "url": url,
+            },
+        },
+    }
+
+
+# ─── Topic slug / lookup helpers (Phase 4C — topic hub pages) ────────
+#
+# Topics are a fixed list (`TOPIC_TAGS` in app/core/catalog.py). They're
+# referenced by name everywhere internally but exposed externally as
+# kebab-case slugs in URLs (/topic/computer-science). These helpers do
+# the bidirectional mapping so handlers don't have to repeat the logic.
+
+def build_topic_slug_index(topic_tags: list[str]) -> dict[str, str]:
+    """Returns {slug: original_topic_name} so URL handlers can resolve
+    /topic/{slug} back to the canonical name to use for DB lookups."""
+    return {slugify(t): t for t in topic_tags if t}
+
+
+def topic_slug(topic: str) -> str:
+    """Slug for a given topic name. Stable across runs (slugify is
+    deterministic) so URLs don't change."""
+    return slugify(topic)
+
+
+# ─── Topic hub page renderer (Phase 4C) ──────────────────────────────
+
+def render_topic_books(books: list[dict[str, Any]], site_url: str) -> str:
+    """List the books tagged with this topic. Each is a cross-link to
+    /book/{id} so the topic hub becomes an entry-point page that pushes
+    PageRank down to entity pages."""
+    if not books:
+        return ""
+    items = []
+    for b in books:
+        if not b.get("id") or not b.get("name"):
+            continue
+        author = f' — {_esc(b["author"])}' if b.get("author") else ""
+        items.append(
+            f'<li><a href="{_esc(site_url)}/book/{_esc(b["id"])}">{_esc(b["name"])}</a>{author}</li>'
+        )
+    if not items:
+        return ""
+    return (
+        '<section><h2>Books in this topic</h2>'
+        f'<ul class="topic-books">{"".join(items)}</ul></section>'
+    )
+
+
+def render_topic_minds(minds: list[dict[str, Any]], site_url: str) -> str:
+    if not minds:
+        return ""
+    items = []
+    for m in minds:
+        if not m.get("id") or not m.get("name"):
+            continue
+        era = f' — {_esc(m["era"])}' if m.get("era") else ""
+        items.append(
+            f'<li><a href="{_esc(site_url)}/mind/{_esc(m["id"])}">{_esc(m["name"])}</a>{era}</li>'
+        )
+    if not items:
+        return ""
+    return (
+        '<section><h2>Great minds on this topic</h2>'
+        f'<ul class="topic-minds">{"".join(items)}</ul></section>'
+    )
+
+
+def render_topic_intro(topic: str, book_count: int, mind_count: int) -> str:
+    """Top-of-page intro paragraph. Generated from counts, not LLM —
+    Google rewards concise factual lead paragraphs that match the H1."""
+    if not topic:
+        return ""
+    parts = []
+    if book_count > 0:
+        parts.append(f"{book_count} {'book' if book_count == 1 else 'books'}")
+    if mind_count > 0:
+        parts.append(f"{mind_count} great {'mind' if mind_count == 1 else 'minds'}")
+    if not parts:
+        intro = (
+            f"Explore {_esc(topic)} on Feynman — chat with the best books "
+            f"and great thinkers shaping this field."
+        )
+    else:
+        and_clause = " and ".join(parts)
+        intro = (
+            f"{and_clause} on {_esc(topic)} curated for chat and exploration "
+            f"on Feynman — read the canon, ask the questions you actually have, "
+            f"and discuss with the thinkers who shaped the field."
+        )
+    return f'<p class="topic-intro">{intro}</p>'
+
+
+def collection_jsonld(
+    *,
+    name: str,
+    description: str,
+    url: str,
+    items: list[dict[str, str]],
+    site_url: str,
+) -> dict[str, Any]:
+    """Schema.org/CollectionPage with embedded ItemList — the right shape
+    for a topic hub. ``items`` is a list of {name, url} dicts."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": name,
+        "description": description,
+        "url": url,
+        "isPartOf": {
+            "@type": "WebSite",
+            "name": "Feynman",
+            "url": site_url,
+        },
+        "mainEntity": {
+            "@type": "ItemList",
+            "numberOfItems": len(items),
+            "itemListElement": [
+                {
+                    "@type": "ListItem",
+                    "position": i + 1,
+                    "url": item["url"],
+                    "name": item["name"],
+                }
+                for i, item in enumerate(items)
+            ],
+        },
+    }
 
 
 # ─── Capability detection + CTA matrix (Phase 3a) ───────────────────

--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -379,6 +379,66 @@ def render_popular_questions(
     )
 
 
+def render_related_books(books: list[dict[str, Any]], site_url: str) -> str:
+    """Other books readers may want next. Same-topic and same-author
+    matches surfaced together. Phase 5 — closes the book↔book half of
+    the internal linking graph."""
+    if not books:
+        return ""
+    items = []
+    for b in books:
+        if not b.get("id") or not b.get("name"):
+            continue
+        author = f' — {_esc(b["author"])}' if b.get("author") else ""
+        items.append(
+            f'<li><a href="{_esc(site_url)}/book/{_esc(b["id"])}">{_esc(b["name"])}</a>{author}</li>'
+        )
+    if not items:
+        return ""
+    return (
+        '<section><h2>Related books</h2>'
+        f'<ul class="related-books">{"".join(items)}</ul></section>'
+    )
+
+
+def render_topic_link_back(topic: str, site_url: str) -> str:
+    """A single "← back to topic" link on entity pages whose meta.category
+    matches one of the canonical topics. Closes the book→topic-hub edge,
+    pushing PageRank up the tree."""
+    if not topic:
+        return ""
+    slug = slugify(topic)
+    if not slug:
+        return ""
+    return (
+        f'<p class="topic-link-back">More on '
+        f'<a href="{_esc(site_url)}/topic/{slug}">{_esc(topic)}</a></p>'
+    )
+
+
+def render_topic_links_for_mind(matching_topics: list[str], site_url: str) -> str:
+    """Render a row of links to relevant topic hubs from a mind's page.
+    ``matching_topics`` is a pre-filtered list — caller decides which
+    topics this mind belongs to (typically via qa.is_mind_topic_relevant).
+    """
+    if not matching_topics:
+        return ""
+    items = []
+    for t in matching_topics[:5]:
+        slug = slugify(t)
+        if not slug:
+            continue
+        items.append(
+            f'<a href="{_esc(site_url)}/topic/{slug}">{_esc(t)}</a>'
+        )
+    if not items:
+        return ""
+    return (
+        '<p class="topic-links">Explore the topics this mind discusses: '
+        f'{" · ".join(items)}</p>'
+    )
+
+
 def render_minds_for_book(minds: list[dict[str, Any]], site_url: str) -> str:
     """Cross-links from /book/{id} → /mind/{id}. The single biggest
     internal-link source we have."""

--- a/app/core/ugc.py
+++ b/app/core/ugc.py
@@ -1,0 +1,178 @@
+"""User-generated content pipeline for public-discussion pages
+(Phase 6 of the SEO/GEO plan).
+
+Privacy model — read this before changing anything in this module:
+
+  * **Opt-in only.** A chat session is private by default
+    (`public_status = 'private'`). It only becomes a candidate for public
+    display after the owning user explicitly calls the /share API, which
+    sets `public_status = 'opted_in'` and stamps `consent_at`.
+  * **Moderation required.** Opted-in sessions are still not public until
+    an admin sets `public_status = 'approved'` (and stamps `approved_at` +
+    `approved_by`). This module's read helpers filter on this status —
+    nothing else does, so leaking is hard.
+  * **Right to withdraw.** Owners can flip status to `'withdrawn'` at any
+    time. Withdrawn sessions never render even if previously approved.
+  * **PII scrubbing.** ``scrub_pii_for_public_display`` redacts email
+    addresses, phone numbers, and explicit URLs before any content is
+    rendered. Conservative — better to over-redact than leak.
+  * **Anonymous by default.** ``public_handle`` is optional; when absent
+    we display "Anonymous". User-supplied handles are themselves PII so
+    we cap length and reject anything that contains an `@` or a digit
+    pattern that looks like a phone number.
+  * **Feature flag.** ``ENABLE_PUBLIC_DISCUSSIONS`` gates the entire
+    surface. Default OFF means even if migrations have populated columns
+    and a user has somehow opted in, the public render route + opt-in
+    API return 404. Don't flip the flag until product/legal sign off
+    AND the SPA opt-in UI ships.
+
+Status values:
+  ``private``    - default, never displayed (also covers brand-new sessions)
+  ``opted_in``   - user consented, awaiting moderation. NOT displayed.
+  ``approved``   - admin approved. RENDERED on /book/{id}/discussions etc.
+  ``rejected``   - admin rejected (content unsuitable / failed PII review).
+  ``withdrawn``  - user withdrew consent post-approval. Stops rendering.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+# Module-level kill switch. Read at import time — restart-required if
+# you change it. That's intentional: a runtime flip would mean the
+# next request after deployment could be the first time the surface
+# is live, with no warm-up. Restart-required keeps the activation
+# observable in the deploy log.
+_PUBLIC_DISCUSSIONS_ENABLED = os.getenv(
+    "ENABLE_PUBLIC_DISCUSSIONS", "false"
+).strip().lower() in ("1", "true", "yes", "on")
+
+
+def is_enabled() -> bool:
+    return _PUBLIC_DISCUSSIONS_ENABLED
+
+
+# ─── PII scrubbing ────────────────────────────────────────────────────
+#
+# All public content passes through scrub_pii_for_public_display before
+# rendering. Conservative: catch the obvious shapes, accept some false
+# positives (e.g. a string that looks like a phone number but isn't).
+# Anything more sophisticated (named-entity recognition for personal
+# names, geo addresses, etc.) is out of v1 scope — the per-conversation
+# admin review serves as the human backstop for those.
+
+# Emails — RFC-ish, broad enough to catch user.name+tag@sub.example.co
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
+)
+
+# Phone-ish digit runs: 7+ digits with optional separators and an
+# optional country prefix. Catches "(415) 555-1234", "+86 138 0013 8000",
+# "415-555-1234", "4155551234". May false-positive on long numeric IDs;
+# that's acceptable for v1.
+_PHONE_RE = re.compile(
+    r"(?<!\d)(?:\+?\d{1,3}[\s\-.])?(?:\(?\d{2,4}\)?[\s\-.]?)?\d{3}[\s\-.]?\d{3,4}(?!\d)"
+)
+
+# URLs — broad, including bare domains. Strips them entirely rather
+# than rewriting because we don't want personalized URLs surfaced
+# (github.com/{user}, linkedin.com/in/{handle}, etc).
+_URL_RE = re.compile(
+    r"\bhttps?://[^\s<>\"']+",
+    re.IGNORECASE,
+)
+
+# Handles like @username and #hashtags often carry identity. Strip.
+_AT_HANDLE_RE = re.compile(r"(?<!\w)@[A-Za-z0-9_]{2,30}\b")
+
+
+def scrub_pii_for_public_display(text: str) -> str:
+    """Run the four redactors. Returns the sanitized string. The
+    "[redacted]" marker stays in human-readable English regardless of
+    source language because it doubles as a visible accountability cue
+    on the rendered page."""
+    if not text:
+        return ""
+    out = _EMAIL_RE.sub("[email redacted]", text)
+    out = _URL_RE.sub("[link redacted]", out)
+    out = _PHONE_RE.sub("[phone redacted]", out)
+    out = _AT_HANDLE_RE.sub("[handle redacted]", out)
+    return out
+
+
+# ─── Public handle validation ─────────────────────────────────────────
+
+_HANDLE_MAX_LEN = 40
+_HANDLE_DIGIT_RUN_RE = re.compile(r"\d{4,}")
+
+
+def validate_public_handle(raw: str) -> tuple[str, str | None]:
+    """Returns (cleaned_handle, error). Cleaned handle is empty if the
+    input is rejected. The error message is meant for the API response.
+
+    Rules:
+      * Trim whitespace.
+      * Max ``_HANDLE_MAX_LEN`` chars after trim.
+      * Reject anything containing '@' (looks like email).
+      * Reject a run of 4+ digits (looks like a phone number).
+      * Reject empty after trim (caller should fall back to "Anonymous").
+    """
+    if raw is None:
+        return ("", None)  # Anonymous — not an error
+    handle = raw.strip()
+    if not handle:
+        return ("", None)
+    if "@" in handle:
+        return ("", "Handle cannot contain '@'")
+    if _HANDLE_DIGIT_RUN_RE.search(handle):
+        return ("", "Handle cannot contain a long run of digits")
+    if len(handle) > _HANDLE_MAX_LEN:
+        return ("", f"Handle too long (max {_HANDLE_MAX_LEN} characters)")
+    return (handle, None)
+
+
+# ─── JSON-LD for public discussions ───────────────────────────────────
+
+def discussion_forum_jsonld(
+    *,
+    posts: list[dict[str, Any]],
+    page_url: str,
+    headline: str,
+    about_url: str,
+    about_type: str = "CreativeWork",
+    about_name: str = "",
+) -> dict[str, Any]:
+    """Schema.org/DiscussionForumPosting — Google added rich-result
+    support for this in 2024. Each post is a Comment with an
+    anonymized author. Posts in are expected to be already PII-scrubbed.
+
+    ``posts`` items have keys: handle, body, created_at, session_id.
+    ``about_type`` is "Book" for /book/{id}/discussions, "Person" for
+    /mind/{id}/discussions.
+    """
+    comments = []
+    for i, p in enumerate(posts):
+        comments.append({
+            "@type": "Comment",
+            "position": i + 1,
+            "author": {
+                "@type": "Person",
+                "name": p.get("handle") or "Anonymous",
+            },
+            "text": p.get("body", ""),
+            "dateCreated": p.get("created_at", ""),
+        })
+    return {
+        "@context": "https://schema.org",
+        "@type": "DiscussionForumPosting",
+        "headline": headline,
+        "url": page_url,
+        "about": {
+            "@type": about_type,
+            "name": about_name,
+            "url": about_url,
+        },
+        "commentCount": len(comments),
+        "comment": comments,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -43,11 +43,14 @@ from .core.db import (
     init_db,
     list_agents,
     list_chat_sessions,
+    list_books_by_topic,
     list_books_for_mind,
     list_messages,
     list_minds,
+    list_minds_by_topic,
     list_minds_for_agent,
     list_questions,
+    list_questions_batch,
     list_related_minds,
     list_session_messages,
     list_user_interest_profile,
@@ -71,6 +74,7 @@ from .core.indexer import index_text
 from .core.providers import GeminiProvider, ProviderError, chat_with_fallback, pick_provider
 from .core.rag import build_context, retrieve, retrieve_cross_book
 from .core import seo as seo_render
+from .core import qa as qa_module
 from .core.minds import (
     SEED_MINDS,
     create_mind_from_content,
@@ -692,23 +696,75 @@ def sitemap_xml():
     # through the Supabase pooler. We cap them with a defensive limit
     # AND wrap the whole response in a TTL cache.
     try:
-        for agent in list_agents(limit=5000):
-            if agent.get("status") != "ready":
-                continue
+        ready_agents = [
+            a for a in list_agents(limit=5000)
+            if a.get("status") == "ready"
+        ]
+        # Batch-fetch questions for all ready agents in a single query —
+        # the previous loop pattern would issue N round-trips inside the
+        # sitemap render hot path.
+        questions_by_agent = list_questions_batch([a["id"] for a in ready_agents])
+        for agent in ready_agents:
+            agent_id = agent["id"]
             priority = "0.7" if agent.get("type") == "ai_book" else "0.5"
             urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent["id"]}</loc>
+    <loc>{_SITE_URL}/book/{agent_id}</loc>
     <lastmod>{today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>{priority}</priority>
   </url>
 """
-        for mind in list_minds(limit=5000):
+            # Phase 4A — compound Q&A URLs. One per popular question per
+            # book. Slightly lower priority than the parent page; weekly
+            # changefreq because answers may be regenerated.
+            for q in questions_by_agent.get(agent_id, []):
+                qslug = seo_render.slugify(q)
+                if not qslug:
+                    continue
+                urls += f"""  <url>
+    <loc>{_SITE_URL}/book/{agent_id}/q/{qslug}</loc>
+    <lastmod>{today}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+"""
+        all_minds = list_minds(limit=5000)
+        for mind in all_minds:
             urls += f"""  <url>
     <loc>{_SITE_URL}/mind/{mind["id"]}</loc>
     <lastmod>{today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>
+"""
+        # Phase 4B — mind-on-topic compound URLs. Only emit pairs that
+        # pass the relevance filter so we don't list /mind/X/on/Y for
+        # combos that the route would 404 anyway.
+        for mind in all_minds:
+            for topic in TOPIC_TAGS:
+                if not qa_module.is_mind_topic_relevant(mind, topic):
+                    continue
+                tslug = seo_render.topic_slug(topic)
+                if not tslug:
+                    continue
+                urls += f"""  <url>
+    <loc>{_SITE_URL}/mind/{mind["id"]}/on/{tslug}</loc>
+    <lastmod>{today}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+"""
+        # Topic hub pages — 15 fixed URLs from TOPIC_TAGS. Cheap to include
+        # and they're the upper layer of the topic→entity link graph.
+        for topic in TOPIC_TAGS:
+            slug = seo_render.topic_slug(topic)
+            if not slug:
+                continue
+            urls += f"""  <url>
+    <loc>{_SITE_URL}/topic/{slug}</loc>
+    <lastmod>{today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
 """
     except Exception:
@@ -1065,7 +1121,11 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
     stats_html = seo_render.render_stats(total_words, chapter_count)
     toc_html = seo_render.render_toc(chapters)
     samples_html = seo_render.render_sample_passages(chunks)
-    questions_html = seo_render.render_popular_questions(questions, chat_url)
+    # Each question links to its own /book/{id}/q/{slug} compound page —
+    # turns one entity URL into 6 indexable URLs (book + 5 Q&A).
+    questions_html = seo_render.render_popular_questions(
+        questions, chat_url, book_id=agent_id, site_url=base,
+    )
     minds_html = seo_render.render_minds_for_book(related_minds, base)
     cta_html = seo_render.render_cta_matrix(
         caps, entity_id=agent_id, entity_name=title_raw, base=base
@@ -1346,6 +1406,380 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 {redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
+
+
+# ─── Phase 4A — Book Q&A compound pages ─────────────────────────────
+#
+# /book/{agent_id}/q/{slug} renders one indexable URL per popular
+# question per book. 5 questions per indexed book × hundreds of books
+# = thousands of new long-tail entry points. Each page is:
+#   * Grounded in RAG-retrieved passages from the parent book
+#   * Optionally enriched with an LLM-synthesized answer (cacheable,
+#     kill-switched by ENABLE_QA_LLM env var)
+#   * Wrapped in QAPage schema for Google rich-result eligibility
+#
+# Caching strategy: answers are slow to generate (RAG + LLM round trip).
+# We cache the rendered HTML by (agent_id, slug) so the first crawler
+# pays the cost and every subsequent hit is free. The Vercel edge
+# Cache-Control header gives us a second tier outside the function.
+
+_QA_PAGE_CACHE_TTL = 86400  # 24h — answers don't change unless we
+                            # explicitly re-run the question/answer flow
+
+
+@app.get("/book/{agent_id}/q/{question_slug}", response_class=HTMLResponse)
+def book_question_page(agent_id: str, question_slug: str, request: Request) -> HTMLResponse:
+    """Per-question compound page for a book. See module-level comment."""
+    from html import escape as html_esc
+
+    agent = get_agent(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    try:
+        questions = list_questions(agent_id) or []
+    except Exception:
+        questions = []
+    question = seo_render.find_question_by_slug(questions, question_slug)
+    if not question:
+        raise HTTPException(status_code=404, detail="Question not found for this book")
+
+    cache_key = f"qa_page:{agent_id}:{question_slug}"
+    cached = _cache_get(cache_key, _QA_PAGE_CACHE_TTL)
+    if cached is not None:
+        return HTMLResponse(
+            cached,
+            headers={
+                "Cache-Control": "public, max-age=3600, s-maxage=86400",
+                "X-Cache": "HIT",
+            },
+        )
+
+    book = get_ai_book_by_agent(agent_id)
+    title_raw = book["title"] if book and book.get("title") else agent.get("name", "Untitled")
+    title = html_esc(title_raw)
+    base = _SITE_URL
+    book_url = f"{base}/book/{agent_id}"
+    canonical = f"{base}/book/{agent_id}/q/{question_slug}"
+
+    # ── Generate answer (lazy, in-process cached) ──────────────────────
+    qa_result = qa_module.generate_grounded_answer(
+        agent_id, question, book_title=title_raw,
+    )
+    answer = qa_result.get("answer", "")
+    passages = qa_result.get("passages", [])
+
+    # ── Render sections ────────────────────────────────────────────────
+    answer_html = seo_render.render_qa_answer(answer)
+    passages_html = seo_render.render_qa_passages(passages)
+    siblings_html = seo_render.render_sibling_questions(
+        questions, agent_id, base, current_question=question,
+    )
+
+    qa_ld = seo_render.jsonld_script(seo_render.qa_page_jsonld(
+        question=question,
+        answer=answer,
+        url=canonical,
+        book_title=title_raw,
+        book_url=book_url,
+    ))
+    breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
+        ("Feynman", base),
+        ("Books", f"{base}/#/library"),
+        (title_raw, book_url),
+        ("Q&A", canonical),
+    ]))
+
+    page_title_raw = f"{question} — {title_raw}"
+    if len(page_title_raw) > 120:
+        page_title_raw = page_title_raw[:117].rsplit(" ", 1)[0] + "..."
+    page_title = html_esc(page_title_raw)
+    desc_raw = answer[:180].strip() if answer else (
+        f"Discuss \"{question}\" with the book \"{title_raw}\" on Feynman."
+    )
+    if len(desc_raw) > 200:
+        desc_raw = desc_raw[:197].rsplit(" ", 1)[0] + "..."
+    desc = html_esc(desc_raw)
+    og_image_url = f"{base}/book/{agent_id}/og.png?v={config.OG_IMAGE_CACHE_VERSION}"
+    chat_url = f"{base}/#/chat/{agent_id}"
+
+    html = f"""<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{page_title}</title>
+<meta name="description" content="{desc}">
+<link rel="canonical" href="{canonical}">
+<meta property="og:type" content="article">
+<meta property="og:title" content="{html_esc(question)}">
+<meta property="og:description" content="{desc}">
+<meta property="og:image" content="{og_image_url}">
+<meta property="og:url" content="{canonical}">
+<meta property="og:site_name" content="Feynman">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@steve_yeow">
+<meta name="twitter:title" content="{html_esc(question)}">
+<meta name="twitter:description" content="{desc}">
+<meta name="twitter:image" content="{og_image_url}">
+{qa_ld}
+{breadcrumb_ld}
+</head><body>
+<nav class="qa-back"><a href="{book_url}">← {title}</a></nav>
+<h1>{html_esc(question)}</h1>
+{answer_html}
+{passages_html}
+{siblings_html}
+<p class="cta"><a href="{html_esc(chat_url)}">Chat about this question →</a></p>
+</body></html>"""
+    _cache_set(cache_key, html)
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "public, max-age=3600, s-maxage=86400",
+            "X-Cache": "MISS",
+        },
+    )
+
+
+# ─── Phase 4B — Mind-on-topic compound pages ────────────────────────
+#
+# /mind/{mind_id}/on/{topic_slug} renders an imagined-perspective essay
+# of how this mind would approach this topic. Relevance is enforced —
+# non-matching pairs 404 to avoid programmatic spam (e.g. "Confucius on
+# Computer Science"). Essays are LLM-generated, labelled as imagined,
+# and grounded in the mind's persona/thinking_style/typical_phrases.
+
+_MIND_ESSAY_CACHE_TTL = 86400
+
+
+@app.get("/mind/{mind_id}/on/{topic_slug}", response_class=HTMLResponse)
+def mind_on_topic_page(mind_id: str, topic_slug: str, request: Request) -> HTMLResponse:
+    """Per-(mind, topic) compound page. See module-level comment."""
+    from html import escape as html_esc
+
+    mind = get_mind(mind_id)
+    if not mind:
+        raise HTTPException(status_code=404, detail="Mind not found")
+    topic = _resolve_topic_slug(topic_slug)
+    if not topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+    if not qa_module.is_mind_topic_relevant(mind, topic):
+        # Relevance gate — pair isn't plausible enough to merit an essay.
+        # 404 keeps Google from indexing programmatic combinations.
+        raise HTTPException(status_code=404, detail="Topic not relevant to this mind")
+
+    cache_key = f"mind_essay:{mind_id}:{topic_slug}"
+    cached = _cache_get(cache_key, _MIND_ESSAY_CACHE_TTL)
+    if cached is not None:
+        return HTMLResponse(
+            cached,
+            headers={
+                "Cache-Control": "public, max-age=3600, s-maxage=86400",
+                "X-Cache": "HIT",
+            },
+        )
+
+    name_raw = mind.get("name", "Unknown")
+    name = html_esc(name_raw)
+    base = _SITE_URL
+    mind_url = f"{base}/mind/{mind_id}"
+    canonical = f"{base}/mind/{mind_id}/on/{topic_slug}"
+    chat_url = f"{base}/#/mind/{mind_id}"
+
+    essay_result = qa_module.generate_mind_on_topic_essay(mind, topic)
+    essay = essay_result.get("essay", "")
+    if not essay:
+        # Generation failed (LLM disabled, provider error, or empty
+        # response). Don't render a blank page — 404 so we don't pollute
+        # the index with empty essays.
+        raise HTTPException(status_code=404, detail="Essay unavailable")
+
+    page_title_raw = f"How {name_raw} would approach {topic} — Feynman"
+    if len(page_title_raw) > 120:
+        page_title_raw = page_title_raw[:117].rsplit(" ", 1)[0] + "..."
+    page_title = html_esc(page_title_raw)
+    desc_raw = essay[:180].strip().replace("\n", " ")
+    if len(desc_raw) > 200:
+        desc_raw = desc_raw[:197].rsplit(" ", 1)[0] + "..."
+    desc = html_esc(desc_raw)
+    og_image_url = f"{base}/mind/{mind_id}/og.png"
+
+    essay_html = seo_render.render_mind_on_topic_essay(essay, name_raw, topic)
+    article_ld = seo_render.jsonld_script(seo_render.mind_essay_jsonld(
+        mind_name=name_raw, topic=topic, essay=essay,
+        url=canonical, mind_url=mind_url, image=og_image_url,
+    ))
+    breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
+        ("Feynman", base),
+        ("Great Minds", f"{base}/#/minds"),
+        (name_raw, mind_url),
+        (topic, canonical),
+    ]))
+    topic_hub_url = f"{base}/topic/{topic_slug}"
+
+    html = f"""<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{page_title}</title>
+<meta name="description" content="{desc}">
+<link rel="canonical" href="{canonical}">
+<meta property="og:type" content="article">
+<meta property="og:title" content="{html_esc(f'How {name_raw} would approach {topic}')}">
+<meta property="og:description" content="{desc}">
+<meta property="og:image" content="{og_image_url}">
+<meta property="og:url" content="{canonical}">
+<meta property="og:site_name" content="Feynman">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@steve_yeow">
+<meta name="twitter:title" content="{html_esc(f'How {name_raw} would approach {topic}')}">
+<meta name="twitter:description" content="{desc}">
+<meta name="twitter:image" content="{og_image_url}">
+{article_ld}
+{breadcrumb_ld}
+</head><body>
+<nav class="essay-back"><a href="{mind_url}">← {name}</a></nav>
+<h1>How {name} would approach {html_esc(topic)}</h1>
+{essay_html}
+<p class="related-links">
+  Read more: <a href="{mind_url}">About {name}</a> ·
+  <a href="{topic_hub_url}">{html_esc(topic)} on Feynman</a>
+</p>
+<p class="cta"><a href="{html_esc(chat_url)}">Chat with {name} →</a></p>
+</body></html>"""
+    _cache_set(cache_key, html)
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "public, max-age=3600, s-maxage=86400",
+            "X-Cache": "MISS",
+        },
+    )
+
+
+# ─── Phase 4C — Topic hub pages ─────────────────────────────────────
+#
+# /topic/{slug} aggregates books and minds tagged with one of the 15
+# TOPIC_TAGS. Pure aggregation — no LLM calls. Each page becomes:
+#   * a new indexable URL (sitemap)
+#   * an internal-PageRank conduit pushing authority to entity pages
+#   * a canonical destination for queries like "best Economics books"
+#
+# Cache aggressively: topic membership only changes when a new catalog
+# book is discovered, which is rare. 1 hour TTL is plenty fresh.
+
+_TOPIC_PAGE_CACHE_TTL = 3600
+
+
+def _resolve_topic_slug(slug: str) -> str | None:
+    """Find the canonical topic name for a URL slug. None if no match."""
+    index = seo_render.build_topic_slug_index(TOPIC_TAGS)
+    return index.get(slug.lower())
+
+
+@app.get("/topic/{slug}", response_class=HTMLResponse)
+def topic_page(slug: str, request: Request) -> HTMLResponse:
+    """Server-rendered topic hub. Lists all books + minds tagged with this
+    topic with cross-links — both for users and for the crawler graph.
+    """
+    from html import escape as html_esc
+
+    topic = _resolve_topic_slug(slug)
+    if not topic:
+        raise HTTPException(status_code=404, detail="Topic not found")
+
+    cache_key = f"topic_page:{slug}"
+    cached = _cache_get(cache_key, _TOPIC_PAGE_CACHE_TTL)
+    if cached is not None:
+        return HTMLResponse(
+            cached,
+            headers={
+                "Cache-Control": "public, max-age=3600, s-maxage=86400",
+                "X-Cache": "HIT",
+            },
+        )
+
+    try:
+        books = list_books_by_topic(topic, limit=30)
+    except Exception:
+        books = []
+    try:
+        minds = list_minds_by_topic(topic, limit=12)
+    except Exception:
+        minds = []
+
+    base = _SITE_URL
+    canonical = f"{base}/topic/{slug}"
+    title = html_esc(f"{topic} on Feynman")
+    desc_raw = (
+        f"Chat with the best {topic} books and great minds on Feynman. "
+        f"{len(books)} curated {('book' if len(books) == 1 else 'books')}, "
+        f"{len(minds)} {('thinker' if len(minds) == 1 else 'thinkers')}."
+    )
+    if len(desc_raw) > 200:
+        desc_raw = desc_raw[:197].rsplit(" ", 1)[0] + "..."
+    desc = html_esc(desc_raw)
+
+    intro_html = seo_render.render_topic_intro(topic, len(books), len(minds))
+    books_html = seo_render.render_topic_books(books, base)
+    minds_html = seo_render.render_topic_minds(minds, base)
+
+    # Collection schema with embedded ItemList (book entries first, then
+    # minds). LLMs use this to enumerate "what's in this topic" cleanly.
+    items: list[dict[str, str]] = []
+    for b in books[:30]:
+        if b.get("id") and b.get("name"):
+            items.append({"name": b["name"], "url": f"{base}/book/{b['id']}"})
+    for m in minds[:12]:
+        if m.get("id") and m.get("name"):
+            items.append({"name": m["name"], "url": f"{base}/mind/{m['id']}"})
+
+    collection_ld = seo_render.jsonld_script(seo_render.collection_jsonld(
+        name=f"{topic} on Feynman",
+        description=desc_raw,
+        url=canonical,
+        items=items,
+        site_url=base,
+    ))
+    breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
+        ("Feynman", base),
+        ("Topics", f"{base}/#/library"),
+        (topic, canonical),
+    ]))
+
+    html = f"""<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<meta name="description" content="{desc}">
+<link rel="canonical" href="{canonical}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="{title}">
+<meta property="og:description" content="{desc}">
+<meta property="og:url" content="{canonical}">
+<meta property="og:site_name" content="Feynman">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@steve_yeow">
+<meta name="twitter:title" content="{title}">
+<meta name="twitter:description" content="{desc}">
+{collection_ld}
+{breadcrumb_ld}
+</head><body>
+<h1>{html_esc(topic)}</h1>
+{intro_html}
+{books_html}
+{minds_html}
+<p class="cta"><a href="{base}/#/library">Explore the full Feynman library →</a></p>
+</body></html>"""
+    _cache_set(cache_key, html)
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "public, max-age=3600, s-maxage=86400",
+            "X-Cache": "MISS",
+        },
+    )
 
 
 @app.get("/api/public/book/{agent_id}/read")

--- a/app/main.py
+++ b/app/main.py
@@ -43,15 +43,25 @@ from .core.db import (
     init_db,
     list_agents,
     list_chat_sessions,
+    approve_chat_session_public,
+    count_pending_public_sessions,
+    get_chat_session_with_public_status,
     list_books_by_topic,
     list_books_for_mind,
     list_messages,
+    list_messages_for_public_session,
     list_minds,
     list_minds_by_topic,
     list_minds_for_agent,
+    list_public_sessions_for_agent,
+    list_public_sessions_for_mind,
     list_questions,
     list_questions_batch,
+    list_related_books,
     list_related_minds,
+    reject_chat_session_public,
+    request_chat_session_share,
+    withdraw_chat_session_share,
     list_session_messages,
     list_user_interest_profile,
     list_votes,
@@ -75,6 +85,7 @@ from .core.providers import GeminiProvider, ProviderError, chat_with_fallback, p
 from .core.rag import build_context, retrieve, retrieve_cross_book
 from .core import seo as seo_render
 from .core import qa as qa_module
+from .core import ugc as ugc_module
 from .core.minds import (
     SEED_MINDS,
     create_mind_from_content,
@@ -767,6 +778,27 @@ def sitemap_xml():
     <priority>0.8</priority>
   </url>
 """
+        # Phase 6 — public discussion pages. Only included when the
+        # feature flag is on, so the sitemap stays consistent with the
+        # actual route surface. Flip ENABLE_PUBLIC_DISCUSSIONS to surface
+        # these to Google.
+        if ugc_module.is_enabled():
+            for agent in ready_agents:
+                urls += f"""  <url>
+    <loc>{_SITE_URL}/book/{agent["id"]}/discussions</loc>
+    <lastmod>{today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.4</priority>
+  </url>
+"""
+            for mind in all_minds:
+                urls += f"""  <url>
+    <loc>{_SITE_URL}/mind/{mind["id"]}/discussions</loc>
+    <lastmod>{today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.4</priority>
+  </url>
+"""
     except Exception:
         pass
 
@@ -1107,6 +1139,16 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
         related_minds = list_minds_for_agent(agent_id)
     except Exception:
         related_minds = []
+    # Phase 5 — related books surfaced from same-topic + same-author cohort
+    agent_meta = agent.get("meta") or {}
+    book_topic = (agent_meta.get("category") or "").strip()
+    book_author = author_raw or (agent_meta.get("author") or "")
+    try:
+        related_books = list_related_books(
+            agent_id, topic=book_topic, author=book_author, limit=6,
+        )
+    except Exception:
+        related_books = []
 
     # ── Detect capabilities (Phase 3a) ──────────────────────────────────
     # Not every book supports every action; e.g. catalog stubs only support
@@ -1127,6 +1169,8 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
         questions, chat_url, book_id=agent_id, site_url=base,
     )
     minds_html = seo_render.render_minds_for_book(related_minds, base)
+    related_books_html = seo_render.render_related_books(related_books, base)
+    topic_link_html = seo_render.render_topic_link_back(book_topic, base) if book_topic else ""
     cta_html = seo_render.render_cta_matrix(
         caps, entity_id=agent_id, entity_name=title_raw, base=base
     )
@@ -1213,6 +1257,8 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {toc_html}
 {questions_html}
 {minds_html}
+{related_books_html}
+{topic_link_html}
 {cta_html}
 {redirect_script}
 </body></html>"""
@@ -1297,6 +1343,13 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
         related = list_related_minds(mind_id, domain_raw)
     except Exception:
         related = []
+    # Phase 5 — surface topic-hub links for any TOPIC_TAG this mind is
+    # relevant to. Reuses the same morphological matcher Phase 4B uses
+    # to gate /mind/{id}/on/{topic} compound pages, so the two link sets
+    # stay consistent.
+    matching_topics = [
+        t for t in TOPIC_TAGS if qa_module.is_mind_topic_relevant(mind, t)
+    ]
 
     # "Books in library" surfaces the extras that Notable Works doesn't already
     # list — avoid double-rendering the same title in both sections.
@@ -1320,6 +1373,7 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
     works_html = seo_render.render_mind_works(works_list, linked_books, base)
     extra_books_html = seo_render.render_books_for_mind(extra_books, base)
     related_html = seo_render.render_related_minds(related, base)
+    topic_links_html = seo_render.render_topic_links_for_mind(matching_topics, base)
 
     # ── JSON-LD ─────────────────────────────────────────────────────────
     # sameAs telling Google's Knowledge Graph "this is THE Karl Marx" is
@@ -1402,6 +1456,7 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 {works_html}
 {extra_books_html}
 {related_html}
+{topic_links_html}
 <p class="cta"><a href="{html_esc(reader_url)}">Chat with {name} on Feynman →</a></p>
 {redirect_script}
 </body></html>"""
@@ -1777,6 +1832,388 @@ def topic_page(slug: str, request: Request) -> HTMLResponse:
         html,
         headers={
             "Cache-Control": "public, max-age=3600, s-maxage=86400",
+            "X-Cache": "MISS",
+        },
+    )
+
+
+# ─── Phase 6 — UGC: public discussions ──────────────────────────────
+#
+# Privacy is the whole game here. The feature is entirely gated by the
+# ENABLE_PUBLIC_DISCUSSIONS env var (default OFF) — all five routes
+# below return 404 when the flag is off, so the surface is invisible
+# until product/legal sign off. See app/core/ugc.py for the full
+# privacy model.
+#
+# Admin moderation is gated by ADMIN_USER_IDS env (comma-separated
+# user IDs). Empty / unset means no one can moderate, which combined
+# with the feature flag means the system stays in a safe state by
+# default even if the flag is accidentally flipped.
+
+
+def _is_admin_user(request: Request) -> bool:
+    """Membership check against ADMIN_USER_IDS env var."""
+    admin_ids = {
+        s.strip() for s in os.getenv("ADMIN_USER_IDS", "").split(",") if s.strip()
+    }
+    if not admin_ids:
+        return False
+    uid = _get_user_id(request)
+    return bool(uid) and uid in admin_ids
+
+
+def _require_ugc_enabled() -> None:
+    """Raise 404 if the feature flag is off. We use 404 (not 403) to
+    avoid signalling the route's existence to probes — the surface is
+    effectively absent when disabled."""
+    if not ugc_module.is_enabled():
+        raise HTTPException(status_code=404, detail="Not found")
+
+
+class ShareChatSessionRequest(BaseModel):
+    handle: str | None = Field(default=None, max_length=40)
+
+
+@app.post("/api/chat-sessions/{session_id}/share")
+def api_chat_session_share(
+    session_id: str, payload: ShareChatSessionRequest, request: Request,
+):
+    """User opts in to making this chat session publicly visible.
+    Status moves to 'opted_in' awaiting admin approval. Idempotent —
+    re-sharing updates the handle but doesn't double-stamp consent."""
+    _require_ugc_enabled()
+    uid = _get_user_id(request)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    handle, err = ugc_module.validate_public_handle(payload.handle or "")
+    if err:
+        raise HTTPException(status_code=422, detail=err)
+    result = request_chat_session_share(session_id, uid, handle=handle or None)
+    if not result:
+        # Either not found, not owned, or rejected — return 404 for all
+        # three to avoid leaking ownership / state info.
+        raise HTTPException(status_code=404, detail="Session not eligible for sharing")
+    return {
+        "id": result["id"],
+        "public_status": result["public_status"],
+        "public_handle": result.get("public_handle"),
+        "consent_at": result.get("consent_at"),
+    }
+
+
+@app.post("/api/chat-sessions/{session_id}/withdraw")
+def api_chat_session_withdraw(session_id: str, request: Request):
+    """User withdraws consent. Status moves to 'withdrawn' (or stays
+    withdrawn — idempotent). Works at any prior status."""
+    _require_ugc_enabled()
+    uid = _get_user_id(request)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    result = withdraw_chat_session_share(session_id, uid)
+    if not result:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {"id": result["id"], "public_status": result["public_status"]}
+
+
+@app.get("/api/chat-sessions/{session_id}/public-status")
+def api_chat_session_public_status(session_id: str, request: Request):
+    """Read the current public status of a session. Owner-only."""
+    _require_ugc_enabled()
+    uid = _get_user_id(request)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    sess = get_chat_session_with_public_status(session_id)
+    if not sess or sess.get("user_id") != uid:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {
+        "id": sess["id"],
+        "public_status": sess.get("public_status", "private"),
+        "public_handle": sess.get("public_handle"),
+        "consent_at": sess.get("consent_at"),
+        "approved_at": sess.get("approved_at"),
+    }
+
+
+class AdminApproveRequest(BaseModel):
+    public_title: str | None = Field(default=None, max_length=200)
+
+
+@app.post("/api/admin/chat-sessions/{session_id}/approve")
+def api_admin_approve_session(
+    session_id: str, payload: AdminApproveRequest, request: Request,
+):
+    """Admin approves an opted-in session for public display."""
+    _require_ugc_enabled()
+    if not _is_admin_user(request):
+        # Don't reveal whether the route exists to non-admins.
+        raise HTTPException(status_code=404, detail="Not found")
+    admin_uid = _get_user_id(request) or ""
+    result = approve_chat_session_public(
+        session_id, admin_uid, public_title=payload.public_title,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Session not pending approval")
+    return {"id": result["id"], "public_status": result["public_status"]}
+
+
+@app.post("/api/admin/chat-sessions/{session_id}/reject")
+def api_admin_reject_session(session_id: str, request: Request):
+    _require_ugc_enabled()
+    if not _is_admin_user(request):
+        raise HTTPException(status_code=404, detail="Not found")
+    admin_uid = _get_user_id(request) or ""
+    result = reject_chat_session_public(session_id, admin_uid)
+    if not result:
+        raise HTTPException(status_code=404, detail="Session not pending approval")
+    return {"id": result["id"], "public_status": result["public_status"]}
+
+
+@app.get("/api/admin/moderation-queue/count")
+def api_admin_moderation_queue_count(request: Request):
+    """Tiny endpoint for an admin dashboard to poll the queue size."""
+    _require_ugc_enabled()
+    if not _is_admin_user(request):
+        raise HTTPException(status_code=404, detail="Not found")
+    return {"pending": count_pending_public_sessions()}
+
+
+# ── Public discussion render routes (SSR; feature-flag gated) ────────
+
+
+def _render_public_post_html(session: dict[str, Any], chat_url: str) -> str:
+    """Render one approved chat session as a discussion post. PII is
+    scrubbed before display. Empty bodies render as a one-line stub
+    rather than a blank card."""
+    from html import escape as html_esc
+
+    title = (
+        session.get("public_title")
+        or session.get("title")
+        or "Discussion"
+    )
+    handle = session.get("public_handle") or "Anonymous"
+    # Fetch messages and assemble a sanitized snippet (cap at 4 messages,
+    # 600 chars each, then PII-scrub the whole thing).
+    msgs = []
+    try:
+        # SAFETY: list_messages_for_public_session enforces a SQL-side
+        # join on public_status='approved' so even if upstream caching
+        # surfaced a stale session row, the messages are gated by the
+        # current DB state. Caller still scrubs PII before render.
+        raw_msgs = list_messages_for_public_session(session["id"]) or []
+    except Exception:
+        raw_msgs = []
+    for m in raw_msgs[:6]:
+        role = m.get("role", "")
+        content = (m.get("content") or "").strip()
+        if not content:
+            continue
+        if len(content) > 600:
+            content = content[:597].rsplit(" ", 1)[0] + "…"
+        msgs.append((role, content))
+
+    inner = ""
+    if msgs:
+        rows = []
+        for role, content in msgs:
+            scrubbed = ugc_module.scrub_pii_for_public_display(content)
+            role_label = html_esc(role.upper()) if role else ""
+            rows.append(
+                f'<div class="msg msg-{html_esc(role)}">'
+                f'<small class="msg-role">{role_label}</small>'
+                f'<p>{html_esc(scrubbed)}</p>'
+                '</div>'
+            )
+        inner = "".join(rows)
+    else:
+        inner = '<p class="msg-empty"><em>No public content in this discussion.</em></p>'
+
+    return (
+        '<article class="public-post">'
+        f'<header><h3>{html_esc(title)}</h3>'
+        f'<small class="post-author">— {html_esc(handle)}</small></header>'
+        f'{inner}'
+        f'<p class="post-cta"><a href="{html_esc(chat_url)}">Start your own chat →</a></p>'
+        '</article>'
+    )
+
+
+def _render_public_discussions_page(
+    *,
+    entity_type: str,    # "book" or "mind"
+    entity_id: str,
+    entity_name: str,
+    entity_canonical: str,
+    chat_url: str,
+    sessions: list[dict[str, Any]],
+) -> str:
+    """Assemble the full HTML for a /discussions page. Common between
+    book and mind."""
+    from html import escape as html_esc
+
+    title_raw = f"Discussions about {entity_name} — Feynman"
+    title = html_esc(title_raw)
+    if sessions:
+        desc_raw = (
+            f"{len(sessions)} public "
+            f"{('discussion' if len(sessions) == 1 else 'discussions')} "
+            f"about {entity_name} on Feynman. "
+            f"All conversations are user-shared with consent and PII-scrubbed."
+        )
+    else:
+        desc_raw = (
+            f"Public discussions about {entity_name} on Feynman. "
+            f"Be the first to share — open a chat and opt in from your session."
+        )
+    if len(desc_raw) > 200:
+        desc_raw = desc_raw[:197].rsplit(" ", 1)[0] + "..."
+    desc = html_esc(desc_raw)
+
+    posts_html = "".join(_render_public_post_html(s, chat_url) for s in sessions)
+    if not posts_html:
+        posts_html = (
+            '<p class="no-discussions">No public discussions yet. '
+            f'Be the first — chat with {html_esc(entity_name)} and opt to share '
+            'your conversation from the session menu.</p>'
+        )
+
+    # Build DiscussionForumPosting JSON-LD only when there are real posts
+    # (avoid emitting an empty thread schema that Google may flag).
+    forum_ld = ""
+    if sessions:
+        posts_for_ld = [
+            {
+                "handle": s.get("public_handle") or "Anonymous",
+                "body": ugc_module.scrub_pii_for_public_display(
+                    (s.get("public_title") or s.get("title") or "")
+                )[:300],
+                "created_at": s.get("approved_at") or s.get("created_at") or "",
+                "session_id": s["id"],
+            }
+            for s in sessions
+        ]
+        forum_ld = seo_render.jsonld_script(ugc_module.discussion_forum_jsonld(
+            posts=posts_for_ld,
+            page_url=entity_canonical + "/discussions",
+            headline=f"Discussions about {entity_name}",
+            about_url=entity_canonical,
+            about_type="Book" if entity_type == "book" else "Person",
+            about_name=entity_name,
+        ))
+    breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
+        ("Feynman", _SITE_URL),
+        (
+            "Books" if entity_type == "book" else "Great Minds",
+            f"{_SITE_URL}/#/{'library' if entity_type == 'book' else 'minds'}",
+        ),
+        (entity_name, entity_canonical),
+        ("Discussions", entity_canonical + "/discussions"),
+    ]))
+
+    return f"""<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<meta name="description" content="{desc}">
+<link rel="canonical" href="{entity_canonical}/discussions">
+<meta property="og:type" content="website">
+<meta property="og:title" content="{title}">
+<meta property="og:description" content="{desc}">
+<meta property="og:url" content="{entity_canonical}/discussions">
+<meta property="og:site_name" content="Feynman">
+{forum_ld}
+{breadcrumb_ld}
+</head><body>
+<nav class="back-link"><a href="{entity_canonical}">← {html_esc(entity_name)}</a></nav>
+<h1>Discussions about {html_esc(entity_name)}</h1>
+{posts_html}
+<p class="cta"><a href="{html_esc(chat_url)}">Start your own chat →</a></p>
+</body></html>"""
+
+
+_PUBLIC_DISCUSSIONS_CACHE_TTL = 600  # 10 min — fresh enough for new approvals
+
+
+@app.get("/book/{agent_id}/discussions", response_class=HTMLResponse)
+def book_discussions_page(agent_id: str, request: Request) -> HTMLResponse:
+    """List approved public discussions for this book. Returns 404 if
+    the feature flag is off, so the surface is invisible by default."""
+    _require_ugc_enabled()
+    agent = get_agent(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    cache_key = f"public_discussions_book:{agent_id}"
+    cached = _cache_get(cache_key, _PUBLIC_DISCUSSIONS_CACHE_TTL)
+    if cached is not None:
+        return HTMLResponse(
+            cached,
+            headers={
+                "Cache-Control": "public, max-age=600, s-maxage=600",
+                "X-Cache": "HIT",
+            },
+        )
+
+    try:
+        sessions = list_public_sessions_for_agent(agent_id)
+    except Exception:
+        sessions = []
+    entity_name = agent.get("name") or "this book"
+    html = _render_public_discussions_page(
+        entity_type="book",
+        entity_id=agent_id,
+        entity_name=entity_name,
+        entity_canonical=f"{_SITE_URL}/book/{agent_id}",
+        chat_url=f"{_SITE_URL}/#/chat/{agent_id}",
+        sessions=sessions,
+    )
+    _cache_set(cache_key, html)
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "public, max-age=600, s-maxage=600",
+            "X-Cache": "MISS",
+        },
+    )
+
+
+@app.get("/mind/{mind_id}/discussions", response_class=HTMLResponse)
+def mind_discussions_page(mind_id: str, request: Request) -> HTMLResponse:
+    _require_ugc_enabled()
+    mind = get_mind(mind_id)
+    if not mind:
+        raise HTTPException(status_code=404, detail="Mind not found")
+
+    cache_key = f"public_discussions_mind:{mind_id}"
+    cached = _cache_get(cache_key, _PUBLIC_DISCUSSIONS_CACHE_TTL)
+    if cached is not None:
+        return HTMLResponse(
+            cached,
+            headers={
+                "Cache-Control": "public, max-age=600, s-maxage=600",
+                "X-Cache": "HIT",
+            },
+        )
+
+    try:
+        sessions = list_public_sessions_for_mind(mind_id)
+    except Exception:
+        sessions = []
+    entity_name = mind.get("name") or "this mind"
+    html = _render_public_discussions_page(
+        entity_type="mind",
+        entity_id=mind_id,
+        entity_name=entity_name,
+        entity_canonical=f"{_SITE_URL}/mind/{mind_id}",
+        chat_url=f"{_SITE_URL}/#/mind/{mind_id}",
+        sessions=sessions,
+    )
+    _cache_set(cache_key, html)
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "public, max-age=600, s-maxage=600",
             "X-Cache": "MISS",
         },
     )

--- a/app/main.py
+++ b/app/main.py
@@ -43,9 +43,12 @@ from .core.db import (
     init_db,
     list_agents,
     list_chat_sessions,
+    list_books_for_mind,
     list_messages,
     list_minds,
+    list_minds_for_agent,
     list_questions,
+    list_related_minds,
     list_session_messages,
     list_user_interest_profile,
     list_votes,
@@ -67,6 +70,7 @@ from .core.db import (
 from .core.indexer import index_text
 from .core.providers import GeminiProvider, ProviderError, chat_with_fallback, pick_provider
 from .core.rag import build_context, retrieve, retrieve_cross_book
+from .core import seo as seo_render
 from .core.minds import (
     SEED_MINDS,
     create_mind_from_content,
@@ -991,7 +995,14 @@ def _is_crawler(request: Request) -> bool:
 
 @app.get("/book/{agent_id}", response_class=HTMLResponse)
 def book_page(agent_id: str, request: Request) -> HTMLResponse:
-    """Server-rendered book landing page with OG tags and JSON-LD for SEO/GEO."""
+    """Server-rendered book landing page.
+
+    Content composition lives in ``app/core/seo.py`` — this handler is just
+    the glue that loads data, builds sections, and assembles the document.
+    Every enrichment query is wrapped in try/except so a failed Supabase
+    call or a missing-index book degrades to the old shell page rather than
+    crashing the whole SSR.
+    """
     from html import escape as html_esc
     from urllib.parse import quote
 
@@ -1000,11 +1011,12 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
         raise HTTPException(status_code=404, detail="Book not found")
 
     book = get_ai_book_by_agent(agent_id) if agent else None
-    title = html_esc(book["title"] if book and book.get("title") else agent.get("name", "Untitled"))
-    meta = agent.get("meta") or {}
+    title_raw = book["title"] if book and book.get("title") else agent.get("name", "Untitled")
+    title = html_esc(title_raw)
     outline = book.get("outline") if book else None
     subtitle_raw = outline.get("subtitle", "") if isinstance(outline, dict) else ""
-    chapter_count = len(outline.get("chapters", [])) if isinstance(outline, dict) else 0
+    chapters = outline.get("chapters", []) if isinstance(outline, dict) else []
+    chapter_count = len(chapters)
     author_raw = _resolve_og_author(agent, book)
     total_words = book.get("total_words", 0) if book else 0
 
@@ -1025,42 +1037,62 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
     reader_url = f"{base}/#/read/{id_path}"
     v = config.OG_IMAGE_CACHE_VERSION
     og_image_url = f"{base}/book/{id_path}/og.png?v={v}"
-    reader_js = json.dumps(reader_url)
 
-    chapters_json = "[]"
-    toc_html = ""
-    if book and isinstance(outline, dict):
-        chapters = outline.get("chapters", [])
-        toc_items = "".join(f"<li>{html_esc(ch.get('title', ''))}</li>" for ch in chapters)
-        toc_html = f"<h2>Table of Contents</h2><ol>{toc_items}</ol>" if toc_items else ""
-        chapters_json = json.dumps([
-            {"@type": "Chapter", "name": ch.get("title", ""), "position": i + 1}
-            for i, ch in enumerate(chapters)
-        ])
+    # ── Load enrichment data (all cheap; no LLM/embedding at SSR time) ──
+    try:
+        chunks = get_chunks_text_only(agent_id)
+    except Exception:
+        chunks = []
+    try:
+        questions = list_questions(agent_id) or []
+    except Exception:
+        questions = []
+    try:
+        related_minds = list_minds_for_agent(agent_id)
+    except Exception:
+        related_minds = []
 
-    jsonld = json.dumps({
-        "@context": "https://schema.org",
-        "@type": "Book",
-        "name": book["title"] if book and book.get("title") else agent.get("name", "Untitled"),
-        "description": subtitle_raw or desc,
-        "author": {"@type": "Person", "name": author_raw} if author_raw else None,
-        "url": canonical,
-        "image": og_image_url,
-        "numberOfPages": chapter_count or None,
-        "wordCount": total_words or None,
-        "hasPart": json.loads(chapters_json) if chapters_json != "[]" else None,
-        "publisher": {"@type": "Organization", "name": "Feynman", "url": base},
-    }, ensure_ascii=False)
+    # ── Build content sections ──────────────────────────────────────────
+    about_html = seo_render.render_book_about(subtitle_raw, author_raw)
+    stats_html = seo_render.render_stats(total_words, chapter_count)
+    toc_html = seo_render.render_toc(chapters)
+    samples_html = seo_render.render_sample_passages(chunks, count=3, max_chars=500)
+    questions_html = seo_render.render_popular_questions(questions, reader_url)
+    minds_html = seo_render.render_minds_for_book(related_minds, base)
 
-    read_time = max(1, (total_words or 0) // 250)
-    stats_parts = []
-    if total_words:
-        stats_parts.append(f"{total_words:,} words")
-    if read_time:
-        stats_parts.append(f"~{read_time} min read")
-    if chapter_count:
-        stats_parts.append(f"{chapter_count} chapters")
-    stats_html = " · ".join(stats_parts)
+    # ── Build JSON-LD blocks ────────────────────────────────────────────
+    book_ld = seo_render.jsonld_script(seo_render.book_jsonld(
+        title=title_raw,
+        description=subtitle_raw or desc_raw,
+        author=author_raw,
+        url=canonical,
+        image=og_image_url,
+        word_count=total_words or None,
+        chapters=chapters or None,
+        site_url=base,
+    ))
+    breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
+        ("Feynman", base),
+        ("Books", f"{base}/#/library"),
+        (title_raw, canonical),
+    ]))
+    faq_ld = ""
+    if questions:
+        # Deflection answer — non-empty is required by Google's FAQPage spec.
+        # Real answer surfaces inside the chat experience, not here.
+        deflect = f"Open Feynman to chat with this book and explore the answer in depth: {reader_url}"
+        faq_ld = seo_render.jsonld_script(seo_render.faq_jsonld([
+            (q, deflect) for q in questions if q
+        ]))
+
+    body_style = '' if _is_crawler(request) else ' style="opacity:0"'
+    redirect_script = (
+        ''
+        if _is_crawler(request)
+        else f'<script>window.location.replace({json.dumps(reader_url)});</script>'
+    )
+    author_meta = f'<meta property="book:author" content="{html_esc(author_raw)}">' if author_raw else ''
+    author_html = f'<p class="book-author">by {html_esc(author_raw)}</p>' if author_raw else ''
 
     html = f"""<!DOCTYPE html>
 <html lang="en"><head>
@@ -1078,7 +1110,7 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 <meta property="og:image:alt" content="{og_image_alt}">
 <meta property="og:url" content="{canonical}">
 <meta property="og:site_name" content="Feynman">
-{f'<meta property="book:author" content="{html_esc(author_raw)}">' if author_raw else ''}
+{author_meta}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@steve_yeow">
 <meta name="twitter:creator" content="@steve_yeow">
@@ -1086,14 +1118,20 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
 <meta name="twitter:image:alt" content="{og_image_alt}">
-<script type="application/ld+json">{jsonld}</script>
-</head><body{'' if _is_crawler(request) else ' style="opacity:0"'}>
+{book_ld}
+{breadcrumb_ld}
+{faq_ld}
+</head><body{body_style}>
 <h1>{title}</h1>
-{f'<p>by {html_esc(author_raw)}</p>' if author_raw else ''}
-{f'<p>{desc}</p>' if subtitle_raw else ''}
+{author_html}
+{about_html}
+{stats_html}
+{samples_html}
 {toc_html}
-<p><a href="{html_esc(reader_url)}">Read this book on Feynman</a></p>
-{'' if _is_crawler(request) else f'<script>window.location.replace({json.dumps(reader_url)});</script>'}
+{questions_html}
+{minds_html}
+<p class="cta"><a href="{html_esc(reader_url)}">Read and chat with this book on Feynman →</a></p>
+{redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
 
@@ -1126,54 +1164,115 @@ def mind_og_image(mind_id: str):
 
 @app.get("/mind/{mind_id}", response_class=HTMLResponse)
 def mind_page(mind_id: str, request: Request) -> HTMLResponse:
-    """Server-rendered mind landing page with OG tags and JSON-LD Person schema."""
+    """Server-rendered mind landing page.
+
+    Content composition lives in ``app/core/seo.py``. We render every mind
+    column the schema exposes — bio, thinking_style, typical_phrases,
+    persona excerpt, works, plus cross-links to books and related minds —
+    so each page meets the content-density bar required to rank and to be
+    cited by LLMs.
+    """
     from html import escape as html_esc
 
     mind = get_mind(mind_id)
     if not mind:
         raise HTTPException(status_code=404, detail="Mind not found")
 
-    name = html_esc(mind.get("name", "Unknown"))
-    era = html_esc(mind.get("era", ""))
-    domain = html_esc(mind.get("domain", ""))
-    bio = html_esc(mind.get("bio_summary", ""))
+    name_raw = mind.get("name", "Unknown")
+    name = html_esc(name_raw)
+    era_raw = mind.get("era", "")
+    era = html_esc(era_raw)
+    domain_raw = mind.get("domain", "")
+    domain = html_esc(domain_raw)
+    bio_raw = mind.get("bio_summary", "")
     works_raw = mind.get("works") or []
     works_list = works_raw if isinstance(works_raw, list) else []
+    thinking_style = mind.get("thinking_style", "") or ""
+    phrases_raw = mind.get("typical_phrases") or []
+    phrases = phrases_raw if isinstance(phrases_raw, list) else []
+    persona = mind.get("persona", "") or ""
 
-    desc_raw = mind.get("bio_summary", "") or f"{mind.get('name', 'Unknown')} — {mind.get('domain', '')} thinker on Feynman"
+    desc_raw = bio_raw or f"{name_raw} — {domain_raw} thinker on Feynman"
     if len(desc_raw) > 200:
         desc_raw = desc_raw[:197].rsplit(" ", 1)[0] + "..."
     desc = html_esc(desc_raw)
-    name_parts = mind.get("name", "").strip().split()
+    name_parts = name_raw.strip().split()
     first_name = html_esc(name_parts[0]) if name_parts else ""
     last_name = html_esc(" ".join(name_parts[1:])) if len(name_parts) > 1 else ""
-    og_image_alt = html_esc(f"Portrait of {mind.get('name', 'great mind')} on Feynman")
+    og_image_alt = html_esc(f"Portrait of {name_raw} on Feynman")
     base = _SITE_URL
     canonical = f"{base}/mind/{mind_id}"
     og_image_url = f"{base}/mind/{mind_id}/og.png"
     reader_url = f"{base}/#/mind/{mind_id}"
-    reader_js = json.dumps(reader_url)
 
-    works_html = ""
-    if works_list:
-        items = "".join(f"<li>{html_esc(w)}</li>" for w in works_list[:20])
-        works_html = f"<h2>Notable Works</h2><ul>{items}</ul>"
+    # ── Load enrichment data ────────────────────────────────────────────
+    try:
+        linked_books = list_books_for_mind(mind_id)
+    except Exception:
+        linked_books = []
+    try:
+        related = list_related_minds(mind_id, domain_raw)
+    except Exception:
+        related = []
 
-    jsonld = json.dumps({
-        "@context": "https://schema.org",
-        "@type": "Person",
-        "name": mind.get("name", "Unknown"),
-        "description": mind.get("bio_summary", ""),
-        "knowsAbout": mind.get("domain", ""),
-        "url": canonical,
-        "image": og_image_url,
-        "sameAs": [],
-    }, ensure_ascii=False)
+    # "Books in library" surfaces the extras that Notable Works doesn't already
+    # list — avoid double-rendering the same title in both sections.
+    works_titles = {(w or "").lower() for w in works_list if w}
+    extra_books = []
+    for b in linked_books:
+        bname = (b.get("name") or "").lower()
+        if not bname:
+            continue
+        if bname in works_titles:
+            continue
+        if any(bname in wt or wt in bname for wt in works_titles):
+            continue
+        extra_books.append(b)
 
-    chat_count = mind.get("chat_count", 0)
-    domains_list = [d.strip() for d in domain.split(",") if d.strip()] if domain else []
-    domains_tags = "".join(f'<span class="domain-tag">{html_esc(d)}</span>' for d in domains_list)
-    domains_html = f'<div class="domains">{domains_tags}</div>' if domains_list else ""
+    # ── Build content sections ──────────────────────────────────────────
+    bio_html = seo_render.render_mind_bio(bio_raw)
+    thinking_html = seo_render.render_mind_thinking_style(thinking_style)
+    phrases_html = seo_render.render_mind_phrases(phrases)
+    persona_html = seo_render.render_mind_persona_excerpt(persona)
+    works_html = seo_render.render_mind_works(works_list, linked_books, base)
+    extra_books_html = seo_render.render_books_for_mind(extra_books, base)
+    related_html = seo_render.render_related_minds(related, base)
+
+    # ── JSON-LD ─────────────────────────────────────────────────────────
+    # sameAs telling Google's Knowledge Graph "this is THE Karl Marx" is
+    # the single biggest entity-identity signal we can send. Curated list
+    # lives in seo.FAMOUS_MIND_SAMEAS; unmatched names get None and the
+    # schema validator skips the field.
+    person_ld = seo_render.jsonld_script(seo_render.person_jsonld(
+        name=name_raw,
+        description=bio_raw,
+        domain=domain_raw,
+        url=canonical,
+        image=og_image_url,
+        same_as=seo_render.lookup_same_as(name_raw),
+    ))
+    breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
+        ("Feynman", base),
+        ("Great Minds", f"{base}/#/minds"),
+        (name_raw, canonical),
+    ]))
+
+    body_style = '' if _is_crawler(request) else ' style="opacity:0"'
+    redirect_script = (
+        ''
+        if _is_crawler(request)
+        else f'<script>window.location.replace({json.dumps(reader_url)});</script>'
+    )
+    if era_raw and domain_raw:
+        era_domain_html = f'<p class="mind-meta">{era} · {domain}</p>'
+    elif era_raw:
+        era_domain_html = f'<p class="mind-meta">{era}</p>'
+    elif domain_raw:
+        era_domain_html = f'<p class="mind-meta">{domain}</p>'
+    else:
+        era_domain_html = ''
+    profile_first = f'<meta property="profile:first_name" content="{first_name}">' if first_name else ''
+    profile_last = f'<meta property="profile:last_name" content="{last_name}">' if last_name else ''
 
     html = f"""<!DOCTYPE html>
 <html lang="en"><head>
@@ -1191,8 +1290,8 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 <meta property="og:image:alt" content="{og_image_alt}">
 <meta property="og:url" content="{canonical}">
 <meta property="og:site_name" content="Feynman">
-{f'<meta property="profile:first_name" content="{first_name}">' if first_name else ''}
-{f'<meta property="profile:last_name" content="{last_name}">' if last_name else ''}
+{profile_first}
+{profile_last}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@steve_yeow">
 <meta name="twitter:creator" content="@steve_yeow">
@@ -1200,14 +1299,20 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
 <meta name="twitter:image:alt" content="{og_image_alt}">
-<script type="application/ld+json">{jsonld}</script>
-</head><body{'' if _is_crawler(request) else ' style="opacity:0"'}>
+{person_ld}
+{breadcrumb_ld}
+</head><body{body_style}>
 <h1>{name}</h1>
-{f'<p>{era} · {domain}</p>' if era else f'<p>{domain}</p>'}
-{f'<p>{bio}</p>' if bio else ''}
+{era_domain_html}
+{bio_html}
+{thinking_html}
+{phrases_html}
+{persona_html}
 {works_html}
-<p><a href="{html_esc(reader_url)}">Chat with {name} on Feynman</a></p>
-{'' if _is_crawler(request) else f'<script>window.location.replace({json.dumps(reader_url)});</script>'}
+{extra_books_html}
+{related_html}
+<p class="cta"><a href="{html_esc(reader_url)}">Chat with {name} on Feynman →</a></p>
+{redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
 

--- a/app/main.py
+++ b/app/main.py
@@ -1052,13 +1052,24 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
     except Exception:
         related_minds = []
 
+    # ── Detect capabilities (Phase 3a) ──────────────────────────────────
+    # Not every book supports every action; e.g. catalog stubs only support
+    # chat. Render the CTA matrix to match — no more blanket "Read" link
+    # for books with 63 words of content.
+    caps = seo_render.detect_capabilities(agent, book)
+    chat_url = f"{base}/#/chat/{id_path}"
+    cta_target_url = reader_url if caps.get("read") or caps.get("preview") else chat_url
+
     # ── Build content sections ──────────────────────────────────────────
     about_html = seo_render.render_book_about(subtitle_raw, author_raw)
     stats_html = seo_render.render_stats(total_words, chapter_count)
     toc_html = seo_render.render_toc(chapters)
-    samples_html = seo_render.render_sample_passages(chunks, count=3, max_chars=500)
-    questions_html = seo_render.render_popular_questions(questions, reader_url)
+    samples_html = seo_render.render_sample_passages(chunks)
+    questions_html = seo_render.render_popular_questions(questions, chat_url)
     minds_html = seo_render.render_minds_for_book(related_minds, base)
+    cta_html = seo_render.render_cta_matrix(
+        caps, entity_id=agent_id, entity_name=title_raw, base=base
+    )
 
     # ── Build JSON-LD blocks ────────────────────────────────────────────
     book_ld = seo_render.jsonld_script(seo_render.book_jsonld(
@@ -1085,11 +1096,23 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
             (q, deflect) for q in questions if q
         ]))
 
-    body_style = '' if _is_crawler(request) else ' style="opacity:0"'
+    # ── Decide who sees the landing page vs gets redirected ─────────────
+    # Crawlers: always see the landing page (no redirect, body visible).
+    # In-product clicks (Referer = our origin): redirect to the SPA action
+    #   so the existing UX is unchanged — they expect to land in reader/chat.
+    # Everyone else (Google, share links, direct visits, missing referer):
+    #   stay on the landing page so they see what the URL actually offers
+    #   instead of being dropped into an empty reader.
+    referer = request.headers.get("referer", "") or request.headers.get("referrer", "")
+    show_landing = (
+        _is_crawler(request)
+        or not seo_render.is_internal_referer(referer, base)
+    )
+    body_style = '' if show_landing else ' style="opacity:0"'
     redirect_script = (
         ''
-        if _is_crawler(request)
-        else f'<script>window.location.replace({json.dumps(reader_url)});</script>'
+        if show_landing
+        else f'<script>window.location.replace({json.dumps(cta_target_url)});</script>'
     )
     author_meta = f'<meta property="book:author" content="{html_esc(author_raw)}">' if author_raw else ''
     author_html = f'<p class="book-author">by {html_esc(author_raw)}</p>' if author_raw else ''
@@ -1130,7 +1153,7 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {toc_html}
 {questions_html}
 {minds_html}
-<p class="cta"><a href="{html_esc(reader_url)}">Read and chat with this book on Feynman →</a></p>
+{cta_html}
 {redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
@@ -1257,10 +1280,18 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
         (name_raw, canonical),
     ]))
 
-    body_style = '' if _is_crawler(request) else ' style="opacity:0"'
+    # Same referer-aware gate as book_page — external visitors see the
+    # landing page (with bio + works + cross-links to books), internal
+    # clicks continue straight to the mind chat as before.
+    referer = request.headers.get("referer", "") or request.headers.get("referrer", "")
+    show_landing = (
+        _is_crawler(request)
+        or not seo_render.is_internal_referer(referer, base)
+    )
+    body_style = '' if show_landing else ' style="opacity:0"'
     redirect_script = (
         ''
-        if _is_crawler(request)
+        if show_landing
         else f'<script>window.location.replace({json.dumps(reader_url)});</script>'
     )
     if era_raw and domain_raw:

--- a/scripts/backfill_questions.py
+++ b/scripts/backfill_questions.py
@@ -1,0 +1,171 @@
+"""Backfill the `questions` table for books indexed before
+`indexer.generate_questions()` was wired into the indexing pipeline.
+
+Why this exists
+---------------
+The Phase 0+1+2 SEO work surfaces a book's auto-generated study questions
+on its /book/{id} landing page (and Phase 4A turns each question into its
+own /book/{id}/q/{slug} compound URL). New books get questions filled
+automatically during indexing. Old books — anything indexed before that
+hook landed — have an empty `questions` row and render without the
+Popular Questions section. This script fills the gap.
+
+Usage
+-----
+  python -m scripts.backfill_questions             # backfill every eligible book
+  python -m scripts.backfill_questions --dry-run   # report what would change
+  python -m scripts.backfill_questions --limit 10  # process at most 10 books
+  python -m scripts.backfill_questions --agent ID  # one specific book
+
+Required env vars
+-----------------
+  DATABASE_URL    Same string the app uses to reach Supabase Postgres.
+  GEMINI_API_KEY  (or whichever provider is configured) — needed for the
+                  LLM call inside `generate_questions`.
+
+Properties
+----------
+- **Idempotent.** Skips agents that already have questions. Re-running
+  picks up wherever it left off; safe to interrupt and resume.
+- **Bounded cost.** ~1 LLM round trip per book (5 questions in one call).
+  At Gemini Flash rates, the whole 750-book backfill costs roughly $1.
+- **Non-destructive.** Never deletes or overwrites existing questions.
+- **Read-egress conscious.** Pulls only the first ~3 chunks per book to
+  keep the prompt small. The legacy text-sample slicing is identical to
+  what the live indexer uses.
+
+Operational notes
+-----------------
+- Run from the project root: `python -m scripts.backfill_questions`.
+- The script connects to whichever DB `DATABASE_URL` points at — point
+  it at production Supabase to backfill prod, at a local DB to backfill
+  locally. There's no Supabase-side execution; this is just a Python
+  process holding a DB connection.
+- Always `--dry-run` first to eyeball the count and sample picks.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+from app.core import config  # noqa: F401  — ensures env is loaded
+from app.core.db import (
+    get_chunks_text_only,
+    get_agent,
+    init_db,
+    list_agents,
+    list_questions,
+)
+from app.core.questions import generate_questions
+
+log = logging.getLogger("backfill_questions")
+
+
+# Match what app/core/indexer.py uses when first generating questions —
+# keep the input window identical so backfilled questions are stylistically
+# consistent with the ones that come out of the live pipeline.
+_PROMPT_SAMPLE_CHARS = 3000
+
+
+def _eligible(agent: dict) -> tuple[bool, str]:
+    """Return (eligible, reason). Eligible = ready agent with chunks and
+    no existing questions."""
+    if agent.get("status") != "ready":
+        return False, f"status={agent.get('status')!r}"
+    agent_id = agent["id"]
+    if list_questions(agent_id):
+        return False, "questions_exist"
+    return True, ""
+
+
+def _process_one(agent: dict, dry_run: bool) -> tuple[bool, str]:
+    """Generate questions for one agent. Returns (ok, message)."""
+    agent_id = agent["id"]
+    name = (agent.get("name") or "")[:80]
+    try:
+        chunks = get_chunks_text_only(agent_id)
+    except Exception as exc:
+        return False, f"chunks fetch failed: {exc}"
+    if not chunks:
+        return False, "no chunks (cannot generate questions)"
+
+    text_sample = "\n\n".join(c["text"] for c in chunks[:3])[:_PROMPT_SAMPLE_CHARS]
+    if not text_sample.strip():
+        return False, "chunks empty"
+
+    if dry_run:
+        return True, f"[dry-run] would generate questions ({len(text_sample)} chars sample)"
+
+    try:
+        questions = generate_questions(agent_id, text_sample)
+    except Exception as exc:
+        return False, f"generate_questions failed: {exc}"
+    if not questions:
+        return False, "LLM returned no questions"
+    return True, f"generated {len(questions)} questions"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would change without making LLM calls or writing.")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Process at most this many eligible books.")
+    parser.add_argument("--agent", type=str, default=None,
+                        help="Process only this agent id.")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Print per-skip detail in addition to processed books.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    print(f"--- backfill_questions (dry_run={args.dry_run}) ---", file=sys.stderr)
+    init_db()
+
+    if args.agent:
+        a = get_agent(args.agent)
+        if not a:
+            print(f"agent not found: {args.agent}", file=sys.stderr)
+            return 2
+        targets = [a]
+    else:
+        targets = list(list_agents(limit=10000))
+
+    print(f"scanning {len(targets)} agents", file=sys.stderr)
+
+    processed = ok = failed = skipped = 0
+    start = time.time()
+    for agent in targets:
+        eligible, reason = _eligible(agent)
+        if not eligible:
+            skipped += 1
+            if args.verbose:
+                print(f"  skip {agent['id'][:8]} {agent.get('name','')[:40]!r:<42} ({reason})", file=sys.stderr)
+            continue
+        if args.limit is not None and processed >= args.limit:
+            break
+        processed += 1
+        success, msg = _process_one(agent, dry_run=args.dry_run)
+        marker = "OK " if success else "FAIL"
+        print(f"  {marker} {agent['id'][:8]} {agent.get('name','')[:60]!r:<62} — {msg}", file=sys.stderr)
+        if success:
+            ok += 1
+        else:
+            failed += 1
+
+    elapsed = time.time() - start
+    print(
+        f"--- done in {elapsed:.1f}s: processed={processed} ok={ok} "
+        f"failed={failed} skipped={skipped} ---",
+        file=sys.stderr,
+    )
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -619,6 +619,254 @@ class TestIsInternalReferer:
         ) is True
 
 
+class TestPhase4QAHelpers:
+    """Phase 4A: /book/{id}/q/{slug} compound pages."""
+
+    def test_find_question_by_slug_exact(self):
+        qs = ["What is X?", "Why Y?", "How Z?"]
+        assert seo.find_question_by_slug(qs, "what-is-x") == "What is X?"
+        assert seo.find_question_by_slug(qs, "why-y") == "Why Y?"
+
+    def test_find_question_by_slug_case_insensitive(self):
+        qs = ["What is X?"]
+        assert seo.find_question_by_slug(qs, "WHAT-IS-X") == "What is X?"
+
+    def test_find_question_by_slug_no_match(self):
+        assert seo.find_question_by_slug(["A?"], "missing") is None
+        assert seo.find_question_by_slug([], "any") is None
+        assert seo.find_question_by_slug(["A?"], "") is None
+
+    def test_render_qa_answer_preserves_paragraphs(self):
+        out = seo.render_qa_answer("First para.\n\nSecond para.")
+        assert out.count("<p>") == 2
+        assert "First para." in out
+        assert "Second para." in out
+
+    def test_render_qa_answer_includes_attribution(self):
+        # Transparency about AI synthesis is required by helpful-content guidance
+        out = seo.render_qa_answer("Some answer.")
+        assert "Synthesized" in out or "synthesized" in out.lower()
+
+    def test_render_qa_answer_empty(self):
+        assert seo.render_qa_answer("") == ""
+        assert seo.render_qa_answer("   ") == ""
+
+    def test_render_qa_passages_attributes_chunks(self):
+        out = seo.render_qa_passages([
+            {"chunk_index": 0, "text": "Passage one."},
+            {"chunk_index": 5, "text": "Passage six."},
+        ])
+        # 1-indexed display for humans
+        assert "Passage [1]" in out
+        assert "Passage [6]" in out
+
+    def test_render_qa_passages_escapes_html(self):
+        out = seo.render_qa_passages([{"chunk_index": 0, "text": "<script>x</script>"}])
+        assert "<script>x</script>" not in out
+        assert "&lt;script&gt;" in out
+
+    def test_render_sibling_questions_skips_self(self):
+        out = seo.render_sibling_questions(
+            ["What is X?", "Why Y?", "How Z?"],
+            book_id="abc", site_url="https://x.com",
+            current_question="Why Y?",
+        )
+        # Current question must not appear as a sibling self-link
+        assert "Why Y?" not in out
+        assert "What is X?" in out and "How Z?" in out
+
+    def test_render_sibling_questions_uses_compound_urls(self):
+        out = seo.render_sibling_questions(
+            ["What is X?"], book_id="abc", site_url="https://x.com",
+        )
+        assert 'href="https://x.com/book/abc/q/what-is-x"' in out
+
+    def test_qa_page_jsonld_uses_real_answer_when_present(self):
+        ld = seo.qa_page_jsonld(
+            question="What is X?", answer="X is the unknown.",
+            url="https://x.com/q", book_title="Book", book_url="https://x.com/b",
+        )
+        assert ld["@type"] == "QAPage"
+        assert ld["mainEntity"]["acceptedAnswer"]["text"] == "X is the unknown."
+
+    def test_qa_page_jsonld_deflects_when_answer_missing(self):
+        # Empty answer must still produce a non-empty acceptedAnswer for
+        # Google's QAPage schema to be accepted
+        ld = seo.qa_page_jsonld(
+            question="What is X?", answer="",
+            url="https://x.com/q", book_title="Book", book_url="https://x.com/b",
+        )
+        text = ld["mainEntity"]["acceptedAnswer"]["text"]
+        assert text  # non-empty deflection
+        assert "Book" in text  # mentions the book by title
+
+
+class TestPhase4MindOnTopic:
+    """Phase 4B: /mind/{id}/on/{topic} compound pages."""
+
+    def _marx(self) -> dict:
+        return {
+            "id": "m1", "name": "Karl Marx",
+            "domain": "Political Economy, Philosophy",
+            "bio_summary": "German philosopher and political economist.",
+            "thinking_style": "Materialist dialectics.",
+            "persona": "Analyzes through class struggle.",
+            "typical_phrases": ["Workers of the world, unite!"],
+        }
+
+    def test_relevance_match_on_substring(self):
+        from app.core import qa
+        marx = self._marx()
+        assert qa.is_mind_topic_relevant(marx, "Economics") is True  # 'Econom' in 'Political Economy'
+        assert qa.is_mind_topic_relevant(marx, "Philosophy") is True
+
+    def test_relevance_rejects_unrelated_topic(self):
+        from app.core import qa
+        marx = self._marx()
+        assert qa.is_mind_topic_relevant(marx, "Computer Science") is False
+        assert qa.is_mind_topic_relevant(marx, "Biology") is False
+
+    def test_relevance_ignores_noise_tokens(self):
+        from app.core import qa
+        # "Art & Design" should not match purely on "&" or "of"
+        mind = {"name": "X", "domain": "Mathematics, Physics"}
+        assert qa.is_mind_topic_relevant(mind, "Art & Design") is False
+
+    def test_relevance_handles_missing_data(self):
+        from app.core import qa
+        assert qa.is_mind_topic_relevant(None, "X") is False
+        assert qa.is_mind_topic_relevant({}, "X") is False
+        assert qa.is_mind_topic_relevant({"domain": ""}, "X") is False
+        assert qa.is_mind_topic_relevant({"domain": "Economics"}, "") is False
+
+    def test_relevance_multiword_topic(self):
+        from app.core import qa
+        mind = {"name": "X", "domain": "Political Economy, Philosophy"}
+        # Multi-word topic — substring match on full string
+        assert qa.is_mind_topic_relevant(mind, "Political Science") is True  # 'Political' in domain
+
+    def test_render_mind_essay_labels_as_imagined(self):
+        # Hard requirement: never present LLM output as the mind's actual words
+        out = seo.render_mind_on_topic_essay(
+            "First paragraph.\n\nSecond paragraph.",
+            "Karl Marx", "Economics",
+        )
+        assert "Imagined" in out or "imagined" in out.lower()
+        assert "Karl Marx" in out
+        # Counts both <p> and <p class="…"> — the attribution paragraph
+        # has a class so it shows up as "<p " in raw HTML.
+        assert out.count("<p") >= 3  # 2 body paragraphs + 1 attribution
+
+    def test_render_mind_essay_empty_returns_empty(self):
+        assert seo.render_mind_on_topic_essay("", "X", "Y") == ""
+
+    def test_mind_essay_jsonld_marks_about_entity(self):
+        ld = seo.mind_essay_jsonld(
+            mind_name="Karl Marx", topic="Economics",
+            essay="An essay.",
+            url="https://x.com/m/1/on/economics",
+            mind_url="https://x.com/mind/1",
+        )
+        assert ld["@type"] == "Article"
+        assert ld["about"]["@type"] == "Person"
+        assert ld["about"]["name"] == "Karl Marx"
+        # Author is Feynman (the synthesizer), not Marx — accurate attribution
+        assert ld["author"]["@type"] == "Organization"
+        assert ld["author"]["name"] == "Feynman"
+
+
+class TestPhase4TopicHub:
+    """Phase 4C: /topic/{slug} pages."""
+
+    def test_build_topic_slug_index(self):
+        tags = ["Computer Science", "Economics", "Self-Development"]
+        idx = seo.build_topic_slug_index(tags)
+        assert idx["computer-science"] == "Computer Science"
+        assert idx["economics"] == "Economics"
+        assert idx["self-development"] == "Self-Development"
+
+    def test_topic_slug_kebab(self):
+        assert seo.topic_slug("Business & Strategy") == "business-strategy"
+        assert seo.topic_slug("Self-Development") == "self-development"
+
+    def test_render_topic_books_cross_links(self):
+        out = seo.render_topic_books(
+            [{"id": "b1", "name": "Sapiens", "author": "Yuval Harari"}],
+            "https://x.com",
+        )
+        assert 'href="https://x.com/book/b1"' in out
+        assert "Sapiens" in out
+        assert "Yuval Harari" in out
+
+    def test_render_topic_minds_cross_links(self):
+        out = seo.render_topic_minds(
+            [{"id": "m1", "name": "Marx", "era": "19th Century"}],
+            "https://x.com",
+        )
+        assert 'href="https://x.com/mind/m1"' in out
+        assert "Marx" in out
+        assert "19th Century" in out
+
+    def test_render_topic_intro_with_counts(self):
+        out = seo.render_topic_intro("Economics", 12, 5)
+        assert "12 books" in out
+        assert "5 great minds" in out
+        assert "Economics" in out
+
+    def test_render_topic_intro_singular(self):
+        out = seo.render_topic_intro("Economics", 1, 1)
+        assert "1 book" in out and "1 great mind" in out
+        assert "1 books" not in out and "1 great minds" not in out
+
+    def test_render_topic_intro_zero_counts(self):
+        # No content yet, but still emit a meaningful intro
+        out = seo.render_topic_intro("Economics", 0, 0)
+        assert "Economics" in out
+        assert out  # not empty
+
+    def test_collection_jsonld_structure(self):
+        ld = seo.collection_jsonld(
+            name="Economics on Feynman",
+            description="...",
+            url="https://x.com/topic/economics",
+            items=[
+                {"name": "Sapiens", "url": "https://x.com/book/b1"},
+                {"name": "Marx", "url": "https://x.com/mind/m1"},
+            ],
+            site_url="https://x.com",
+        )
+        assert ld["@type"] == "CollectionPage"
+        assert ld["mainEntity"]["@type"] == "ItemList"
+        assert ld["mainEntity"]["numberOfItems"] == 2
+        # 1-indexed positions
+        assert ld["mainEntity"]["itemListElement"][0]["position"] == 1
+
+
+class TestPopularQuestionsCompoundUrls:
+    """Phase 4A integration: popular questions on the book page should
+    link to each question's own /book/{id}/q/{slug} URL, not all to
+    the same chat URL."""
+
+    def test_links_to_compound_url_when_book_id_provided(self):
+        out = seo.render_popular_questions(
+            ["What is X?", "Why Y?"],
+            fallback_url="https://x.com/#/chat/abc",
+            book_id="abc",
+            site_url="https://x.com",
+        )
+        assert 'href="https://x.com/book/abc/q/what-is-x"' in out
+        assert 'href="https://x.com/book/abc/q/why-y"' in out
+        # Fallback URL should not appear
+        assert "/#/chat/abc" not in out
+
+    def test_falls_back_to_chat_url_without_book_id(self):
+        # Backward compatibility for any caller not using compound URLs
+        out = seo.render_popular_questions(
+            ["What is X?"], "https://x.com/#/chat/abc",
+        )
+        assert 'href="https://x.com/#/chat/abc"' in out
+
+
 class TestSparseDataDegradation:
     """A fresh book or mind with no chunks / no questions / no links still
     needs to render without crashing. The page is allowed to be thin in

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -463,6 +463,162 @@ class TestContentDensityFloor:
         assert 'href="https://x.com/book/' in html
 
 
+class TestCapabilityDetection:
+    """Phase 3a: only show CTAs that the entity actually supports.
+    The motivating bug: catalog books with 63 words of stub content were
+    sending users to an empty reader because the page blindly linked to
+    /#/read/. detect_capabilities + render_cta_matrix fix this."""
+
+    def test_full_ai_book_supports_read_preview_chat(self):
+        agent = {"type": "ai_book", "status": "ready"}
+        book = {
+            "total_words": 50000,
+            "outline": {"chapters": [{"title": "Ch1"}, {"title": "Ch2"}]},
+        }
+        caps = seo.detect_capabilities(agent, book)
+        assert caps["read"] is True
+        assert caps["chat"] is True
+
+    def test_catalog_stub_chat_only(self):
+        # The exact failure mode from production: 63 words of stub
+        agent = {"type": "catalog", "status": "catalog"}
+        book = None  # catalog agents have no ai_books row
+        caps = seo.detect_capabilities(agent, book)
+        assert caps["read"] is False, "catalog stubs must not advertise Read"
+        assert caps["preview"] is False
+        assert caps["chat"] is True, "chat is always available for non-failed agents"
+
+    def test_partial_content_is_preview_not_read(self):
+        agent = {"type": "catalog", "status": "ready"}
+        book = {"total_words": 200, "outline": {"chapters": []}}
+        caps = seo.detect_capabilities(agent, book)
+        assert caps["read"] is False
+        assert caps["preview"] is True
+        assert caps["chat"] is True
+
+    def test_writing_status_is_preview(self):
+        agent = {"type": "ai_book", "status": "ready"}
+        book = {
+            "total_words": 5000,
+            "status": "writing",
+            "outline": {"chapters": [{"title": "Ch1"}]},
+        }
+        caps = seo.detect_capabilities(agent, book)
+        # Mid-write: words present but book is still being generated
+        # → "Preview" framing is more honest than "Read"
+        assert caps["preview"] is True
+
+    def test_failed_agent_no_caps(self):
+        agent = {"type": "ai_book", "status": "failed"}
+        book = {"total_words": 50000, "outline": {"chapters": [{"title": "X"}]}}
+        caps = seo.detect_capabilities(agent, book)
+        assert caps == {"read": False, "preview": False, "chat": False}
+
+    def test_upload_with_chunks_is_readable_even_without_chapters(self):
+        agent = {"type": "upload", "status": "ready"}
+        book = None  # uploads don't go through ai_books table
+        # Uploads carry their word count on the agent itself sometimes — but
+        # without a book row we have nothing to count. Capability is False
+        # in this minimal fixture; production upload paths populate ai_books
+        # or expose word count via chunks reassembly.
+        caps = seo.detect_capabilities(agent, book)
+        # No word count available → not readable (correct conservative default)
+        assert caps["read"] is False
+        assert caps["chat"] is True
+
+    def test_none_agent_no_caps(self):
+        assert seo.detect_capabilities(None, None) == {
+            "read": False, "preview": False, "chat": False,
+        }
+
+
+class TestRenderCtaMatrix:
+    def test_renders_read_and_chat_for_full_book(self):
+        caps = {"read": True, "preview": True, "chat": True}
+        out = seo.render_cta_matrix(
+            caps, entity_id="abc", entity_name="Sapiens", base="https://x.com",
+        )
+        assert "Read Sapiens" in out
+        assert "Chat about Sapiens" in out
+        # Read subsumes Preview — no separate Preview button when Read available
+        assert "Preview Sapiens" not in out
+        assert 'href="https://x.com/#/read/abc"' in out
+        assert 'href="https://x.com/#/chat/abc"' in out
+
+    def test_renders_only_chat_for_catalog_stub(self):
+        caps = {"read": False, "preview": False, "chat": True}
+        out = seo.render_cta_matrix(
+            caps, entity_id="abc", entity_name="Stub Book", base="https://x.com",
+        )
+        # The bug fix: no misleading Read button for catalog stubs
+        assert "Read Stub Book" not in out
+        assert "Chat about Stub Book" in out
+        # And only the chat URL — no /#/read/ link at all
+        assert "/#/read/" not in out
+        assert 'href="https://x.com/#/chat/abc"' in out
+
+    def test_renders_preview_when_partial_content(self):
+        caps = {"read": False, "preview": True, "chat": True}
+        out = seo.render_cta_matrix(
+            caps, entity_id="abc", entity_name="Half-written Book",
+            base="https://x.com",
+        )
+        assert "Preview Half-written Book" in out
+        assert "Chat about Half-written Book" in out
+        assert "Read Half-written Book" not in out
+
+    def test_renders_nothing_when_no_capabilities(self):
+        # Failed agent — neither button is appropriate
+        out = seo.render_cta_matrix(
+            {"read": False, "preview": False, "chat": False},
+            entity_id="abc", entity_name="X", base="https://x.com",
+        )
+        assert out == ""
+
+    def test_escapes_entity_name_in_button_text(self):
+        out = seo.render_cta_matrix(
+            {"read": True, "preview": True, "chat": True},
+            entity_id="abc", entity_name="<script>alert(1)</script>",
+            base="https://x.com",
+        )
+        assert "<script>alert(1)</script>" not in out
+        assert "&lt;script&gt;" in out
+
+
+class TestIsInternalReferer:
+    def test_external_referer_is_not_internal(self):
+        assert seo.is_internal_referer(
+            "https://www.google.com/search?q=feynman",
+            "https://feynman.wiki",
+        ) is False
+
+    def test_missing_referer_is_not_internal(self):
+        # Conservative: no referer means we can't be sure → treat as external
+        # → land on landing page (safer for the SEO bounce-rate concern)
+        assert seo.is_internal_referer("", "https://feynman.wiki") is False
+        assert seo.is_internal_referer(None, "https://feynman.wiki") is False
+
+    def test_internal_referer_recognized(self):
+        assert seo.is_internal_referer(
+            "https://feynman.wiki/#/library", "https://feynman.wiki",
+        ) is True
+        assert seo.is_internal_referer(
+            "https://feynman.wiki/book/abc", "https://feynman.wiki",
+        ) is True
+
+    def test_subdomain_is_not_treated_as_same(self):
+        # api.feynman.wiki referring is not the same as a user navigating
+        # from the main app — be conservative.
+        assert seo.is_internal_referer(
+            "https://api.feynman.wiki/something", "https://feynman.wiki",
+        ) is False
+
+    def test_case_insensitive_host_match(self):
+        assert seo.is_internal_referer(
+            "https://FEYNMAN.WIKI/page", "https://feynman.wiki",
+        ) is True
+
+
 class TestSparseDataDegradation:
     """A fresh book or mind with no chunks / no questions / no links still
     needs to render without crashing. The page is allowed to be thin in

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1,0 +1,503 @@
+"""Tests for SEO/GEO page composition helpers (app/core/seo.py).
+
+These guard against the "thin content regression" — the failure mode where
+a refactor accidentally strips the rendered sections back down to a 24-word
+shell. Each test asserts a contract that any future maintainer must keep.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from app.core import seo
+
+
+# ─── slugify ──────────────────────────────────────────────────────────
+
+class TestSlugify:
+    def test_basic_title(self):
+        assert seo.slugify("How to Win Friends and Influence People") == \
+            "how-to-win-friends-and-influence-people"
+
+    def test_name_with_apostrophe(self):
+        assert seo.slugify("Marx's Capital") == "marx-s-capital"
+
+    def test_empty_returns_untitled(self):
+        assert seo.slugify("") == "untitled"
+        assert seo.slugify(None or "") == "untitled"
+
+    def test_punctuation_collapses_to_single_dash(self):
+        assert seo.slugify("hello -- world!!") == "hello-world"
+
+    def test_max_len_respected(self):
+        long = "x" * 200
+        out = seo.slugify(long, max_len=30)
+        assert len(out) <= 30
+
+    def test_non_ascii_degrades_gracefully(self):
+        # Non-Latin characters are dropped to dashes; we still get something safe
+        out = seo.slugify("孔子 Confucius")
+        assert out  # never empty for any non-empty input
+        assert re.match(r"^[a-z0-9-]+$", out)
+
+    def test_idempotent(self):
+        slug = seo.slugify("Some Book Title")
+        assert seo.slugify(slug) == slug
+
+
+# ─── visible_word_count ───────────────────────────────────────────────
+
+class TestVisibleWordCount:
+    def test_strips_scripts(self):
+        html = "<html><body>Hello world<script>var x = 1;</script></body></html>"
+        assert seo.visible_word_count(html) == 2
+
+    def test_strips_styles(self):
+        html = "<html><body>Hello world<style>body{color:red}</style></body></html>"
+        assert seo.visible_word_count(html) == 2
+
+    def test_strips_tags(self):
+        html = "<p>one <strong>two</strong> three</p>"
+        assert seo.visible_word_count(html) == 3
+
+    def test_empty(self):
+        assert seo.visible_word_count("") == 0
+        assert seo.visible_word_count("<html></html>") == 0
+
+
+# ─── JSON-LD builders ─────────────────────────────────────────────────
+
+class TestJsonLdBuilders:
+    def test_breadcrumb_structure(self):
+        bc = seo.breadcrumb_jsonld([
+            ("Home", "https://x.com"),
+            ("Books", "https://x.com/books"),
+            ("Foo", "https://x.com/book/foo"),
+        ])
+        assert bc["@type"] == "BreadcrumbList"
+        assert len(bc["itemListElement"]) == 3
+        # Position numbering is 1-indexed per schema.org spec
+        assert bc["itemListElement"][0]["position"] == 1
+        assert bc["itemListElement"][-1]["position"] == 3
+
+    def test_faq_requires_non_empty_answer(self):
+        faq = seo.faq_jsonld([("What is X?", "Open the app to find out.")])
+        assert faq["@type"] == "FAQPage"
+        entity = faq["mainEntity"][0]
+        assert entity["@type"] == "Question"
+        assert entity["acceptedAnswer"]["text"]  # must be non-empty
+
+    def test_book_jsonld_omits_word_count_when_zero(self):
+        # Schema validators reject null leaves; jsonld_script drops them.
+        book = seo.book_jsonld(
+            title="T", description="D", author="A",
+            url="https://x.com/b", image="https://x.com/i.png",
+            word_count=None, chapters=None, site_url="https://x.com",
+        )
+        wrapped = seo.jsonld_script(book)
+        parsed = json.loads(wrapped.split(">", 1)[1].rsplit("<", 1)[0])
+        assert "wordCount" not in parsed
+        assert "hasPart" not in parsed
+
+    def test_book_jsonld_emits_haspart_when_chapters_present(self):
+        book = seo.book_jsonld(
+            title="T", description="D", author="A",
+            url="https://x.com/b", image="https://x.com/i.png",
+            word_count=12345,
+            chapters=[{"title": "Ch1"}, {"title": "Ch2"}],
+            site_url="https://x.com",
+        )
+        wrapped = seo.jsonld_script(book)
+        parsed = json.loads(wrapped.split(">", 1)[1].rsplit("<", 1)[0])
+        assert parsed["wordCount"] == 12345
+        assert len(parsed["hasPart"]) == 2
+        assert parsed["hasPart"][0]["@type"] == "Chapter"
+
+    def test_book_jsonld_never_emits_number_of_pages(self):
+        # We intentionally don't render numberOfPages anywhere — Schema.org
+        # defines it as physical pages, not chapters. The old code had a
+        # semantic bug; ensure we never reintroduce it.
+        book = seo.book_jsonld(
+            title="T", description="D", author="A",
+            url="u", image="i", word_count=100,
+            chapters=[{"title": "Ch1"}], site_url="s",
+        )
+        wrapped = seo.jsonld_script(book)
+        assert "numberOfPages" not in wrapped
+
+    def test_person_jsonld_includes_same_as(self):
+        p = seo.person_jsonld(
+            name="Karl Marx", description="", domain="",
+            url="u", image="i",
+            same_as=["https://en.wikipedia.org/wiki/Karl_Marx"],
+        )
+        assert p["sameAs"] == ["https://en.wikipedia.org/wiki/Karl_Marx"]
+
+    def test_person_jsonld_knows_about_splits_domain(self):
+        p = seo.person_jsonld(
+            name="X", description="d", domain="Physics, Mathematics",
+            url="u", image="i",
+        )
+        assert p["knowsAbout"] == ["Physics", "Mathematics"]
+
+    def test_jsonld_script_wraps_and_drops_nulls(self):
+        payload = {"a": 1, "b": None, "c": "", "d": [], "e": {"f": None, "g": 2}}
+        s = seo.jsonld_script(payload)
+        assert s.startswith('<script type="application/ld+json">')
+        assert s.endswith("</script>")
+        # nulls/empty values must be stripped
+        assert "null" not in s
+        # nested empty cleanup
+        body = s.split(">", 1)[1].rsplit("<", 1)[0]
+        parsed = json.loads(body)
+        assert parsed == {"a": 1, "e": {"g": 2}}
+
+
+# ─── Section renderers — non-empty input produces visible content ──────
+
+class TestRenderBookSections:
+    def test_about_renders_subtitle(self):
+        out = seo.render_book_about("A guide to influence.", "Dale Carnegie")
+        assert "guide to influence" in out
+
+    def test_about_empty_returns_empty(self):
+        assert seo.render_book_about("", "") == ""
+
+    def test_stats_includes_words_chapters_reading_time(self):
+        out = seo.render_stats(50000, 12)
+        assert "50,000 words" in out
+        assert "12 chapters" in out
+        assert "min read" in out
+
+    def test_stats_empty(self):
+        assert seo.render_stats(0, 0) == ""
+
+    def test_toc_renders_ol(self):
+        out = seo.render_toc([{"title": "Ch1"}, {"title": "Ch2"}])
+        assert "<ol" in out
+        assert "Ch1" in out and "Ch2" in out
+
+    def test_toc_skips_blank_titles(self):
+        out = seo.render_toc([{"title": ""}, {"title": "Ch2"}])
+        assert "Ch2" in out
+        # Only one <li> should render
+        assert out.count("<li>") == 1
+
+    def test_sample_passages_truncates(self):
+        long = "word " * 200  # 1000 chars
+        out = seo.render_sample_passages([{"text": long}], count=1, max_chars=100)
+        assert "<blockquote>" in out
+        # truncation marker present
+        assert "…" in out
+
+    def test_sample_passages_escapes_html(self):
+        out = seo.render_sample_passages([{"text": "<script>x</script>"}], count=1)
+        assert "<script>x</script>" not in out
+        assert "&lt;script&gt;" in out
+
+    def test_popular_questions_renders_with_links(self):
+        out = seo.render_popular_questions(
+            ["What is X?", "Why Y?"],
+            "https://x.com/#/read/abc",
+        )
+        assert out.count("<li>") == 2
+        assert "What is X?" in out
+        assert "https://x.com/#/read/abc" in out
+
+    def test_minds_for_book_renders_cross_links(self):
+        minds = [{"id": "m1", "name": "Marx", "domain": "Economics"}]
+        out = seo.render_minds_for_book(minds, "https://x.com")
+        assert 'href="https://x.com/mind/m1"' in out
+        assert "Marx" in out
+
+
+class TestRenderMindSections:
+    def test_thinking_style_renders(self):
+        out = seo.render_mind_thinking_style("Systems thinking, first principles.")
+        assert "first principles" in out
+
+    def test_phrases_renders_quotes(self):
+        out = seo.render_mind_phrases(["Cogito ergo sum", "Ich denke, also bin ich"])
+        assert "<q>" in out
+        assert "Cogito" in out
+
+    def test_phrases_limit(self):
+        out = seo.render_mind_phrases([f"phrase{i}" for i in range(20)], limit=3)
+        assert out.count("<q>") == 3
+
+    def test_persona_excerpt_truncates(self):
+        long = "word " * 500
+        out = seo.render_mind_persona_excerpt(long, max_chars=80)
+        assert "…" in out
+
+    def test_works_cross_links_when_match(self):
+        works = ["Das Kapital", "The Communist Manifesto"]
+        linked = [{"id": "b1", "name": "Das Kapital"}]
+        out = seo.render_mind_works(works, linked, "https://x.com")
+        assert 'href="https://x.com/book/b1"' in out
+        # Unlinked work stays plain text
+        assert "The Communist Manifesto" in out
+        # Only one anchor — the matching one
+        assert out.count("<a ") == 1
+
+    def test_works_fuzzy_match(self):
+        # Subtitle variation should still match
+        works = ["Das Kapital, Volume I"]
+        linked = [{"id": "b1", "name": "Das Kapital"}]
+        out = seo.render_mind_works(works, linked, "https://x.com")
+        assert 'href="https://x.com/book/b1"' in out
+
+    def test_lookup_same_as_case_insensitive(self):
+        assert seo.lookup_same_as("Karl Marx") == seo.lookup_same_as("KARL MARX")
+        assert seo.lookup_same_as("karl marx") == seo.lookup_same_as("Karl Marx")
+
+    def test_lookup_same_as_returns_wikipedia_and_wikidata(self):
+        urls = seo.lookup_same_as("Albert Einstein")
+        assert urls is not None
+        assert any("wikipedia" in u for u in urls)
+        assert any("wikidata" in u for u in urls)
+
+    def test_lookup_same_as_unknown_returns_none(self):
+        assert seo.lookup_same_as("Some Person Nobody Knows") is None
+        assert seo.lookup_same_as("") is None
+
+    def test_related_minds_renders(self):
+        related = [
+            {"id": "m1", "name": "Engels", "era": "19th Century"},
+            {"id": "m2", "name": "Lenin", "era": "20th Century"},
+        ]
+        out = seo.render_related_minds(related, "https://x.com")
+        assert "Engels" in out and "Lenin" in out
+        assert 'href="https://x.com/mind/m1"' in out
+
+
+# ─── End-to-end content density floor ─────────────────────────────────
+
+class TestContentDensityFloor:
+    """If these break, the per-entity SEO/GEO strategy is broken. They are
+    the regression net for the "24-word shell" failure mode that motivated
+    the rewrite in the first place."""
+
+    def _build_book_html(self) -> str:
+        # Realistic chunk size — actual indexed chunks average ~1200 chars
+        # of varied prose. The default render_sample_passages truncates at
+        # 800 chars per blockquote × 3 = ~2400 chars rendered.
+        chunk_text_a = (
+            "The fundamental technique in handling people requires that we never "
+            "criticize them directly. Criticism puts a person on the defensive and "
+            "wounds their precious pride; it hurts their sense of importance and "
+            "arouses resentment. Even when criticism is justified, the person we "
+            "criticize will rarely respond with the change we desired. Instead, they "
+            "will spend their energy justifying themselves and explaining why their "
+            "behavior was correct. The skill we must cultivate is the patience to "
+            "understand what made someone act as they did before we attempt to "
+            "change them."
+        )
+        chunk_text_b = (
+            "Give honest and sincere appreciation. The deepest principle in human "
+            "nature is the craving to be appreciated, and most people pass through "
+            "their lives without experiencing it. Flattery is hollow and selfish; "
+            "appreciation comes from the heart and is grounded in genuine attention "
+            "to what is admirable in another person. When we notice the work, the "
+            "effort, the choices someone has made, and we tell them so clearly and "
+            "specifically, we awaken something powerful — a willingness to engage "
+            "with us as collaborators rather than adversaries."
+        )
+        chunk_text_c = (
+            "Arouse in the other person an eager want. The only way to influence "
+            "anyone is to talk about what they want and show them how to get it. "
+            "Every action we ever take springs from a fundamental desire — for "
+            "security, for recognition, for the well-being of those we love. To "
+            "persuade effectively, we must first stand in the other person's shoes "
+            "and see the question from their angle, then frame our proposal as the "
+            "thing that helps them get what they already wanted."
+        )
+        chunks = [
+            {"text": chunk_text_a},
+            {"text": chunk_text_b},
+            {"text": chunk_text_c},
+        ]
+        sections = [
+            "<h1>How to Win Friends and Influence People</h1>",
+            "<p>by Dale Carnegie</p>",
+            seo.render_book_about(
+                "Dale Carnegie's classic guide to interpersonal communication, "
+                "influence, and the timeless principles of human relations that "
+                "have shaped business and personal success for nearly a century.",
+                "Dale Carnegie",
+            ),
+            seo.render_stats(89000, 30),
+            seo.render_sample_passages(chunks),
+            seo.render_toc([
+                {"title": "Fundamental Techniques in Handling People"},
+                {"title": "Six Ways to Make People Like You"},
+                {"title": "How to Win People to Your Way of Thinking"},
+                {"title": "Be a Leader: How to Change People Without Giving Offense"},
+                {"title": "Letters That Produced Miraculous Results"},
+                {"title": "Seven Rules for Making Your Home Life Happier"},
+                {"title": "How to Develop Self-Confidence"},
+                {"title": "The Big Secret of Dealing with People"},
+                {"title": "Make People Glad to Do What You Want"},
+                {"title": "Concluding Principles for Lasting Influence"},
+            ]),
+            seo.render_popular_questions(
+                [
+                    "What is the central thesis of How to Win Friends and Influence People?",
+                    "How does Carnegie suggest handling criticism in a workplace setting?",
+                    "What role does sincere appreciation play in building influence?",
+                    "How can these communication techniques apply to modern digital teams?",
+                    "What concrete evidence does Carnegie cite to support his claims?",
+                ],
+                "https://x.com/#/read/abc",
+            ),
+            seo.render_minds_for_book(
+                [
+                    {"id": "m1", "name": "Dale Carnegie", "domain": "Communication"},
+                    {"id": "m2", "name": "Adam Smith", "domain": "Economics, Moral Philosophy"},
+                    {"id": "m3", "name": "Benjamin Franklin", "domain": "Practical Philosophy"},
+                ],
+                "https://x.com",
+            ),
+        ]
+        return "<html><body>" + "\n".join(sections) + "</body></html>"
+
+    def _build_mind_html(self) -> str:
+        # Persona texts are typically 1500+ chars of system-prompt-style
+        # description; sample below is representative.
+        persona = (
+            "I approach every question by first asking who benefits materially "
+            "from the present arrangement and whose labor is appropriated to "
+            "produce that benefit. Ideology, religion, law, and politics are "
+            "the superstructure resting on the economic base; to understand "
+            "any of them you must first understand the underlying relations of "
+            "production. History is the history of class struggle, and the "
+            "conflict between those who own the means of production and those "
+            "who must sell their labor is the engine of social transformation. "
+            "Capitalism is not natural or eternal — it emerged from specific "
+            "historical conditions and contains internal contradictions that "
+            "will lead to its eventual supersession by a more rational system "
+            "in which producers collectively control the conditions of their work."
+        )
+        sections = [
+            "<h1>Karl Marx</h1>",
+            "<p>19th Century · Political Economy, Philosophy</p>",
+            seo.render_mind_bio(
+                "Karl Marx (1818-1883) was a German philosopher, economist, "
+                "political theorist, and revolutionary socialist whose theories "
+                "about society, economics, and politics — collectively understood "
+                "as Marxism — hold that human societies develop through class "
+                "conflict. His most famous works, co-authored with Friedrich Engels, "
+                "include The Communist Manifesto (1848) and the three-volume Das "
+                "Kapital. His ideas profoundly influenced the development of "
+                "socialist and communist movements across the twentieth century."
+            ),
+            seo.render_mind_thinking_style(
+                "Materialist dialectics. Analyzes societies through the lens of "
+                "class conflict and economic relations. Distinguishes appearance "
+                "from underlying social reality, and treats every institution as "
+                "historically contingent rather than natural or eternal."
+            ),
+            seo.render_mind_phrases([
+                "The history of all hitherto existing society is the history of class struggles.",
+                "Workers of the world, unite! You have nothing to lose but your chains.",
+                "From each according to his ability, to each according to his needs.",
+                "The philosophers have only interpreted the world; the point is to change it.",
+                "Religion is the opium of the people.",
+            ]),
+            seo.render_mind_persona_excerpt(persona),
+            seo.render_mind_works(
+                [
+                    "Das Kapital, Volume I",
+                    "The Communist Manifesto",
+                    "The German Ideology",
+                    "Economic and Philosophic Manuscripts of 1844",
+                    "Theses on Feuerbach",
+                    "Grundrisse",
+                    "Critique of the Gotha Programme",
+                ],
+                [{"id": "b1", "name": "Das Kapital"}],
+                "https://x.com",
+            ),
+            seo.render_related_minds(
+                [
+                    {"id": "m2", "name": "Friedrich Engels", "era": "19th Century"},
+                    {"id": "m3", "name": "Adam Smith", "era": "18th Century"},
+                    {"id": "m4", "name": "G.W.F. Hegel", "era": "19th Century"},
+                ],
+                "https://x.com",
+            ),
+        ]
+        return "<html><body>" + "\n".join(sections) + "</body></html>"
+
+    def test_book_page_clears_phase1_word_floor(self):
+        """The motivating diagnostic showed 24 visible words. Phase 1 of the
+        SEO plan (Sample passages + TOC + Popular Questions + Minds-for-book)
+        clears 400 words on representative fixtures — an ~17x improvement.
+
+        Stretch target (Phase 4: compound URLs + per-chapter pages) is 800+;
+        reaching that requires additional surface area, not just thicker
+        Phase 1 sections. If this floor drops, Phase 1 has regressed."""
+        html = self._build_book_html()
+        wc = seo.visible_word_count(html)
+        assert wc >= 400, f"Book page only renders {wc} visible words; Phase 1 floor is 400"
+
+    def test_mind_page_clears_phase1_word_floor(self):
+        """The motivating diagnostic showed 101 visible words. Phase 1 of the
+        SEO plan (bio + thinking_style + phrases + persona excerpt + works +
+        related minds) clears 280 on representative fixtures — a ~2.8x
+        improvement. Stretch target (Phase 4: per-topic essay pages) is 500+."""
+        html = self._build_mind_html()
+        wc = seo.visible_word_count(html)
+        assert wc >= 280, f"Mind page only renders {wc} visible words; Phase 1 floor is 280"
+
+    def test_book_page_has_internal_mind_links(self):
+        """Internal linking graph is the multiplier on entity authority."""
+        html = self._build_book_html()
+        assert html.count('href="https://x.com/mind/') >= 2
+
+    def test_mind_page_has_internal_book_link(self):
+        html = self._build_mind_html()
+        assert 'href="https://x.com/book/' in html
+
+
+class TestSparseDataDegradation:
+    """A fresh book or mind with no chunks / no questions / no links still
+    needs to render without crashing. The page is allowed to be thin in
+    that case — we just can't 500 the request."""
+
+    def test_book_sections_with_no_data(self):
+        # Every render_* should return "" (not raise) for empty inputs
+        assert seo.render_book_about("", "") == ""
+        assert seo.render_stats(0, 0) == ""
+        assert seo.render_toc([]) == ""
+        assert seo.render_sample_passages([]) == ""
+        assert seo.render_popular_questions([], "https://x.com") == ""
+        assert seo.render_minds_for_book([], "https://x.com") == ""
+
+    def test_mind_sections_with_no_data(self):
+        assert seo.render_mind_bio("") == ""
+        assert seo.render_mind_thinking_style("") == ""
+        assert seo.render_mind_phrases([]) == ""
+        assert seo.render_mind_persona_excerpt("") == ""
+        assert seo.render_mind_works([], [], "https://x.com") == ""
+        assert seo.render_books_for_mind([], "https://x.com") == ""
+        assert seo.render_related_minds([], "https://x.com") == ""
+
+    def test_jsonld_still_emits_with_minimal_data(self):
+        # Even with no enrichment, the structured-data blocks must render
+        book = seo.book_jsonld(
+            title="Untitled", description="", author="",
+            url="u", image="i", word_count=None, chapters=None, site_url="s",
+        )
+        wrapped = seo.jsonld_script(book)
+        assert "@type" in wrapped and "Book" in wrapped
+
+        person = seo.person_jsonld(
+            name="Unknown", description="", domain="",
+            url="u", image="i",
+        )
+        wrapped = seo.jsonld_script(person)
+        assert "@type" in wrapped and "Person" in wrapped

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -867,6 +867,227 @@ class TestPopularQuestionsCompoundUrls:
         assert 'href="https://x.com/#/chat/abc"' in out
 
 
+class TestPhase5RelatedBooks:
+    """Related-books cross-links on /book/{id} — Phase 5 closes the
+    book↔book half of the internal linking graph."""
+
+    def test_render_related_books_cross_links(self):
+        out = seo.render_related_books(
+            [
+                {"id": "b1", "name": "Sapiens", "author": "Yuval Harari"},
+                {"id": "b2", "name": "Homo Deus", "author": "Yuval Harari"},
+            ],
+            "https://x.com",
+        )
+        assert 'href="https://x.com/book/b1"' in out
+        assert 'href="https://x.com/book/b2"' in out
+        assert "Sapiens" in out and "Homo Deus" in out
+        assert "Yuval Harari" in out
+
+    def test_render_related_books_empty(self):
+        assert seo.render_related_books([], "https://x.com") == ""
+
+    def test_render_related_books_skips_malformed_entries(self):
+        out = seo.render_related_books(
+            [
+                {"id": "b1", "name": "Good"},
+                {"id": "", "name": "Missing ID"},
+                {"id": "b3", "name": ""},
+            ],
+            "https://x.com",
+        )
+        assert "Good" in out
+        assert "Missing ID" not in out
+        assert out.count("<li>") == 1
+
+    def test_render_topic_link_back(self):
+        out = seo.render_topic_link_back("Economics", "https://x.com")
+        assert 'href="https://x.com/topic/economics"' in out
+        assert "Economics" in out
+
+    def test_render_topic_link_back_empty(self):
+        assert seo.render_topic_link_back("", "https://x.com") == ""
+
+    def test_render_topic_links_for_mind(self):
+        out = seo.render_topic_links_for_mind(
+            ["Economics", "Philosophy"], "https://x.com",
+        )
+        assert 'href="https://x.com/topic/economics"' in out
+        assert 'href="https://x.com/topic/philosophy"' in out
+
+    def test_render_topic_links_for_mind_caps_at_five(self):
+        out = seo.render_topic_links_for_mind(
+            ["T" + str(i) for i in range(20)], "https://x.com",
+        )
+        # Cap is 5
+        assert out.count("<a ") == 5
+
+
+class TestPhase6UgcPiiScrubbing:
+    """Phase 6: PII scrubbing must redact before any public render.
+    Conservative — better to over-redact than leak."""
+
+    def test_scrub_email(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("Email me at john.doe+tag@example.co")
+        assert "john.doe" not in out
+        assert "example.co" not in out
+        assert "[email redacted]" in out
+
+    def test_scrub_multiple_emails(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("a@b.com and c@d.org")
+        assert out.count("[email redacted]") == 2
+
+    def test_scrub_phone_us_format(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("Call (415) 555-1234 anytime")
+        assert "555-1234" not in out
+        assert "555" not in out  # full number stripped
+        assert "[phone redacted]" in out
+
+    def test_scrub_phone_intl_format(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("+86 138 0013 8000")
+        assert "138" not in out
+        assert "[phone redacted]" in out
+
+    def test_scrub_url(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("See https://github.com/me/repo")
+        assert "github.com" not in out
+        assert "[link redacted]" in out
+
+    def test_scrub_at_handle(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("Follow @username for more")
+        assert "@username" not in out
+        assert "[handle redacted]" in out
+
+    def test_scrub_preserves_non_pii_text(self):
+        from app.core import ugc
+        text = "The book discusses how capitalism evolved in the 19th century."
+        assert ugc.scrub_pii_for_public_display(text) == text
+
+    def test_scrub_empty(self):
+        from app.core import ugc
+        assert ugc.scrub_pii_for_public_display("") == ""
+
+    def test_scrub_mixed(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display(
+            "I'm jane@example.com, call 555-867-5309 or DM @jane_x"
+        )
+        assert "jane@example" not in out
+        assert "867" not in out
+        assert "@jane_x" not in out
+
+
+class TestPhase6UgcHandleValidation:
+    def test_valid_handle(self):
+        from app.core import ugc
+        h, err = ugc.validate_public_handle("ReaderJane")
+        assert h == "ReaderJane"
+        assert err is None
+
+    def test_trims_whitespace(self):
+        from app.core import ugc
+        h, err = ugc.validate_public_handle("  jane  ")
+        assert h == "jane"
+
+    def test_empty_returns_anonymous_not_error(self):
+        from app.core import ugc
+        h, err = ugc.validate_public_handle("")
+        assert h == ""
+        assert err is None  # caller falls back to "Anonymous"
+        h, err = ugc.validate_public_handle(None)
+        assert h == ""
+        assert err is None
+
+    def test_rejects_email_like(self):
+        from app.core import ugc
+        h, err = ugc.validate_public_handle("jane@example.com")
+        assert h == ""
+        assert err is not None
+        assert "@" in err
+
+    def test_rejects_long_digit_run(self):
+        from app.core import ugc
+        h, err = ugc.validate_public_handle("user12345")  # 5 digits in a row
+        assert h == ""
+        assert err is not None
+
+    def test_rejects_too_long(self):
+        from app.core import ugc
+        h, err = ugc.validate_public_handle("x" * 100)
+        assert h == ""
+        assert err is not None
+
+
+class TestPhase6UgcFeatureFlag:
+    """The kill switch must default OFF and gate everything."""
+
+    def test_default_disabled(self):
+        # We can't change the env var post-import (read at module load
+        # time), but the module-level read at import time is the only
+        # thing that matters in production. Default should be False.
+        from app.core import ugc
+        # Just confirm the function exists and returns a bool — actual
+        # value depends on env. In test env (no var), default is False.
+        result = ugc.is_enabled()
+        assert isinstance(result, bool)
+        # In CI / local dev where ENABLE_PUBLIC_DISCUSSIONS is unset,
+        # this must be False.
+        import os
+        if not os.getenv("ENABLE_PUBLIC_DISCUSSIONS"):
+            assert result is False
+
+
+class TestPhase6UgcDiscussionForumJsonld:
+    def test_basic_structure(self):
+        from app.core import ugc
+        ld = ugc.discussion_forum_jsonld(
+            posts=[
+                {
+                    "handle": "Jane",
+                    "body": "Great book.",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "session_id": "s1",
+                },
+            ],
+            page_url="https://x.com/book/b1/discussions",
+            headline="Discussions about Sapiens",
+            about_url="https://x.com/book/b1",
+            about_type="Book",
+            about_name="Sapiens",
+        )
+        assert ld["@type"] == "DiscussionForumPosting"
+        assert ld["commentCount"] == 1
+        assert ld["comment"][0]["@type"] == "Comment"
+        assert ld["comment"][0]["author"]["name"] == "Jane"
+        assert ld["about"]["@type"] == "Book"
+        assert ld["about"]["name"] == "Sapiens"
+
+    def test_anonymous_falls_back_when_handle_missing(self):
+        from app.core import ugc
+        ld = ugc.discussion_forum_jsonld(
+            posts=[{"body": "x", "created_at": "", "session_id": "s1"}],
+            page_url="u", headline="h", about_url="a",
+            about_type="Book", about_name="n",
+        )
+        assert ld["comment"][0]["author"]["name"] == "Anonymous"
+
+    def test_empty_posts(self):
+        from app.core import ugc
+        ld = ugc.discussion_forum_jsonld(
+            posts=[], page_url="u", headline="h", about_url="a",
+            about_type="Person", about_name="n",
+        )
+        assert ld["commentCount"] == 0
+        assert ld["comment"] == []
+        assert ld["about"]["@type"] == "Person"
+
+
 class TestSparseDataDegradation:
     """A fresh book or mind with no chunks / no questions / no links still
     needs to render without crashing. The page is allowed to be thin in


### PR DESCRIPTION
Five waves of SEO/GEO work landed on this branch, designed to be reverted individually if any single wave regresses.

## What ships

| Commit | Phase | Scope |
|---|---|---|
| \`e25b3b1\` | 0+1+2 | Per-entity content enrichment — book pages 24→~450 visible words (19x), mind pages 101→~330 words (3.3x), correct JSON-LD, FAQPage schema, sameAs for 24 famous minds |
| \`38253b9\` | 3a    | Capability-aware landing + referer-based redirect — catalog stubs no longer advertise misleading 'Read', external visitors stay on landing page (fixes bounce-rate bug from empty reader redirect) |
| \`e0fa69a\` | 4     | Compound URLs — \`/topic/{slug}\`, \`/book/{id}/q/{slug}\`, \`/mind/{id}/on/{slug}\`. ~5,000 indexable URLs from ~750, each with unique RAG/persona-grounded content. ENABLE_QA_LLM / ENABLE_MIND_ESSAY kill switches |
| \`5741206\` | 5+6   | Related-books linking graph + full UGC pipeline (DB schema, opt-in API, admin moderation, PII scrubbing, /discussions render route, DiscussionForumPosting JSON-LD) — entirely gated behind ENABLE_PUBLIC_DISCUSSIONS default OFF |

## Production safety story

- **UGC pipeline is OFF by default.** \`ENABLE_PUBLIC_DISCUSSIONS=false\` means all 8 UGC routes return 404, sitemap excludes \`/discussions\`. To activate, product needs to (a) build SPA opt-in UI, (b) set \`ADMIN_USER_IDS\`, (c) flip the env var.
- **LLM features have kill switches.** \`ENABLE_QA_LLM=false\` falls back to passage-only Q&A pages (no LLM cost). \`ENABLE_MIND_ESSAY=false\` turns \`/mind/{id}/on/{slug}\` into 404.
- **DB migrations are additive + idempotent.** SAVEPOINT/ROLLBACK pattern in PG branch, try/except in SQLite branch. Re-runs are safe. No destructive operations.
- **PII scrubbing is conservative.** Emails, phones, URLs, @handles redacted before any public render. SQL-side gating on \`public_status='approved'\` even after cache layer.

## Verification done before this PR

- 188/188 unit tests pass (twice, paranoid)
- Integration test confirms flag-OFF gates all UGC surfaces (8 routes → 404, sitemap clean)
- Integration test confirms flag-ON happy path: opt-in → admin approval → render with PII scrubbed (verified email/phone/@handle all redacted, non-PII content visible)
- DB migration idempotency: 3 consecutive init_db() runs succeed
- All modules import cleanly
- Vercel config validated
- No secrets / debug prints in app code

## Deploy plan

1. Merge this PR → Vercel auto-deploys main
2. Spot-check production: \`curl https://feynman.wiki/topic/economics\`, \`curl https://feynman.wiki/sitemap.xml | grep -c '<loc>'\` (expect ~5x previous count)
3. Run questions backfill locally when ready: \`python -m scripts.backfill_questions --dry-run\` then real run (~\$1, ~15-30 min)
4. (Future) Activate UGC: build SPA opt-in UI, set ADMIN_USER_IDS + ENABLE_PUBLIC_DISCUSSIONS=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)