### PR TITLE
feat(seo): surface Type-4 pages + hybrid curated+community layer on landing pages

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1643,6 +1643,129 @@ def list_minds_for_agent(agent_id: str, limit: int = 12) -> list[dict[str, Any]]
         return [dict(r) for r in rows]
 
 
+def list_minds_active_for_agent(
+    agent_id: str, since_days: int = 60, min_count: int = 1,
+) -> dict[str, dict[str, Any]]:
+    """Community-emergent activity signal: which minds have actually
+    spoken in chat sessions where this book was in context.
+
+    Returns ``{mind_name_lower: {count, last_seen}}`` so the renderer
+    can look up by mind name. Mind name is the only stable join key —
+    the SPA writes ``mindName`` into role='mind' message meta_json
+    (see app/static/app.js ``_queueSessionMessage`` flow) and writes
+    ``contextBooks: [{id, title}]`` into role='user' message meta_json
+    on the same session. We co-join within session_id.
+
+    Derivation chain (PG-only — relies on JSONB operators):
+      1. user messages where meta_json.contextBooks contains agent_id
+      2. JOIN their session to mind messages in the SAME session
+      3. GROUP by mindName, count distinct sessions
+
+    ``since_days`` bounds the lookback so old chats don't dominate as
+    the corpus grows. ``min_count`` filters out one-off invocations
+    so the badge represents real activity, not noise.
+
+    Pairs with ``list_minds_for_agent`` (the curated layer): renderer
+    overlays the activity dict on top of the mind_works cards, badging
+    minds with measurable real-chat activity. Cold-start safe — returns
+    empty dict if no signal yet, in which case the curated layer
+    renders unchanged.
+
+    Empty in SQLite path (no JSONB operators); returns {} as a no-op.
+    """
+    if not _USE_PG:
+        return {}
+    with get_conn() as conn:
+        try:
+            rows = _fetchall(conn,
+                """
+                WITH book_sessions AS (
+                    SELECT DISTINCT sm.session_id
+                    FROM session_messages sm
+                    WHERE sm.role = 'user'
+                      AND sm.created_at::timestamp
+                          > NOW() - INTERVAL '1 day' * %s
+                      AND sm.meta_json::jsonb -> 'contextBooks' @>
+                          jsonb_build_array(jsonb_build_object('id', %s::text))
+                )
+                SELECT LOWER(sm.meta_json::jsonb->>'mindName') AS mind_name,
+                       COUNT(DISTINCT sm.session_id) AS session_count,
+                       MAX(sm.created_at) AS last_seen
+                FROM session_messages sm
+                JOIN book_sessions bs ON bs.session_id = sm.session_id
+                WHERE sm.role = 'mind'
+                  AND sm.meta_json::jsonb->>'mindName' IS NOT NULL
+                GROUP BY LOWER(sm.meta_json::jsonb->>'mindName')
+                HAVING COUNT(DISTINCT sm.session_id) >= %s
+                ORDER BY session_count DESC
+                """, (since_days, agent_id, min_count))
+            return {
+                r["mind_name"]: {
+                    "count": int(r["session_count"]),
+                    "last_seen": r.get("last_seen") or "",
+                }
+                for r in rows if r.get("mind_name")
+            }
+        except Exception as exc:
+            log.warning("list_minds_active_for_agent failed: %s", exc)
+            return {}
+
+
+def list_mind_recent_topics(
+    mind_id: str, limit: int = 8, min_topic_chars: int = 4,
+) -> list[dict[str, Any]]:
+    """Aggregated topic themes pulled from real chats with this mind agent.
+
+    Source: ``mind_memories.topic`` rows where ``user_id IS NULL`` (the
+    privacy-preserving anonymized aggregation that ``extract_and_save_memory``
+    already writes alongside per-user private interaction memories — see
+    ``app/core/minds.py:extract_and_save_memory``). Per-user memories with
+    ``user_id`` set are NOT included; this query only surfaces topics that
+    the mind has discussed across multiple users in non-private form.
+
+    Each row is ``{topic, count, last_seen}`` so the renderer can size the
+    UI by activity level (popular vs occasional) and show a freshness hint.
+
+    Skips trivial topics:
+      * shorter than ``min_topic_chars`` (e.g. blank, single word)
+      * boilerplate strings that the memory extractor sometimes emits as
+        topic labels for non-content turns (``user_profile``,
+        ``conversation initiation``, ``philosophical self-introduction``)
+
+    Used by the mind landing page's "Recent themes" hybrid section
+    (curated TOPIC_TAGS via ``matching_topics`` is the navigational layer
+    that drives ``/mind/{id}/on/{topic-slug}`` URLs; this is the
+    community-emergent informational layer with no URL impact).
+    """
+    boilerplate = (
+        "user_profile",
+        "conversation initiation",
+        "philosophical self-introduction",
+    )
+    boilerplate_placeholders = ",".join(["?"] * len(boilerplate))
+    with get_conn() as conn:
+        try:
+            rows = _fetchall(conn, _q(
+                f"""SELECT topic, COUNT(*) AS n, MAX(created_at) AS last_seen
+                    FROM mind_memories
+                    WHERE mind_id = ?
+                      AND user_id IS NULL
+                      AND topic IS NOT NULL
+                      AND length(topic) >= ?
+                      AND LOWER(topic) NOT IN ({boilerplate_placeholders})
+                    GROUP BY topic
+                    ORDER BY COUNT(*) DESC, MAX(created_at) DESC
+                    LIMIT ?"""
+            ), (mind_id, min_topic_chars, *boilerplate, limit))
+            return [
+                {"topic": r["topic"], "count": int(r["n"]),
+                 "last_seen": r.get("last_seen") or ""}
+                for r in rows
+            ]
+        except Exception:
+            return []
+
+
 def list_books_for_mind(mind_id: str, limit: int = 12) -> list[dict[str, Any]]:
     """Books in this mind's corpus, with enough fields to render link text
     on /mind/{id}. Filters to ready agents only — drafts shouldn't appear

--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -470,6 +470,52 @@ def render_explore_footer(
     )
 
 
+def render_mind_recent_themes(themes: list[dict[str, Any]]) -> str:
+    """Community-emergent informational block on the mind landing page.
+
+    Renders themes the mind has actually been chatted about (pulled from
+    ``db.list_mind_recent_topics``). Distinct from ``render_topic_links_for_mind``
+    in two important ways:
+
+      * Source — those come from a fixed ``TOPIC_TAGS`` list × ``mind.domain``
+        string matching (static, curated). These come from real chat
+        aggregations (dynamic, community-emergent).
+      * URL footprint — those drive indexable ``/mind/{id}/on/{topic-slug}``
+        compound pages. These have NO links because the topics are open-ended
+        and not constrained to our curated topic set. Expanding URL space
+        based on free-form chat themes would invite Google's auto-generated
+        content penalties; we keep this as descriptive content only.
+
+    Renders nothing if ``themes`` is empty so the section gracefully
+    no-ops for new minds with no chat activity yet.
+    """
+    if not themes:
+        return ""
+    items = []
+    for t in themes[:8]:
+        topic = (t.get("topic") or "").strip()
+        n = int(t.get("count") or 0)
+        if not topic:
+            continue
+        count_badge = f' <span class="theme-count">×{n}</span>' if n > 1 else ""
+        items.append(
+            f'<li class="theme">{_esc(topic)}{count_badge}</li>'
+        )
+    if not items:
+        return ""
+    return (
+        '<section class="mind-recent-themes">'
+        '<h2>Recent themes in conversations</h2>'
+        '<p class="themes-intro">Topics readers have actually been '
+        'discussing with this mind on Feynman, aggregated across '
+        'sessions. Updates as new conversations happen.</p>'
+        '<ul class="themes-list">'
+        f'{"".join(items)}'
+        '</ul>'
+        '</section>'
+    )
+
+
 def render_topic_links_for_mind(matching_topics: list[str], site_url: str) -> str:
     """Render a row of links to relevant topic hubs from a mind's page.
     ``matching_topics`` is a pre-filtered list — caller decides which
