### PR TITLE
feat(seo): A+B — sitemap chunk-count gate + book quality audit script

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1600,6 +1600,45 @@ def list_books_for_mind(mind_id: str, limit: int = 12) -> list[dict[str, Any]]:
         return out
 
 
+def count_chunks_batch(agent_ids: list[str]) -> dict[str, int]:
+    """One-shot count of chunks per agent — used by sitemap to gate
+    /q/ compound URL inclusion. Agents with too few chunks tend to
+    produce low-quality LLM answers (RAG retrieves the wrong things,
+    or the book has been indexed with metadata that doesn't match the
+    actual content). Excluding their /q/ URLs from sitemap protects
+    site-wide quality score.
+
+    Returns {agent_id: count}; agents with zero chunks are omitted."""
+    if not agent_ids:
+        return {}
+    placeholders = ",".join(["?"] * len(agent_ids))
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            f"""SELECT agent_id, COUNT(*) AS n FROM chunks
+                WHERE agent_id IN ({placeholders})
+                GROUP BY agent_id"""
+        ), tuple(agent_ids))
+    return {r["agent_id"]: int(r["n"]) for r in rows}
+
+
+def get_first_chunk_text(agent_id: str, max_chars: int = 400) -> str:
+    """Pull the first chunk's text (truncated) — used by the
+    quality-audit script to spot agent-content mismatches (e.g. agent
+    named 'A World Brewed' but chunk[0] starts with content from a
+    completely different book)."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            """SELECT text FROM chunks
+               WHERE agent_id = ?
+               ORDER BY chunk_index ASC
+               LIMIT 1"""
+        ), (agent_id,))
+        if not row:
+            return ""
+        text = (row["text"] or "").strip()
+        return text[:max_chars] if len(text) > max_chars else text
+
+
 def list_questions_batch(agent_ids: list[str]) -> dict[str, list[str]]:
     """Fetch the question texts for many agents in one query — used by
     sitemap rendering, which would otherwise issue N round-trips.

--- a/app/main.py
+++ b/app/main.py
@@ -46,6 +46,7 @@ from .core.db import (
     approve_chat_session_public,
     count_assistant_messages_batch,
     count_assistant_messages_for_minds_batch,
+    count_chunks_batch,
     count_llm_referrals,
     count_pending_public_sessions,
     get_chat_session_with_public_status,
@@ -757,10 +758,21 @@ def sitemap_xml():
             a for a in list_agents(limit=5000)
             if a.get("status") == "ready"
         ]
+        ready_ids = [a["id"] for a in ready_agents]
         # Batch-fetch questions for all ready agents in a single query —
         # the previous loop pattern would issue N round-trips inside the
         # sitemap render hot path.
-        questions_by_agent = list_questions_batch([a["id"] for a in ready_agents])
+        questions_by_agent = list_questions_batch(ready_ids)
+        # Quality gate for /q/ URL inclusion: a book needs at least this
+        # many indexed chunks for its question pages to produce
+        # substantive RAG-grounded answers. Below the threshold the
+        # synthesized answer tends to be "the passages don't contain
+        # the information" — a low-quality page Google will flag and
+        # which drags site-wide quality score down. 5 chunks ≈ 3-4
+        # paragraphs of indexed content, the minimum for a meaningful
+        # cross-passage synthesis.
+        _MIN_CHUNKS_FOR_Q_URLS = 5
+        chunks_by_agent = count_chunks_batch(ready_ids)
         for agent in ready_agents:
             agent_id = agent["id"]
             priority = "0.7" if agent.get("type") == "ai_book" else "0.5"
