### PR TITLE
feat(seo): branded landing-page chrome — logo header + typography + max-width + footer

### DIFF
--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -1215,6 +1215,68 @@ def is_internal_referer(referer: str, site_url: str) -> bool:
     return bool(site_host) and referer_host == site_host
 
 
+# ─── Landing-page chrome (header + footer + CSS) ──────────────────────
+#
+# Shared across every SSR landing page so the visual treatment is
+# consistent (book, mind, topic, /q/, /on/, /insights, /dialogues,
+# /discussions). CSS lives in app/static/seo-landing.css; helpers below
+# emit the `<link>`, the brand header, and the site footer.
+#
+# Why a separate stylesheet (vs inline): one file, browser-cached on
+# first hit, no re-download per page. ~5KB compressed.
+
+LANDING_CSS_PATH = "/static/seo-landing.css"
+
+
+def landing_css_link() -> str:
+    """The single ``<link>`` tag every SSR landing page should put in
+    its ``<head>``. Versioned via a query param so changes invalidate
+    the browser cache deterministically."""
+    return f'<link rel="stylesheet" href="{LANDING_CSS_PATH}?v=1">'
+
+
+def render_landing_header(site_url: str) -> str:
+    """Brand header — Feynman logo + tagline on the left, primary CTA
+    on the right. Same shape across all landing pages so visitors who
+    arrive from search recognize the brand and have one obvious way to
+    open the app."""
+    return (
+        '<header class="feynman-header">'
+        f'<a class="feynman-brand" href="{_esc(site_url)}/">'
+        '<svg viewBox="0 0 280 64" xmlns="http://www.w3.org/2000/svg" aria-label="Feynman">'
+        '<line x1="8" y1="58" x2="32" y2="30" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>'
+        '<line x1="32" y1="30" x2="56" y2="58" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>'
+        '<line x1="20" y1="44" x2="44" y2="44" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>'
+        '<circle cx="32" cy="14" r="6" fill="currentColor"/>'
+        '<text x="76" y="42" font-family="Inter, -apple-system, sans-serif" '
+        'font-size="26" font-weight="600" fill="currentColor">Feynman</text>'
+        '</svg>'
+        '</a>'
+        '<nav class="feynman-nav">'
+        f'<a href="{_esc(site_url)}/#/library">Library</a>'
+        f'<a href="{_esc(site_url)}/#/minds">Great Minds</a>'
+        f'<a class="feynman-cta" href="{_esc(site_url)}/">Open Feynman →</a>'
+        '</nav>'
+        '</header>'
+    )
+
+
+def render_site_footer(site_url: str) -> str:
+    """Small footer at the absolute bottom of every landing page.
+    Different from the Explore footer (which lists neighbor entities) —
+    this is site-wide chrome: brand mark, legal links, repo link."""
+    return (
+        '<footer class="feynman-site-footer">'
+        f'<span>© Feynman — an interactive knowledge network</span>'
+        '<span>'
+        f'<a href="{_esc(site_url)}/terms">Terms</a> · '
+        f'<a href="{_esc(site_url)}/privacy">Privacy</a> · '
+        '<a href="https://github.com/steveyeow/feynman">GitHub</a>'
+        '</span>'
+        '</footer>'
+    )
+
+
 # ─── Word/structure counters (used by tests to enforce density floors) ─
 
 _TAG_RE = re.compile(r"<[^>]+>")

--- a/app/main.py
+++ b/app/main.py
@@ -1394,10 +1394,12 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
 <meta name="twitter:image:alt" content="{og_image_alt}">
+{seo_render.landing_css_link()}
 {book_ld}
 {breadcrumb_ld}
 {faq_ld}
 </head><body{body_style}>
+{seo_render.render_landing_header(base)}
 <h1>{title}</h1>
 {author_html}
 {about_html}
@@ -1410,6 +1412,7 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {topic_link_html}
 {cta_html}
 {explore_footer_html}