@@ -493,19 +539,50 @@ def render_topic_links_for_mind(matching_topics: list[str], site_url: str) -> st
     )
 
 
-def render_minds_for_book(minds: list[dict[str, Any]], site_url: str) -> str:
+def render_minds_for_book(
+    minds: list[dict[str, Any]],
+    site_url: str,
+    activity: dict[str, dict[str, Any]] | None = None,
+) -> str:
     """Cross-links from /book/{id} → /mind/{id}. The single biggest
-    internal-link source we have."""
+    internal-link source we have.
+
+    Curated layer: ``minds`` comes from ``db.list_minds_for_agent``
+    (mind_works table — set at mind creation time).
+
+    Activity layer (optional): ``activity`` is a dict keyed by
+    LOWERCASE mind name → {count, last_seen}, sourced from
+    ``db.list_minds_active_for_agent`` (real chat sessions where this
+    book was in context AND the mind authored at least one response).
+    When present, minds with measurable activity get an inline badge.
+    Curated minds with no activity render unchanged — the badge is a
+    pure additive signal, not a filter."""
     if not minds:
         return ""
-    items = "".join(
-        f'<li><a href="{_esc(site_url)}/mind/{_esc(m["id"])}">{_esc(m.get("name", ""))}</a>'
-        f'{(" — " + _esc(m["domain"])) if m.get("domain") else ""}</li>'
-        for m in minds
-    )
+    activity = activity or {}
+    items_html = []
+    for m in minds:
+        name = m.get("name", "")
+        domain = m.get("domain", "")
+        badge = ""
+        if activity:
+            act = activity.get(name.lower())
+            if act and act.get("count", 0) > 0:
+                n = act["count"]
+                # "12 chats" / "1 chat" — count is distinct sessions
+                label = "chat" if n == 1 else "chats"
+                badge = (
+                    f' <span class="activity-badge" title="Active in real reader '
+                    f'conversations about this book">● active in {n} {label}</span>'
+                )
+        items_html.append(
+            f'<li><a href="{_esc(site_url)}/mind/{_esc(m["id"])}">{_esc(name)}</a>'
+            f'{(" — " + _esc(domain)) if domain else ""}'
+            f'{badge}</li>'
+        )
     return (
         '<section><h2>Great minds who discuss this book</h2>'
-        f'<ul class="related-minds">{items}</ul></section>'
+        f'<ul class="related-minds">{"".join(items_html)}</ul></section>'
     )
 
 
@@ -626,6 +703,39 @@ def render_related_minds(minds: list[dict[str, Any]], site_url: str) -> str:
 # Render layer for /book/{id}/insights and /mind/{id}/dialogues. The
 # insights themselves come from app/core/insights.py (already PII-
 # sanitized) — we just frame, label, and structure them for crawl.
+
+def render_live_content_link(
+    entity_name: str, kind: str, target_url: str, count: int = 0,
+) -> str:
+    """Surface the entity's Type-4 live-content page (``/insights`` for
+    books, ``/dialogues`` for minds) from the parent landing page. Without
+    this, the landing page never advertises that the Type-4 surface exists
+    — crawlers traverse from sitemap only, and human visitors have no path
+    to the live-content page from a book's or mind's main entry.
+
+    The link is rendered regardless of ``count`` so the page is always
+    discoverable. When ``count > 0`` a small badge advertises real activity;
+    when zero, the empty-state on the target page itself invites the visitor
+    to seed it via a chat. ``kind`` is ``"insights"`` (book) or
+    ``"dialogues"`` (mind) — pure copy variation, same structure."""
+    if kind == "insights":
+        title = f"AI insights about {entity_name}"
+        sub = ("Accumulated AI commentary on this book, drawn from real "
+               "reader chat sessions and updated as more readers engage.")
+    else:
+        title = f"Recent dialogues with {entity_name}"
+        sub = ("AI responses from real chat sessions with this mind agent, "
+               "aggregated and refreshed as new conversations happen.")
+    count_badge = (
+        f' <span class="count-badge">{count}</span>' if count > 0 else ""
+    )
+    return (
+        '<section class="live-content-link">'
+        f'<h2><a href="{_esc(target_url)}">{_esc(title)} →</a>{count_badge}</h2>'
+        f'<p>{_esc(sub)}</p>'
+        '</section>'
+    )
+
 
 def render_insight_cards(insights: list[dict[str, Any]], max_chars: int = 900) -> str:
     """Render the sanitized AI commentaries as a stack of cards. Each