@@ -772,8 +784,11 @@ def sitemap_xml():
   </url>
 """
             # Phase 4A — compound Q&A URLs. One per popular question per
-            # book. Slightly lower priority than the parent page; weekly
-            # changefreq because answers may be regenerated.
+            # book. Gated on chunk count (see _MIN_CHUNKS_FOR_Q_URLS
+            # above) so catalog stubs and mis-indexed books don't expose
+            # their low-quality /q/ pages to Google.
+            if chunks_by_agent.get(agent_id, 0) < _MIN_CHUNKS_FOR_Q_URLS:
+                continue
             for q in questions_by_agent.get(agent_id, []):
                 qslug = seo_render.slugify(q)
                 if not qslug:

--- a/scripts/audit_book_quality.py
+++ b/scripts/audit_book_quality.py
@@ -1,0 +1,206 @@
+"""Audit book-agent data quality — find books whose indexed content
+doesn't actually match what their landing page claims.
+
+Why this exists
+---------------
+Real example from production (2026-05-26): the page
+``feynman.wiki/book/{id}/q/{question}`` for an agent named "A World
+Brewed" returned an LLM answer saying *"The provided passages do not
+contain information about 'A World Brewed.' The only passage given
+details a different book: 'CAMRAs Essential Home Brewing'"*.
+
+The code worked correctly — the LLM honestly admitted the data
+mismatch. But that page is now a low-quality result in Google's eyes
+and degrades the site-wide quality score. The root cause is upstream
+data: the agent row's ``name`` doesn't match the chunks loaded under
+its ``agent_id``.
+
+This script scans every ready/catalog book agent and classifies it
+into one of four buckets:
+
+  HIGH    — substantial content (>= 1000 words) AND >= 10 chunks
+            AND has questions AND first-chunk text mentions the book name
+  MEDIUM  — moderate content (>= 200 words) AND >= 3 chunks
+  LOW     — minimal content (>= 1 chunk but below MEDIUM bar)
+  STUB    — zero chunks (catalog stub only; chat-only capable)
+  MISMATCH — first chunk text mentions a DIFFERENT book title than the
+            agent name (high-confidence data corruption)
+
+Output is a CSV-style report to stdout plus a summary to stderr. Use
+the output to decide which books to re-index, delete, or exclude from
+indexing pipelines.
+
+Usage
+-----
+  python -m scripts.audit_book_quality                # full audit
+  python -m scripts.audit_book_quality --limit 50    # first 50 only
+  python -m scripts.audit_book_quality --only-bad    # MISMATCH + LOW only
+  python -m scripts.audit_book_quality --csv         # CSV header row included
+
+Required env vars
+-----------------
+  DATABASE_URL    Same connection string the app uses.
+
+Properties
+----------
+- Read-only: never modifies the database. Safe to run against prod.
+- Bounded: stops at --limit if provided, else processes all agents.
+- No LLM calls: pure SQL + string heuristics. Costs $0.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from typing import Any
+
+from app.core import config  # noqa: F401  — loads env
+from app.core.db import (
+    get_ai_book_by_agent,
+    get_first_chunk_text,
+    init_db,
+    list_agents,
+    list_questions,
+    count_chunks_batch,
+)
+
+
+# ─── Classification thresholds ────────────────────────────────────────
+_HIGH_MIN_WORDS = 1000
+_HIGH_MIN_CHUNKS = 10
+_MED_MIN_WORDS = 200
+_MED_MIN_CHUNKS = 3
+
+# A book name is at least this many chars before we try fuzzy matching
+# it against chunk content (shorter names like "X" or "If" generate
+# noise).
+_NAME_MATCH_MIN_CHARS = 5
+
+
+def _normalize(s: str) -> str:
+    """Lowercase + strip punctuation for loose substring matching."""
+    return re.sub(r"[^a-z0-9 ]+", " ", s.lower()).strip()
+
+
+def _name_appears_in_chunk(agent_name: str, chunk_text: str) -> bool:
+    """Loose check: does the agent name (or its longest 2-word phrase)
+    appear in the first chunk's first 400 chars? False positives are
+    OK — false negatives just bump the book to MISMATCH for human review."""
+    if not agent_name or not chunk_text:
+        return False
+    if len(agent_name) < _NAME_MATCH_MIN_CHARS:
+        return True  # too short to discriminate; assume OK
+    a_norm = _normalize(agent_name)
+    c_norm = _normalize(chunk_text)
+    # Full-name match wins
+    if a_norm in c_norm:
+        return True
+    # Try the longest 2-word phrase from the name
+    words = [w for w in a_norm.split() if len(w) >= 4]
+    for i in range(len(words) - 1):
+        phrase = words[i] + " " + words[i + 1]
+        if phrase in c_norm:
+            return True
+    # Single distinctive word match (>= 6 chars to avoid common words)
+    for w in words:
+        if len(w) >= 6 and w in c_norm:
+            return True
+    return False
+
+
+def _classify(
+    agent: dict[str, Any], chunk_count: int, book_row: dict[str, Any] | None,
+    first_chunk: str, question_count: int,
+) -> str:
+    if chunk_count == 0:
+        return "STUB"
+    total_words = 0
+    if book_row:
+        total_words = int(book_row.get("total_words") or 0)
+    if not total_words:
+        # Rough estimate from first chunk × chunk_count (assumes uniform)
+        total_words = len(first_chunk.split()) * chunk_count if first_chunk else 0
+
+    agent_name = agent.get("name", "")
+    if not _name_appears_in_chunk(agent_name, first_chunk):
+        return "MISMATCH"
+
+    if total_words >= _HIGH_MIN_WORDS and chunk_count >= _HIGH_MIN_CHUNKS and question_count > 0:
+        return "HIGH"
+    if total_words >= _MED_MIN_WORDS and chunk_count >= _MED_MIN_CHUNKS:
+        return "MEDIUM"
+    return "LOW"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Process at most this many books.")
+    parser.add_argument("--only-bad", action="store_true",
+                        help="Only report MISMATCH and LOW (skip OK books).")
+    parser.add_argument("--csv", action="store_true",
+                        help="Emit CSV header row before data.")
+    args = parser.parse_args()
+
+    print("--- audit_book_quality ---", file=sys.stderr)
+    init_db()
+    all_agents = list_agents(limit=10000)
+    # Focus on book-type agents; minds and other types skip
+    book_agents = [
+        a for a in all_agents
+        if a.get("type") in ("ai_book", "catalog", "upload", "url")
+        and a.get("status") in ("ready", "catalog")
+    ]
+    if args.limit is not None:
+        book_agents = book_agents[: args.limit]
+    print(f"scanning {len(book_agents)} book agents", file=sys.stderr)
+
+    # Batch chunk-counts so we issue one query instead of N
+    chunk_counts = count_chunks_batch([a["id"] for a in book_agents])
+
+    writer = csv.writer(sys.stdout)
+    if args.csv:
+        writer.writerow([
+            "verdict", "agent_id", "name", "type", "status",
+            "chunks", "total_words", "questions", "first_chunk_head",
+        ])
+
+    counts: dict[str, int] = {}
+    for agent in book_agents:
+        aid = agent["id"]
+        chunk_count = chunk_counts.get(aid, 0)
+        first_chunk = get_first_chunk_text(aid, max_chars=400) if chunk_count else ""
+        try:
+            book_row = get_ai_book_by_agent(aid) if agent.get("type") == "ai_book" else None
+        except Exception:
+            book_row = None
+        try:
+            q_count = len(list_questions(aid) or [])
+        except Exception:
+            q_count = 0
+
+        verdict = _classify(agent, chunk_count, book_row, first_chunk, q_count)
+        counts[verdict] = counts.get(verdict, 0) + 1
+
+        if args.only_bad and verdict not in ("MISMATCH", "LOW"):
+            continue
+
+        head = (first_chunk[:120] + "…") if len(first_chunk) > 120 else first_chunk
+        head = head.replace("\n", " ").replace("\r", " ")
+        total_words = (book_row.get("total_words") if book_row else 0) or 0
+        writer.writerow([
+            verdict, aid, (agent.get("name") or "")[:80],
+            agent.get("type", ""), agent.get("status", ""),
+            chunk_count, total_words, q_count, head,
+        ])
+
+    print(
+        "--- summary: " + ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) + " ---",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1595,6 +1595,51 @@ class TestPhase7IndexNow:
         assert r["submitted"] <= 1000
 
 