+{seo_render.render_site_footer(base)}
 {redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
@@ -1612,9 +1615,11 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
 <meta name="twitter:image:alt" content="{og_image_alt}">
+{seo_render.landing_css_link()}
 {person_ld}
 {breadcrumb_ld}
 </head><body{body_style}>
+{seo_render.render_landing_header(base)}
 <h1>{name}</h1>
 {era_domain_html}
 {bio_html}
@@ -1627,6 +1632,7 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 {topic_links_html}
 <p class="cta"><a href="{html_esc(reader_url)}">Chat with {name} on Feynman →</a></p>
 {explore_footer_html}
+{seo_render.render_site_footer(base)}
 {redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
@@ -1748,15 +1754,18 @@ def book_question_page(agent_id: str, question_slug: str, request: Request) -> H
 <meta name="twitter:title" content="{html_esc(question)}">
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
+{seo_render.landing_css_link()}
 {qa_ld}
 {breadcrumb_ld}
 </head><body>
+{seo_render.render_landing_header(base)}
 <nav class="qa-back"><a href="{book_url}">← {title}</a></nav>
 <h1>{html_esc(question)}</h1>
 {answer_html}
 {passages_html}
 {siblings_html}
 <p class="cta"><a href="{html_esc(chat_url)}">Chat about this question →</a></p>
+{seo_render.render_site_footer(base)}
 </body></html>"""
     _cache_set(cache_key, html)
     return HTMLResponse(
@@ -1862,9 +1871,11 @@ def mind_on_topic_page(mind_id: str, topic_slug: str, request: Request) -> HTMLR
 <meta name="twitter:title" content="{html_esc(f'How {name_raw} would approach {topic}')}">
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
+{seo_render.landing_css_link()}
 {article_ld}
 {breadcrumb_ld}
 </head><body>
+{seo_render.render_landing_header(base)}
 <nav class="essay-back"><a href="{mind_url}">← {name}</a></nav>
 <h1>How {name} would approach {html_esc(topic)}</h1>
 {essay_html}
@@ -1873,6 +1884,7 @@ def mind_on_topic_page(mind_id: str, topic_slug: str, request: Request) -> HTMLR
   <a href="{topic_hub_url}">{html_esc(topic)} on Feynman</a>
 </p>
 <p class="cta"><a href="{html_esc(chat_url)}">Chat with {name} →</a></p>
+{seo_render.render_site_footer(base)}
 </body></html>"""
     _cache_set(cache_key, html)
     return HTMLResponse(
@@ -2016,9 +2028,11 @@ def book_insights_page(agent_id: str, request: Request) -> HTMLResponse:
 <meta name="twitter:title" content="{title}">
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
+{seo_render.landing_css_link()}
 {article_ld}
 {breadcrumb_ld}
 </head><body>
+{seo_render.render_landing_header(base)}
 <nav class="insights-back"><a href="{entity_canonical}">← {entity_name}</a></nav>
 <h1>AI insights about {entity_name}</h1>
 <p class="insights-intro">Accumulated AI-synthesized commentary drawn from
@@ -2027,6 +2041,7 @@ the text. The AI's responses are published; user questions remain private.</p>
 {cards_html}
 {empty_html}
 <p class="cta"><a href="{html_esc(chat_url)}">Chat with {entity_name} →</a></p>
+{seo_render.render_site_footer(base)}
 </body></html>"""
     _cache_set(cache_key, html)
     return HTMLResponse(
@@ -2138,9 +2153,11 @@ def mind_dialogues_page(mind_id: str, request: Request) -> HTMLResponse:
 <meta name="twitter:title" content="{title}">
 <meta name="twitter:description" content="{desc}">
 <meta name="twitter:image" content="{og_image_url}">
+{seo_render.landing_css_link()}
 {article_ld}
 {breadcrumb_ld}
 </head><body>
+{seo_render.render_landing_header(base)}
 <nav class="insights-back"><a href="{entity_canonical}">← {entity_name}</a></nav>
 <h1>AI dialogues with {entity_name}</h1>
 <p class="insights-intro">Accumulated AI agent responses from real user
@@ -2149,6 +2166,7 @@ The agent's responses are published; user questions remain private.</p>
 {cards_html}
 {empty_html}
 <p class="cta"><a href="{html_esc(chat_url)}">Chat with {entity_name} →</a></p>
+{seo_render.render_site_footer(base)}
 </body></html>"""
     _cache_set(cache_key, html)
     return HTMLResponse(
@@ -2277,15 +2295,18 @@ def topic_page(slug: str, request: Request) -> HTMLResponse:
 <meta name="twitter:site" content="@steve_yeow">
 <meta name="twitter:title" content="{title}">
 <meta name="twitter:description" content="{desc}">
+{seo_render.landing_css_link()}
 {collection_ld}
 {breadcrumb_ld}
 </head><body>
+{seo_render.render_landing_header(base)}
 <h1>{html_esc(topic)}</h1>
 {intro_html}
 {books_html}
 {minds_html}
 <p class="cta"><a href="{base}/#/library">Explore the full Feynman library →</a></p>
 {explore_footer_html}
+{seo_render.render_site_footer(base)}
 </body></html>"""
     _cache_set(cache_key, html)
     return HTMLResponse(
@@ -2598,13 +2619,16 @@ def _render_public_discussions_page(
 <meta property="og:description" content="{desc}">
 <meta property="og:url" content="{entity_canonical}/discussions">
 <meta property="og:site_name" content="Feynman">
+{seo_render.landing_css_link()}
 {forum_ld}
 {breadcrumb_ld}
 </head><body>
+{seo_render.render_landing_header(_SITE_URL)}
 <nav class="back-link"><a href="{entity_canonical}">← {html_esc(entity_name)}</a></nav>
 <h1>Discussions about {html_esc(entity_name)}</h1>
 {posts_html}
 <p class="cta"><a href="{html_esc(chat_url)}">Start your own chat →</a></p>
+{seo_render.render_site_footer(_SITE_URL)}
 </body></html>"""
 
 

--- a/app/static/seo-landing.css
+++ b/app/static/seo-landing.css
@@ -1,0 +1,315 @@
+/* SEO landing-page stylesheet.
+ *
+ * Loaded by all SSR landing pages (/book/{id}, /mind/{id}, /topic/{slug},
+ * /book/{id}/q/{slug}, /mind/{id}/on/{slug}, /book/{id}/insights,
+ * /mind/{id}/dialogues, /book/{id}/discussions). The SPA at /#/... has
+ * its own separate stylesheet (styles.css); this file is intentionally
+ * small and standalone so it loads fast for first-paint on share links
+ * and search-result clicks.
+ *
+ * Constraints:
+ *  - No external font requests beyond what the SPA already loads —
+ *    re-use Inter + Libre Baskerville from Google Fonts.
+ *  - Match the SPA brand palette (#0071e3 accent, #1d1d1f text on
+ *    #ffffff body, with dark-mode counterparts) so users who navigate
+ *    from landing to SPA don't feel a jarring re-skin.
+ *  - Body styles only — never set `display: none` on .opacity-zero
+ *    bodies because the handler uses `opacity:0` for non-crawler
+ *    visitors during the JS redirect; CSS must not interfere.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Libre+Baskerville:wght@400;700&display=swap');
+
+:root {
+  --feynman-text: #1d1d1f;
+  --feynman-text-secondary: #6e6e73;
+  --feynman-text-tertiary: #a1a1a6;
+  --feynman-bg: #ffffff;
+  --feynman-bg-subtle: #f5f5f7;
+  --feynman-border: rgba(0, 0, 0, 0.08);
+  --feynman-border-strong: rgba(0, 0, 0, 0.14);
+  --feynman-accent: #0071e3;
+  --feynman-accent-hover: #0058b3;
+  --feynman-quote-bg: #f9f9fb;
+  --feynman-quote-border: #e0e0e3;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --feynman-text: #f5f5f7;
+    --feynman-text-secondary: #a1a1a6;
+    --feynman-text-tertiary: #6e6e73;
+    --feynman-bg: #1c1c1e;
+    --feynman-bg-subtle: #2c2c2e;
+    --feynman-border: rgba(255, 255, 255, 0.10);
+    --feynman-border-strong: rgba(255, 255, 255, 0.18);
+    --feynman-accent: #0a84ff;
+    --feynman-accent-hover: #409cff;
+    --feynman-quote-bg: #232325;
+    --feynman-quote-border: rgba(255, 255, 255, 0.08);
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--feynman-bg);
+  color: var(--feynman-text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ─── Header (logo + nav) ────────────────────────────────────────── */
+
+.feynman-header {
+  border-bottom: 1px solid var(--feynman-border);
+  padding: 18px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.feynman-header a.feynman-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--feynman-text);
+  font-weight: 600;
+  font-size: 19px;
+  letter-spacing: -0.01em;
+}
+.feynman-header a.feynman-brand svg {
+  height: 28px;
+  width: auto;
+}
+.feynman-header .feynman-nav {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  font-size: 15px;
+}
+.feynman-header .feynman-nav a {
+  color: var(--feynman-text-secondary);
+  text-decoration: none;
+}
+.feynman-header .feynman-nav a:hover { color: var(--feynman-text); }
+.feynman-header .feynman-nav a.feynman-cta {
+  background: var(--feynman-accent);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-weight: 500;
+}
+.feynman-header .feynman-nav a.feynman-cta:hover {
+  background: var(--feynman-accent-hover);
+  color: #fff;
+}
+
+/* ─── Main content container ─────────────────────────────────────── */
+
+main, body > h1, body > nav.qa-back, body > nav.insights-back,
+body > nav.essay-back, body > nav.back-link, body > nav.feynman-page-nav,
+body > p, body > section, body > article, body > footer,
+body > ol, body > ul, body > blockquote {
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+body > h1 { margin-top: 36px; }
+
+/* ─── Typography ────────────────────────────────────────────────── */
+
+h1, h2, h3 {
+  font-family: 'Libre Baskerville', Georgia, 'Times New Roman', serif;
+  font-weight: 700;
+  color: var(--feynman-text);
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+h1 {
+  font-size: 36px;
+  margin: 0.4em 0 0.6em;
+}
+h2 {
+  font-size: 24px;
+  margin: 2em 0 0.6em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--feynman-border);
+}
+h3 { font-size: 19px; margin: 1.6em 0 0.4em; }
+
+p { margin: 0.6em 0; color: var(--feynman-text); }
+
+a {
+  color: var(--feynman-accent);
+  text-decoration: underline;
+  text-decoration-color: rgba(0, 113, 227, 0.35);
+  text-underline-offset: 2px;
+}
+a:hover {
+  color: var(--feynman-accent-hover);
+  text-decoration-color: currentColor;
+}
+
+ul, ol { padding-left: 1.4em; }
+li { margin: 0.25em 0; }
+
+small { color: var(--feynman-text-tertiary); font-size: 14px; }
+
+/* ─── Section + content blocks ───────────────────────────────────── */
+
+section { margin: 1.5em auto; }
+section > ul.toc { list-style: decimal; padding-left: 1.6em; }
+
+blockquote {
+  margin: 1em auto;
+  padding: 16px 20px;
+  background: var(--feynman-quote-bg);
+  border-left: 3px solid var(--feynman-quote-border);
+  border-radius: 6px;
+  color: var(--feynman-text);
+}
+blockquote p { margin: 0 0 0.5em; }
+blockquote p:last-child { margin-bottom: 0; }
+blockquote footer { color: var(--feynman-text-tertiary); font-size: 13px; }
+
+q {
+  display: inline-block;
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-style: italic;
+  color: var(--feynman-text);
+}
+
+article.insight-card,
+article.public-post {
+  background: var(--feynman-bg-subtle);
+  padding: 18px 22px;
+  border-radius: 10px;
+  /* Use `auto` for left/right so the body>article max-width centering
+   * rule isn't overridden by this higher-specificity class selector. */
+  margin: 16px auto;
+  border: 1px solid var(--feynman-border);
+}
+article.insight-card p,
+article.public-post p { margin: 0.5em 0; }
+
+p.book-author { color: var(--feynman-text-secondary); font-size: 18px; margin-top: 0; }
+p.book-stats, p.mind-meta { color: var(--feynman-text-secondary); font-size: 14px; }
+p.book-about { font-size: 19px; line-height: 1.55; }
+
+p.insights-intro { color: var(--feynman-text-secondary); font-size: 16px; }
+p.qa-attribution, p.essay-attribution,
+p.insights-attribution small,
+p.post-cta { color: var(--feynman-text-tertiary); font-size: 14px; margin-top: 1em; }
+
+p.topic-intro { font-size: 19px; line-height: 1.55; color: var(--feynman-text); }
+p.topic-link-back { color: var(--feynman-text-secondary); }
+p.topic-links { font-size: 15px; color: var(--feynman-text-secondary); }
+p.topic-links a { white-space: nowrap; }
+
+/* ─── CTA buttons ────────────────────────────────────────────────── */
+
+/* `auto` left/right preserves the body>p max-width centering rule —
+ * a plain `margin: 2em 0` would override it via class specificity. */
+p.cta, p.cta-row { margin: 2em auto 1.2em; }
+.cta-btn,
+p.cta > a {
+  display: inline-block;
+  background: var(--feynman-accent);
+  color: #fff !important;
+  padding: 12px 22px;
+  border-radius: 10px;
+  font-weight: 500;
+  text-decoration: none;
+  margin-right: 8px;
+  transition: background 120ms ease;
+}
+.cta-btn:hover,
+p.cta > a:hover { background: var(--feynman-accent-hover); color: #fff !important; }
+
+.cta-btn.cta-chat,
+.cta-btn.cta-preview {
+  background: transparent;
+  color: var(--feynman-accent) !important;
+  border: 1px solid var(--feynman-accent);
+}
+.cta-btn.cta-chat:hover,
+.cta-btn.cta-preview:hover {
+  background: var(--feynman-accent-light, rgba(0,113,227,0.08));
+  color: var(--feynman-accent) !important;
+}
+
+/* ─── Back-link navigation (Q&A, insights, mind essay) ───────────── */
+
+nav.qa-back, nav.insights-back, nav.essay-back, nav.back-link {
+  margin-top: 24px;
+  font-size: 15px;
+}
+nav.qa-back a, nav.insights-back a, nav.essay-back a, nav.back-link a {
+  color: var(--feynman-text-secondary);
+  text-decoration: none;
+}
+nav.qa-back a:hover, nav.insights-back a:hover,
+nav.essay-back a:hover, nav.back-link a:hover {
+  color: var(--feynman-text);
+  text-decoration: underline;
+}
+
+/* ─── Footer (Explore links) ─────────────────────────────────────── */
+
+footer.explore-footer {
+  margin: 3em auto 4em;
+  padding-top: 1.5em;
+  border-top: 1px solid var(--feynman-border);
+  color: var(--feynman-text-tertiary);
+}
+footer.explore-footer a {
+  color: var(--feynman-text-secondary);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--feynman-border-strong);
+}
+footer.explore-footer a:hover { color: var(--feynman-accent); border-bottom-color: var(--feynman-accent); }
+
+/* ─── Site footer (small "Powered by Feynman") ───────────────────── */
+
+footer.feynman-site-footer {
+  max-width: 760px;
+  margin: 4em auto 2em;
+  padding: 1.5em 24px 0;
+  border-top: 1px solid var(--feynman-border);
+  color: var(--feynman-text-tertiary);
+  font-size: 13px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+footer.feynman-site-footer a {
+  color: var(--feynman-text-secondary);
+  text-decoration: none;
+}
+footer.feynman-site-footer a:hover { color: var(--feynman-text); }
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  html, body { font-size: 16px; }
+  h1 { font-size: 28px; }
+  h2 { font-size: 21px; }
+  .feynman-header { padding: 14px 16px; flex-wrap: wrap; gap: 12px; }
+  .feynman-header .feynman-nav { gap: 14px; font-size: 14px; }
+  body > h1, body > p, body > section, body > article, body > footer,
+  body > ol, body > ul, body > blockquote, body > nav { padding-left: 16px; padding-right: 16px; }
+  footer.feynman-site-footer { padding: 1.5em 16px 0; flex-direction: column; align-items: flex-start; }
+}


### PR DESCRIPTION
Plain HTML SSR pages were SEO-functional but UX-unfriendly. This adds ~200 lines of CSS plus Feynman logo header + site footer shared across all 9 SSR landing routes. Brand palette matches SPA. Locally verified via uvicorn + preview screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)