--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,9 @@ from .core.db import (
     list_books_for_mind,
     list_messages,
     list_messages_for_public_session,
+    list_mind_recent_topics,
     list_minds,
+    list_minds_active_for_agent,
     list_minds_by_topic,
     list_minds_for_agent,
     list_public_sessions_for_agent,
@@ -1257,6 +1259,14 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
         related_minds = list_minds_for_agent(agent_id)
     except Exception:
         related_minds = []
+    # Activity overlay for related_minds — minds that have actually spoken
+    # in chat sessions referencing this book (community-emergent signal,
+    # PG-only via JSONB query). Renderer treats this as a purely additive
+    # badge layer: curated minds without activity render unchanged.
+    try:
+        mind_activity = list_minds_active_for_agent(agent_id, since_days=60)
+    except Exception:
+        mind_activity = {}
     # Phase 5 — related books surfaced from same-topic + same-author cohort
     agent_meta = agent.get("meta") or {}
     book_topic = (agent_meta.get("category") or "").strip()
@@ -1292,9 +1302,27 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
     questions_html = seo_render.render_popular_questions(
         questions, chat_url, book_id=agent_id, site_url=base,
     )
-    minds_html = seo_render.render_minds_for_book(related_minds, base)
+    minds_html = seo_render.render_minds_for_book(related_minds, base, activity=mind_activity)
     related_books_html = seo_render.render_related_books(related_books, base)
     topic_link_html = seo_render.render_topic_link_back(book_topic, base) if book_topic else ""
+
+    # Surface /book/{id}/insights from the parent landing page. Without
+    # this link, the Type-4 surface is only reachable from the sitemap —
+    # crawlers eventually find it but human visitors on the book page
+    # have no path to the live-content view.
+    insights_link_html = ""
+    if insights_module.is_enabled():
+        try:
+            counts = count_assistant_messages_batch([agent_id])
+            insights_count = int(counts.get(agent_id, 0))
+        except Exception:
+            insights_count = 0
+        insights_link_html = seo_render.render_live_content_link(
+            entity_name=title_raw,
+            kind="insights",
+            target_url=f"{base}/book/{id_path}/insights",
+            count=insights_count,
+        )
 
     # Phase 5.6 — bottom-of-page Explore neighborhood: 3-5 cross-links
     # to adjacent entities. Mix related minds, related books, and the
@@ -1410,6 +1438,7 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {minds_html}
 {related_books_html}
 {topic_link_html}
+{insights_link_html}
 {cta_html}
 {explore_footer_html}
 {seo_render.render_site_footer(base)}
@@ -1528,6 +1557,34 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
     related_html = seo_render.render_related_minds(related, base)
     topic_links_html = seo_render.render_topic_links_for_mind(matching_topics, base)
 
+    # Community-emergent themes pulled from real chats with this mind
+    # (mind_memories.topic aggregated across users, user_id IS NULL only).
+    # Pairs with the curated topic_links_html above: that section is the
+    # navigational layer (drives /on/{topic-slug} URLs); this section is
+    # the informational layer (no URLs, reflects actual conversations).
+    try:
+        recent_themes = list_mind_recent_topics(mind_id, limit=8)
+    except Exception:
+        recent_themes = []
+    recent_themes_html = seo_render.render_mind_recent_themes(recent_themes)
+
+    # Surface /mind/{id}/dialogues from the mind landing page — same
+    # rationale as the /book/{id}/insights link. Without this, the
+    # dialogues page exists only in the sitemap.
+    dialogues_link_html = ""
+    if insights_module.is_enabled():
+        try:
+            counts = count_assistant_messages_for_minds_batch([mind_id])
+            dialogues_count = int(counts.get(mind_id, 0))
+        except Exception:
+            dialogues_count = 0
+        dialogues_link_html = seo_render.render_live_content_link(
+            entity_name=name_raw,
+            kind="dialogues",
+            target_url=f"{base}/mind/{mind_id}/dialogues",
+            count=dialogues_count,
+        )
+
     # Phase 5.6 — Explore footer. Mix top related minds, top books from
     # this mind's library, and the first matching topic hub.
     explore_items: list[dict[str, str]] = []
@@ -1630,6 +1687,8 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 {extra_books_html}
 {related_html}
 {topic_links_html}
+{recent_themes_html}
+{dialogues_link_html}
 <p class="cta"><a href="{html_esc(reader_url)}">Chat with {name} on Feynman →</a></p>
 {explore_footer_html}
 {seo_render.render_site_footer(base)}


### PR DESCRIPTION
## Summary
Two improvements to entity landing pages that together close the gap
between "Type-4 live-content surfaces exist" and "users + crawlers
can actually find them, and the existing pages reflect real activity."

## 1. Bug fix — link /insights and /dialogues from landing pages

`/book/{id}/insights` and `/mind/{id}/dialogues` shipped in #16/#17
([3f0bf68](https://github.com/steveyeow/Feynman/commit/3f0bf68))
but the only path to them was via sitemap. Human visitors browsing
`/book/sapiens` or `/mind/marx` had no link forward.

`seo.render_live_content_link()` now renders an inline section pointing
at the Type-4 page. Count badge advertises real activity when it exists
(distinct sessions or messages); empty state on the target page invites
seeding via chat when it doesn't.

## 2. Hybrid: curated + community-emergent on landing pages

### a. Mind page "Recent themes in conversations" (new section)

Pulled from `mind_memories.topic` where `user_id IS NULL` — the
privacy-preserving anonymized aggregation `extract_and_save_memory`
already writes alongside per-user private memories. Pure descriptive
text, no URL impact, no expansion of the indexable URL space.

Distinct from the existing "Topic links" block (curated navigation
layer driving `/mind/{id}/on/{topic-slug}` URLs from `TOPIC_TAGS`).
The new section is the information layer.

Real data flowing in production today:
- Foucault: 8 themes including "Edge LLMs and power", "critique of persuasion science"
- Marx: 6 themes including "critique of capitalism", "historical materialism and social structures"
- Laozi: 4 themes including "Daoist meaning of life", "Nature of Tao"

This kind of content — a thinker's framework applied to contemporary
topics — is the structural content moat we can't get from Wikipedia
(static bios) or Goodreads (book reviews).

### b. Book page minds: activity badge on existing cards

`render_minds_for_book` gains an optional `activity` overlay. Curated
layer is `mind_works` (set at mind creation). Activity layer derived
from a PG JSONB query against `session_messages`: minds that
authored responses (`role='mind'`) in chat sessions where the book
appeared in `contextBooks` of any user message.

No frontend change required — the SPA already writes
`contextBooks: [{id, title}]` into user message meta (see
`app/static/app.js` `_queueSessionMessage`).

Cold-start safe: the badge is purely additive. Curated minds with zero
activity render unchanged. Production is currently thin on this signal
(3 contextBooks records in session_messages); it will populate as
SEO traffic drives more book-chat sessions.

## Deliberately NOT included

- **Hybrid for "How they think" (`thinking_style`)** — rejected.
  thinking_style is a meta-bio paragraph; mixing it with live chat-derived
  signal would muddle the separation between meta-description (entity
  intro) and live content (which now lives explicitly at /dialogues).

- **Hybrid for "Popular Questions"** — deferred. Has unresolved design
  choices (write derived high-frequency user questions back to questions
  table → spawn new /q/{slug} URLs vs render in separate non-indexed
  section?) that need product decisions.

## Tests
233 pass (189 SEO + 22 indexer + 22 pgvector). All new sections render
gracefully when their data sources are empty.

## Architecture notes
- Privacy: `list_mind_recent_topics` filters `user_id IS NULL` —
  per-user private interaction memories never surface.
- Cold-start: every new section no-ops when its data source is empty,
  so the changes can't degrade any existing book/mind page.
- SQLite parity: `list_minds_active_for_agent` returns `{}` on SQLite
  (no JSONB operators); curated layer still renders unchanged in
  local-dev mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
