### PR TITLE
fix(seo): QAPage missing Question.text + answerCount (GSC validation)

### DIFF
--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -883,33 +883,66 @@ def qa_page_jsonld(
     url: str,
     book_title: str,
     book_url: str,
+    site_url: str = "",
+    date_created: str = "",
 ) -> dict[str, Any]:
-    """Schema.org/QAPage with acceptedAnswer. Google supports this rich
-    result; LLMs use it as a clean enumerable signal.
+    """Schema.org/QAPage. Required fields per Google's rich-result spec
+    (https://developers.google.com/search/docs/appearance/structured-data/qapage):
 
-    If we don't have an LLM-synthesized answer yet, we still emit the
-    schema with a deflection answer pointing to the chat — better than
-    omitting the schema entirely (which would forfeit the rich-result
-    eligibility) and Google accepts non-empty deflection text."""
+    Question (required):
+      * ``name`` — short summary
+      * ``text`` — full question text  ← was missing in v1, caused
+        "1 invalid item" in GSC URL Inspection
+      * ``answerCount`` — integer count of answers  ← was missing in v1
+      * ``acceptedAnswer`` OR ``suggestedAnswer``
+
+    Answer (required):
+      * ``text``
+      * ``url`` (when answer is on a different URL, optional otherwise)
+
+    Recommended fields we also include for richer eligibility:
+      * ``author`` on both Question and Answer (Organization = Feynman)
+      * ``dateCreated`` when available
+      * ``upvoteCount`` on Answer (0 default — Google accepts 0)
+    """
     answer_text = (answer or "").strip()
     if not answer_text:
         answer_text = (
             f"Open Feynman to chat with the book \"{book_title}\" and explore "
             f"the answer in depth: {book_url}"
         )
+
+    author = {
+        "@type": "Organization",
+        "name": "Feynman",
+    }
+    if site_url:
+        author["url"] = site_url
+
+    question_obj: dict[str, Any] = {
+        "@type": "Question",
+        "name": question,           # short summary (same as text for our case)
+        "text": question,           # FULL question text — required by Google
+        "answerCount": 1,           # required — we always have one synthesized answer
+        "upvoteCount": 0,
+        "url": url,
+        "author": author,
+        "acceptedAnswer": {
+            "@type": "Answer",
+            "text": answer_text,
+            "upvoteCount": 0,
+            "url": url,
+            "author": author,
+        },
+    }
+    if date_created:
+        question_obj["dateCreated"] = date_created
+        question_obj["acceptedAnswer"]["dateCreated"] = date_created
+
     return {
         "@context": "https://schema.org",
         "@type": "QAPage",
-        "mainEntity": {
-            "@type": "Question",
-            "name": question,
-            "url": url,
-            "acceptedAnswer": {
-                "@type": "Answer",
-                "text": answer_text,
-                "url": url,
-            },
-        },
+        "mainEntity": question_obj,
     }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1685,6 +1685,8 @@ def book_question_page(agent_id: str, question_slug: str, request: Request) -> H
         url=canonical,
         book_title=title_raw,
         book_url=book_url,
+        site_url=base,
+        date_created=agent.get("created_at", "") or "",
     ))
     breadcrumb_ld = seo_render.jsonld_script(seo_render.breadcrumb_jsonld([
         ("Feynman", base),

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -700,6 +700,37 @@ class TestPhase4QAHelpers:
         assert text  # non-empty deflection
         assert "Book" in text  # mentions the book by title
 
+    def test_qa_page_jsonld_has_google_required_fields(self):
+        """Regression guard for the 'Q&A: 1 invalid item detected' bug
+        flagged in GSC URL Inspection. Google's QAPage rich-result spec
+        requires Question.text and Question.answerCount in addition to
+        Question.name. v1 emitted only name → GSC rejected the schema."""
+        ld = seo.qa_page_jsonld(
+            question="What is the central thesis?",
+            answer="The central thesis is X.",
+            url="https://x.com/q", book_title="B", book_url="https://x.com/b",
+        )
+        q = ld["mainEntity"]
+        # Required by Google QAPage spec
+        assert "name" in q
+        assert "text" in q, "Question.text required by Google QAPage spec"
+        assert q["text"] == "What is the central thesis?"
+        assert "answerCount" in q, "Question.answerCount required by Google QAPage spec"
+        assert q["answerCount"] == 1
+        # Author for richer eligibility
+        assert "author" in q
+        assert q["author"]["@type"] == "Organization"
+        assert q["acceptedAnswer"]["author"]["@type"] == "Organization"
+
+    def test_qa_page_jsonld_includes_date_created_when_provided(self):
+        ld = seo.qa_page_jsonld(
+            question="Q?", answer="A.",
+            url="u", book_title="B", book_url="b",
+            date_created="2026-01-01T00:00:00Z",
+        )
+        assert ld["mainEntity"]["dateCreated"] == "2026-01-01T00:00:00Z"
+        assert ld["mainEntity"]["acceptedAnswer"]["dateCreated"] == "2026-01-01T00:00:00Z"
+
 
 class TestPhase4MindOnTopic:
     """Phase 4B: /mind/{id}/on/{topic} compound pages."""


### PR DESCRIPTION
GSC URL Inspection flagged 'Q&A: 1 invalid item detected' on /book/{id}/q/{slug} pages. Root cause: Google's QAPage spec requires Question.text and Question.answerCount in addition to Question.name. Fix adds both + 3 recommended fields (author, upvoteCount, dateCreated). Regression test added.

E2E verified: all 6 required fields + 3 recommended fields now in emitted JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)