+class TestDbCountChunksBatch:
+    """Sitemap relies on this to gate /q/ URL inclusion. A regression
+    in the GROUP BY shape would either over-include (low-quality pages
+    get sitemap'd) or under-include (good pages excluded). Smoke-test
+    against the SQLite in-memory DB."""
+
+    def test_returns_per_agent_counts(self):
+        # Use the in-process SQLite DB; add_chunks requires id, vector,
+        # dim, norm columns per row
+        import os, uuid
+        os.environ.pop("DATABASE_URL", None)
+        from app.core.db import init_db, count_chunks_batch, add_chunks, create_agent
+        init_db()
+        a1 = create_agent(name=f"a-{uuid.uuid4().hex[:6]}", agent_type="ai_book", source="x", meta={})
+        a2 = create_agent(name=f"b-{uuid.uuid4().hex[:6]}", agent_type="ai_book", source="x", meta={})
+
+        def _mk(n):
+            return [
+                {
+                    "id": str(uuid.uuid4()),
+                    "chunk_index": i,
+                    "text": f"text {i}",
+                    "vector": b"\x00\x00\x00\x00",
+                    "dim": 0,
+                    "norm": 0.0,
+                }
+                for i in range(n)
+            ]
+        add_chunks(a1, _mk(7))
+        add_chunks(a2, _mk(2))
+        counts = count_chunks_batch([a1, a2])
+        assert counts.get(a1) == 7
+        assert counts.get(a2) == 2
+
+    def test_empty_input(self):
+        from app.core.db import count_chunks_batch
+        assert count_chunks_batch([]) == {}
+
+    def test_missing_agent_omitted(self):
+        # An agent with no chunks doesn't appear in the result dict
+        from app.core.db import count_chunks_batch
+        counts = count_chunks_batch(["nonexistent-id"])
+        assert "nonexistent-id" not in counts
+
+
 class TestSparseDataDegradation:
     """A fresh book or mind with no chunks / no questions / no links still
     needs to render without crashing. The page is allowed to be thin in


### PR DESCRIPTION
Defensive measures against the 'A World Brewed' data-quality issue.

**A. Sitemap chunk-count gate** — /q/ URLs only included when book has ≥5 indexed chunks. Catalog stubs and mis-indexed books stop being advertised as Q&A pages.

**B. scripts/audit_book_quality.py** — read-only classifier (HIGH/MEDIUM/LOW/STUB/MISMATCH). Catches the 'agent name says X, chunks say Y' case. CSV output, zero LLM cost.

245/245 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)