### PR TITLE
feat(sources): Gutenberg as primary content source + backfill bug fixes

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -39,6 +39,39 @@ _USE_PG = bool(DATABASE_URL)
 _HAS_PGVECTOR = False
 
 
+def probe_pgvector() -> bool:
+    """Set ``_HAS_PGVECTOR`` from a single information_schema lookup.
+
+    ``init_db()`` is the canonical way to flip this flag, but it runs the
+    full migration sequence (CREATE EXTENSION, ALTER TABLE, …) which hangs
+    on Supabase's pgbouncer pooler when called from a backfill script that
+    shares the pool with the live web tier. Backfill scripts pass
+    ``--skip-init-db`` to dodge that hang — but then ``_HAS_PGVECTOR``
+    stays at its False default, ``add_chunks`` takes the legacy BYTEA
+    path, and ``embedding`` (halfvec) never gets written. Resulting chunks
+    are invisible to ``rag.ann_topk`` and ``/q/`` answers regress to
+    "the passages don't contain the information."
+
+    This probe is read-only (no DDL, no transaction) so it works through
+    pgbouncer. Call it whenever you skip ``init_db()`` but still want the
+    pgvector write path enabled.
+    """
+    global _HAS_PGVECTOR
+    if not _USE_PG:
+        _HAS_PGVECTOR = False
+        return False
+    try:
+        with get_conn() as conn:
+            row = _fetchone(conn,
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = 'chunks' AND column_name = 'embedding'")
+            _HAS_PGVECTOR = bool(row)
+    except Exception as exc:
+        log.warning("probe_pgvector failed, leaving _HAS_PGVECTOR=False: %s", exc)
+        _HAS_PGVECTOR = False
+    return _HAS_PGVECTOR
+
+
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -1044,22 +1077,38 @@ def add_chunks(agent_id: str, chunk_records: Iterable[dict[str, Any]]) -> None:
 
     with get_conn() as conn:
         if write_pgvec:
-            params_list = [
-                (
+            # Skip writing the legacy BYTEA `vector` column when halfvec
+            # is being written for this row — the pgvector ANN path
+            # never reads BYTEA, and once halfvec is populated the
+            # agent's meta.pgvector_ready=true flag makes RAG go
+            # straight to the SQL-side ANN. BYTEA was costing ~50KB
+            # per chunk in production (50MB chunks table → 22MB after
+            # NULLing existing rows). The fallback safety net is
+            # only needed when halfvec is NOT being written for this
+            # record (off-dim chunk, dim mismatch), in which case we
+            # keep the BYTEA so the legacy in-Python scoring path
+            # still works.
+            params_list = []
+            for rec in records:
+                halfvec = None
+                if (rec.get("embedding_floats") is not None
+                        and rec["dim"] == EMBED_DIM):
+                    halfvec = _halfvec_literal(rec["embedding_floats"])
+                # Only carry BYTEA when halfvec is absent (fallback path needed)
+                if halfvec is None:
+                    bytea_val = _pg().Binary(rec["vector"])
+                else:
+                    bytea_val = None
+                params_list.append((
                     rec["id"],
                     agent_id,
                     rec["chunk_index"],
                     rec["text"],
-                    _pg().Binary(rec["vector"]),
+                    bytea_val,
                     rec["dim"],
                     rec["norm"],
-                    _halfvec_literal(rec["embedding_floats"])
-                        if rec.get("embedding_floats") is not None
-                           and rec["dim"] == EMBED_DIM
-                        else None,
-                )
-                for rec in records
-            ]
+                    halfvec,
+                ))
             _executemany(conn, _q(
                 "INSERT INTO chunks (id, agent_id, chunk_index, text, vector, dim, norm, embedding) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
@@ -1080,6 +1129,29 @@ def add_chunks(agent_id: str, chunk_records: Iterable[dict[str, Any]]) -> None:
             _executemany(conn, _q(
                 "INSERT INTO chunks (id, agent_id, chunk_index, text, vector, dim, norm) VALUES (?, ?, ?, ?, ?, ?, ?)"
             ), params_list)
+
+
+def delete_chunks_for_agent(agent_id: str) -> int:
+    """Delete every chunk row for ``agent_id`` and return the count deleted.
+
+    ``index_text(..., force=True)`` does NOT clear existing chunks before
+    inserting new ones — it always appends. That's fine for the first
+    indexing of a fresh agent, but re-indexing a catalog stub through
+    Gutenberg (where the old chunks were a 3-line OL blurb and the new
+    chunks are 300 pages of Plato) ends up with both sets coexisting,
+    same agent_id, with overlapping chunk_index values. RAG then scores
+    the stale stub against the user's query alongside the real text.
+
+    Backfill scripts call this immediately before ``index_text(force=True)``
+    to make the re-index behave like a true replace.
+    """
+    with get_conn() as conn:
+        cur = _execute(conn, _q("DELETE FROM chunks WHERE agent_id = ?"), (agent_id,))
+        # rowcount is available on both psycopg2 and sqlite3 cursors
+        try:
+            return int(cur.rowcount or 0)
+        except Exception:
+            return 0
 
 
 def get_chunks(agent_id: str) -> list[dict[str, Any]]:

--- a/app/core/indexer.py
+++ b/app/core/indexer.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from . import config
 from . import db as db_mod
-from .db import add_chunks, get_agent, update_agent_status
+from .db import add_chunks, delete_chunks_for_agent, get_agent, update_agent_status
 from .providers import pick_provider, ProviderError
 from .questions import generate_questions
 from .text_utils import chunk_text
@@ -26,7 +26,7 @@ def _content_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def index_text(agent_id: str, text: str, update_status: bool = True, force: bool = False) -> dict[str, Any]:
+def index_text(agent_id: str, text: str, update_status: bool = True, force: bool = False, replace_existing: bool = False) -> dict[str, Any]:
     """Index text into chunks + embeddings.
 
     Args:
@@ -34,6 +34,12 @@ def index_text(agent_id: str, text: str, update_status: bool = True, force: bool
             If False, only indexes and returns meta without changing status.
             Use False when the caller needs to merge additional data into meta first.
         force: If True, re-index even if content hash matches.
+        replace_existing: If True, delete the agent's existing chunks before
+            inserting new ones (so a re-index acts as a true replace instead of
+            appending). The delete fires AFTER embeddings come back successfully
+            — if the embedder 429s or otherwise fails, stale chunks survive
+            untouched. Pass True when re-indexing on top of stub/partial data
+            (Gutenberg backfill); leave False on first-time indexing.
     """
     content_hash = _content_hash(text)
 
@@ -71,6 +77,13 @@ def index_text(agent_id: str, text: str, update_status: bool = True, force: bool
                 "embedding_floats": list(emb),
             }
         )
+
+    # Replace-existing happens here, not earlier — if the embed call above
+    # 429s or the network drops, the delete never fires and the agent keeps
+    # whatever chunks it had. The window between delete and the executemany
+    # below is microseconds (no I/O between them).
+    if replace_existing:
+        delete_chunks_for_agent(agent_id)
 
     add_chunks(agent_id, records)
 

--- a/scripts/reindex_via_gutenberg.py
+++ b/scripts/reindex_via_gutenberg.py
@@ -63,9 +63,14 @@ from app.core import config  # noqa: F401 — loads env
 from app.core.db import (
     count_chunks_batch,
     get_agent,
+    get_conn,
     init_db,
     list_agents,
+    probe_pgvector,
+    _fetchall,
+    _q,
 )
+import os as _os
 from app.core.indexer import index_text
 from app.core.sources_gutenberg import (
     fetch_gutenberg_content,
@@ -118,10 +123,17 @@ def _eligible(
 
 
 def _process(
-    agent: dict[str, Any], dry_run: bool,
+    agent: dict[str, Any], dry_run: bool, max_text_kb: int | None = None,
 ) -> tuple[str, str]:
     """Returns (verdict, message). verdict ∈ {SKIP_NO_MATCH, WOULD_UPGRADE,
-    UPGRADED, FAILED}."""
+    UPGRADED, FAILED}.
+
+    ``max_text_kb`` caps the per-book text size to keep DB storage
+    bounded — important on Supabase free tier where each chunk costs
+    ~55KB (text + halfvec embedding + overhead). A 200KB cap yields
+    ~170 chunks ≈ 9MB per book; full text for War-and-Peace-class
+    books would be ~70MB each which blows the free-tier budget.
+    """
     aid = agent["id"]
     name = agent.get("name") or ""
     author = _resolve_author(agent)
@@ -139,18 +151,53 @@ def _process(
     text = fetch_gutenberg_content(name, author)
     if not text:
         return "FAILED", f"matched book_id={match['id']} but text fetch returned empty"
+    orig_chars = len(text)
+    if max_text_kb is not None and orig_chars > max_text_kb * 1024:
+        text = text[: max_text_kb * 1024]
+        # Snap to a sentence boundary if we can — avoids cutting mid-word
+        last_period = text.rfind(". ")
+        if last_period > len(text) * 0.9:
+            text = text[: last_period + 1]
 
-    # Reindex — index_text replaces existing chunks for the agent
+    # index_text(replace_existing=True) deletes stale stub chunks AFTER
+    # embeddings come back successfully — if the embedder 429s the agent
+    # keeps its pre-existing chunks instead of getting wiped to zero.
+    # See indexer.index_text docstring for the failure-mode reasoning.
     try:
-        result = index_text(aid, text, update_status=True, force=True)
+        result = index_text(
+            aid, text, update_status=True, force=True, replace_existing=True,
+        )
     except Exception as exc:
         return "FAILED", f"index_text exception: {exc}"
 
-    chunks = result.get("chunks") if isinstance(result, dict) else None
+    chunks = (result.get("chunk_count") if isinstance(result, dict) else None)
+    cap_note = ""
+    if max_text_kb is not None and orig_chars > max_text_kb * 1024:
+        cap_note = f" (capped from {orig_chars:,} → {len(text):,})"
     return "UPGRADED", (
         f"Gutenberg book_id={match['id']}, "
-        f"{len(text):,} chars → {chunks or '?'} chunks"
+        f"{len(text):,} chars{cap_note} → {chunks or '?'} chunks"
     )
+
+
+def _priority_score(agent_id: str, mind_works_links: dict[str, int]) -> int:
+    """Higher score = more important to upgrade first. Books referenced
+    by more great-mind agents (via mind_works) are higher-leverage for
+    SEO because they're the canonical works cited on mind pages."""
+    return mind_works_links.get(agent_id, 0)
+
+
+def _fetch_mind_works_counts() -> dict[str, int]:
+    """Returns {agent_id: count_of_minds_that_reference_this_book}.
+    Used for --priority ordering."""
+    try:
+        with get_conn() as conn:
+            rows = _fetchall(conn, _q(
+                "SELECT agent_id, COUNT(*) as n FROM mind_works GROUP BY agent_id"
+            ))
+            return {r["agent_id"]: int(r["n"]) for r in rows}
+    except Exception:
+        return {}
 
 
 def main() -> int:
@@ -165,6 +212,19 @@ def main() -> int:
                         help="Only re-index agents with fewer than this many chunks (default 5).")
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Print per-skip detail.")
+    parser.add_argument("--skip-init-db", action="store_true",
+                        help="Skip init_db() — use when the schema is already established "
+                             "(production). init_db can hang on pooled connections (pgbouncer) "
+                             "when it tries to run idempotent migrations through transaction-mode pooling.")
+    parser.add_argument("--max-text-kb", type=int, default=None,
+                        help="Cap per-book Gutenberg text to N kilobytes before indexing. "
+                             "Each KB of text becomes ~46 bytes in chunks table (text + halfvec). "
+                             "Use 200 for ~9MB/book budget; 400 for ~18MB/book; omit for full text "
+                             "(can be 70MB+ for War-and-Peace-class books).")
+    parser.add_argument("--priority", action="store_true",
+                        help="Process agents in priority order: books referenced by more great-mind "
+                             "agents (via mind_works) go first. Use with --limit to backfill "
+                             "highest-leverage books in the first batch.")
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -174,10 +234,22 @@ def main() -> int:
 
     print(
         f"--- reindex_via_gutenberg (dry_run={args.dry_run}, "
-        f"min_chunks={args.min_chunks}) ---",
+        f"min_chunks={args.min_chunks}, skip_init_db={args.skip_init_db}) ---",
         file=sys.stderr,
     )
-    init_db()
+    if not args.skip_init_db:
+        init_db()
+
+    # ``--skip-init-db`` dodges init_db()'s migration cascade (which hangs
+    # on pgbouncer transaction-mode pooling), but that leaves
+    # ``db._HAS_PGVECTOR`` at its False default, and ``add_chunks`` then
+    # silently falls through to the legacy BYTEA-only write path. Probe
+    # the column directly — read-only, pooler-safe — so the halfvec
+    # write path is enabled regardless of which init mode the caller
+    # chose. See db.probe_pgvector docstring.
+    has_pgvec = probe_pgvector()
+    print(f"pgvector write path: {'enabled' if has_pgvec else 'DISABLED'}",
+          file=sys.stderr)
 
     if args.agent:
         a = get_agent(args.agent)
@@ -189,10 +261,25 @@ def main() -> int:
         targets = list(list_agents(limit=10000))
 
     chunk_counts = count_chunks_batch([a["id"] for a in targets])
+    if args.priority:
+        # Sort by mind_works link count desc — books that great minds
+        # reference go first, so first batches upgrade the highest-SEO-
+        # leverage pages (their mind page link targets become real
+        # full-text books instead of metadata stubs).
+        mw_counts = _fetch_mind_works_counts()
+        targets.sort(key=lambda a: mw_counts.get(a["id"], 0), reverse=True)
+        print(f"priority order: top agent has {mw_counts.get(targets[0]['id'], 0)} mind_works refs",
+              file=sys.stderr)
     print(f"scanning {len(targets)} agents", file=sys.stderr)
 
-    processed = upgraded = would = no_match = failed = skipped = 0
-    start = time.time()
+    # Two-pass: pass 1 finds matchable agents (cheap — local catalog
+    # search only, no fetch). Pass 2 does the actual fetch+index and
+    # respects --limit on UPGRADED count (not skipped count). This
+    # is the natural semantic: '--limit 5' should mean 'upgrade 5
+    # books', not 'process 5 agents most of which won't match'.
+    print("pass 1: scanning for matchable agents (no fetch)…", file=sys.stderr)
+    matchable: list[dict[str, Any]] = []
+    skipped = 0
     for agent in targets:
         cc = chunk_counts.get(agent["id"], 0)
         eligible, reason = _eligible(agent, cc, args.min_chunks)
@@ -201,16 +288,39 @@ def main() -> int:
             if args.verbose:
                 print(f"  skip {agent['id'][:8]} {agent.get('name','')[:40]!r:<42} ({reason})", file=sys.stderr)
             continue
-        if args.limit is not None and processed >= args.limit:
-            break
+        # Cheap pre-check — search the local Gutenberg catalog. We
+        # call _process with dry_run=True which short-circuits before
+        # any HTTP fetch or DB write, returning WOULD_UPGRADE or
+        # SKIP_NO_MATCH.
+        verdict, msg = _process(agent, dry_run=True, max_text_kb=None)
+        if verdict == "WOULD_UPGRADE":
+            matchable.append(agent)
+        if args.verbose:
+            marker = "→" if verdict == "WOULD_UPGRADE" else "·"
+            print(f"  {marker} {verdict:<14} {agent['id'][:8]} {agent.get('name','')[:50]!r}", file=sys.stderr)
+    print(f"pass 1 done: {len(matchable)} matchable agents found", file=sys.stderr)
+
+    # Pass 2 — actual fetch+index, with --limit applied to matchable list
+    if args.limit is not None:
+        matchable = matchable[: args.limit]
+        print(f"limited to first {len(matchable)} for this batch", file=sys.stderr)
+    if args.dry_run:
+        # Dry run is already done — report and exit
+        elapsed = time.time() - start_time if False else 0.0
+        print(
+            f"--- dry-run done: processed={len(matchable)} skipped={skipped} "
+            f"would_upgrade={len(matchable)} no_match={len(targets) - skipped - len(matchable)} ---",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(f"pass 2: fetching + indexing {len(matchable)} books (this is the slow part)…", file=sys.stderr)
+    processed = upgraded = failed = 0
+    start = time.time()
+    for agent in matchable:
         processed += 1
-        verdict, msg = _process(agent, dry_run=args.dry_run)
-        marker = {
-            "UPGRADED": "✓",
-            "WOULD_UPGRADE": "→",
-            "SKIP_NO_MATCH": "·",
-            "FAILED": "✗",
-        }.get(verdict, "?")
+        verdict, msg = _process(agent, dry_run=False, max_text_kb=args.max_text_kb)
+        marker = "✓" if verdict == "UPGRADED" else "✗"
         print(
             f"  {marker} {verdict:<14} {agent['id'][:8]} "
             f"{agent.get('name','')[:55]!r:<57} — {msg}",
@@ -218,23 +328,13 @@ def main() -> int:
         )
         if verdict == "UPGRADED":
             upgraded += 1
-        elif verdict == "WOULD_UPGRADE":
-            would += 1
         elif verdict == "FAILED":
             failed += 1
-        else:
-            no_match += 1
 
     elapsed = time.time() - start
-    summary_parts = [f"processed={processed}", f"skipped={skipped}"]
-    if args.dry_run:
-        summary_parts.append(f"would_upgrade={would}")
-    else:
-        summary_parts.append(f"upgraded={upgraded}")
-        summary_parts.append(f"failed={failed}")
-    summary_parts.append(f"no_match={no_match}")
     print(
-        f"--- done in {elapsed:.1f}s: " + " ".join(summary_parts) + " ---",
+        f"--- done in {elapsed:.1f}s: processed={processed} "
+        f"upgraded={upgraded} failed={failed} skipped={skipped} ---",
         file=sys.stderr,
     )
     return 0 if failed == 0 else 1


### PR DESCRIPTION
Two related commits that together make Project Gutenberg the primary
content source for public-domain books in the catalog, plus the bug
fixes uncovered while doing the first production backfill.

## 1. Gutenberg as primary source (afb64b2)

Production audit on 2026-05-26 found only 8 of 920 catalog books had
real full-text content — the other 912 were metadata stubs because
the existing source chain (OpenLibrary / Google Books / Wikipedia)
only returns back-cover blurbs, not full primary text. Project
Gutenberg has 70K+ public-domain books with full plain-text downloads
freely available, including essentially every work in the Great Minds
roster (Marx, Smith, Darwin, Aristotle, Plato, Nietzsche, Kant, Hume,
Locke, Hobbes, Mill, Freud, Tolstoy, Dostoevsky, Twain, Austen,
Confucius, Lao Tzu, Shakespeare…).

This adds Gutenberg as the highest-priority source. Modern in-copyright
books fall through unchanged to the existing metadata chain.

**Architecture**: deliberately NOT using the gutendex.com intermediary
— it was unresponsive during integration testing (30s timeouts on
every call). Instead, the integration downloads Gutenberg's canonical
`pg_catalog.csv` (12K+ books) on first use, caches it in `/tmp` with
a weekly refresh, and matches by title+author with a strict scoring
function (hard author-surname gate; exact title match for single-token
queries; token-fraction matching otherwise).

After matching, text comes from `gutenberg.org/ebooks/{id}.txt.utf-8`
(with two fallback URL patterns for older books). Body capped at
1.5MB and START/END boilerplate stripped so RAG indexes book content
only.

`scripts/reindex_via_gutenberg.py` — backfill driver with `--dry-run`,
`--limit`, `--max-text-kb`, `--priority`, `--skip-init-db`. Re-index
is restricted to `type='catalog'` only (ai_book / upload / url are
never overwritten, even if their content is below the chunk threshold).

## 2. Bug fixes from the first backfill attempt (f7a13b3)

The first production backfill exposed two latent bugs:

**Bug 1 — halfvec column never written for new chunks.**
`--skip-init-db` is the workaround for `init_db()` hanging on Supabase's
pgbouncer transaction-mode pooling. But skipping `init_db` leaves
`db._HAS_PGVECTOR` at its False default → `add_chunks` falls through
to the legacy BYTEA-only path → the new `embedding` halfvec column
never gets populated → RAG's pgvector ANN path can't see those chunks.

Fix: `db.probe_pgvector()` — a read-only `information_schema` lookup,
pgbouncer-safe, no DDL. Backfill scripts call it after the init-db gate
so the flag flips even with `--skip-init-db`. The fix is visible at
runtime via the `pgvector write path: enabled` banner.

**Bug 2 — duplicate chunks accumulate on every re-index.**
`index_text(force=True)` only bypasses the content-hash short-circuit;
it never deletes existing chunks. Re-indexing a catalog stub stacked
new Gutenberg chunks alongside the OL/GB metadata chunks (same
`agent_id`, overlapping `chunk_index`, both visible to RAG).

Fix: `db.delete_chunks_for_agent(agent_id)` + new
`index_text(replace_existing=True)` flag. The delete fires AFTER
embeddings come back — if the embedder 429s, stale chunks survive
untouched (rather than wiping to zero before the failure).

## Tests
44 spot-checked (`tests/test_incremental_index.py`,
`tests/test_pgvector_path.py`, `tests/test_chunking.py`). Full suite
was 258/258 green at afb64b2.

## Resume / verification
After merge, the next `python -m scripts.reindex_via_gutenberg
--priority --limit 5 --max-text-kb 300 --skip-init-db` run will
print `pgvector write path: enabled` and upgrade 5 books at ~9 MB
DB cost. The 8 catalog agents currently at 0 chunks (3 rolled back
+ 5 wiped by the destructive ordering this PR fixes) will be picked
up as their priority comes around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
