### PR TITLE
fix(auth): add /topic/ to public prefixes (hotfix for #8)

### DIFF
--- a/app/pro/auth.py
+++ b/app/pro/auth.py
@@ -38,7 +38,7 @@ PUBLIC_PATHS = {
     "/llms.txt",
     "/llms-full.txt",
 }
-PUBLIC_PREFIXES = ("/static/", "/share/", "/book/", "/mind/", "/api/public/")
+PUBLIC_PREFIXES = ("/static/", "/share/", "/book/", "/mind/", "/topic/", "/api/public/")
 
 # GET requests to these paths require authentication (user-specific data)
 PRIVATE_GET_PREFIXES = (


### PR DESCRIPTION
Production smoke test after merging #8 surfaced /topic/{slug} returning 401 from pro auth middleware. /book/, /mind/ and /api/public/ were already public; /topic/ was missed when Phase 4C added the new route.

One-line fix: add /topic/ to PUBLIC_PREFIXES.

All 8 new SEO route patterns verified public after fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)