### PR TITLE
ci+fix: JSON-LD regression suite + _learn_agent self-heal on transient errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
           # are written to work against either; the SQLite branch is the
           # cheaper default for CI.
           DATABASE_URL: ""
+          # Dummy LLM key so pick_provider() passes its has_key() check.
+          # Tests that exercise the chat path use unittest.mock to replace
+          # chat_with_fallback — no real network call ever fires. Without
+          # this, pick_provider raises ProviderError before the mock can
+          # intercept, masking the test intent.
+          GEMINI_API_KEY: "ci-dummy-key-never-hits-network"
         run: |
           PYTHONPATH=. pytest tests/ -q --tb=short
 
@@ -58,5 +64,6 @@ jobs:
         # silently ignoring the schema). Cheaper to catch in CI than in GSC.
         env:
           DATABASE_URL: ""
+          GEMINI_API_KEY: "ci-dummy-key-never-hits-network"
         run: |
           PYTHONPATH=. pytest tests/test_jsonld_regression.py -v --tb=short

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        env:
+          # SQLite-only mode for CI. Production uses Postgres but unit tests
+          # are written to work against either; the SQLite branch is the
+          # cheaper default for CI.
+          DATABASE_URL: ""
+        run: |
+          PYTHONPATH=. pytest tests/ -q --tb=short
+
+  jsonld-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: pytest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: JSON-LD required-field regression
+        # Dedicated job that fails loudly on JSON-LD shape regressions.
+        # Phase 7.4 — catches the kind of bug that 89410b8 fixed mid-flight
+        # (QAPage was missing text + answerCount, Google rich-results was
+        # silently ignoring the schema). Cheaper to catch in CI than in GSC.
+        env:
+          DATABASE_URL: ""
+        run: |
+          PYTHONPATH=. pytest tests/test_jsonld_regression.py -v --tb=short

--- a/app/main.py
+++ b/app/main.py
@@ -425,8 +425,25 @@ def _learn_agent(agent_id: str) -> None:
         update_agent_status(agent_id, "ready", merged)
         log.info("Agent %s (%s) learned successfully", agent_id, title)
     except Exception as exc:
+        # Transient failures (Gemini 429, network timeouts, embedder hiccups)
+        # used to set status='error' which left the agent permanently stuck —
+        # next chat couldn't re-trigger _learn_agent because the entry check
+        # only fires on status='catalog'. Revert to 'catalog' so the natural
+        # retry-on-next-chat path works. Stash the last error in meta so
+        # repeated failures are still debuggable from the agent row.
         log.error("Learning failed for agent %s: %s", agent_id, exc)
-        update_agent_status(agent_id, "error", {"error": str(exc)})
+        try:
+            from datetime import datetime, timezone
+            existing = get_agent(agent_id)
+            existing_meta = (existing or {}).get("meta") or {}
+            error_meta = {
+                **existing_meta,
+                "last_learn_error": str(exc)[:500],
+                "last_learn_error_at": datetime.now(timezone.utc).isoformat(),
+            }
+            update_agent_status(agent_id, "catalog", error_meta)
+        except Exception as inner:
+            log.error("Failed to revert agent %s to catalog after learn error: %s", agent_id, inner)
     finally:
         _learning_lock.discard(agent_id)
 

--- a/tests/test_jsonld_regression.py
+++ b/tests/test_jsonld_regression.py
@@ -1,0 +1,218 @@
+"""JSON-LD required-field regression suite (Phase 7.4).
+
+Guards against the failure mode where a refactor silently drops a Google-
+required field from a JSON-LD block. Symptom in production: rich results
+stop appearing for that page type because validators reject the schema —
+but the page still renders fine to humans, so the bug is invisible in
+manual QA. Commit 89410b8 fixed exactly this for QAPage (missing ``text``
+and ``answerCount``); without a regression suite the same gap can re-emerge
+on any builder.
+
+These tests assert ONLY the **Google-required** subset — not every schema.org
+optional field. The required subset comes from
+https://developers.google.com/search/docs/appearance/structured-data and is
+the bar for rich-result eligibility.
+
+Builders are tested in isolation (no DB, no FastAPI) — they're pure
+functions over dicts, fast, deterministic, no fixtures needed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.core import seo
+
+
+def _unwrap_script(html: str) -> dict:
+    """Strip the <script type='application/ld+json'>…</script> wrapper
+    and parse the JSON. Mirrors what a crawler does to extract JSON-LD."""
+    inner = html.split(">", 1)[1].rsplit("<", 1)[0]
+    return json.loads(inner)
+
+
+# ─── Book ─────────────────────────────────────────────────────────────────
+# Required by Google: @type, name, author. URL+image strongly recommended.
+
+class TestBookJsonLD:
+    def test_required_fields_present(self):
+        wrapped = seo.jsonld_script(seo.book_jsonld(
+            title="Sapiens",
+            description="A brief history of humankind",
+            author="Yuval Noah Harari",
+            url="https://feynman.wiki/book/abc",
+            image="https://feynman.wiki/book/abc/og.png",
+            word_count=None,
+            chapters=None,
+            site_url="https://feynman.wiki",
+        ))
+        d = _unwrap_script(wrapped)
+        assert d["@context"] == "https://schema.org"
+        assert d["@type"] == "Book"
+        assert d["name"] == "Sapiens"
+        assert d["author"]["@type"] == "Person"
+        assert d["author"]["name"] == "Yuval Noah Harari"
+        assert d["url"].startswith("https://")
+
+    def test_never_emits_numberofpages_null(self):
+        # Schema validators reject null leaves outright. The builder must
+        # OMIT this field entirely when we don't have it, never null it.
+        wrapped = seo.jsonld_script(seo.book_jsonld(
+            title="X", description="", author="",
+            url="https://x.com/b", image=None,
+            word_count=None, chapters=None,
+            site_url="https://x.com",
+        ))
+        d = _unwrap_script(wrapped)
+        assert "numberOfPages" not in d, \
+            "numberOfPages must never appear (it's for physical pages; " \
+            "we use hasPart for chapters instead)"
+
+
+# ─── Person ───────────────────────────────────────────────────────────────
+# Required by Google: @type, name. sameAs strongly recommended for entity
+# graph reconciliation.
+
+class TestPersonJsonLD:
+    def test_required_fields_present(self):
+        d = seo.person_jsonld(
+            name="Karl Marx",
+            description="19th-century political economist…",
+            domain="Political Economy, Philosophy",
+            url="https://feynman.wiki/mind/marx",
+            image="https://feynman.wiki/mind/marx/og.png",
+        )
+        assert d["@type"] == "Person"
+        assert d["name"] == "Karl Marx"
+        assert d["url"].startswith("https://")
+
+    def test_sameas_when_available(self):
+        # sameAs is what tells Google's Knowledge Graph "this is THE Karl Marx".
+        # Builder must accept and emit it.
+        d = seo.person_jsonld(
+            name="Karl Marx", description="", domain="", url="https://x.com/m",
+            image=None, same_as=["https://en.wikipedia.org/wiki/Karl_Marx"],
+        )
+        assert "sameAs" in d
+        assert d["sameAs"] == ["https://en.wikipedia.org/wiki/Karl_Marx"]
+
+
+# ─── QAPage ───────────────────────────────────────────────────────────────
+# This is the one that bit us in 89410b8. Google requires:
+#   - mainEntity.@type = "Question"
+#   - mainEntity.name (the question text)
+#   - mainEntity.acceptedAnswer.@type = "Answer"
+#   - mainEntity.acceptedAnswer.text (the answer body)
+#   - answerCount is implicitly required for rich-result eligibility
+
+class TestQAPageJsonLD:
+    def test_required_fields_present(self):
+        d = seo.qa_page_jsonld(
+            question="How does Sapiens explain cooperation?",
+            answer="The book argues that shared fictions enable…",
+            url="https://feynman.wiki/book/abc/q/cooperation",
+            book_title="Sapiens",
+            book_url="https://feynman.wiki/book/abc",
+            site_url="https://feynman.wiki",
+        )
+        assert d["@type"] == "QAPage"
+        me = d["mainEntity"]
+        assert me["@type"] == "Question"
+        assert me["name"]
+        # The exact bug from 89410b8 — these two must be present:
+        assert "text" in me, "QAPage Question must have 'text' (Google required)"
+        assert "answerCount" in me, \
+            "QAPage Question must have 'answerCount' (Google required)"
+        acc = me["acceptedAnswer"]
+        assert acc["@type"] == "Answer"
+        assert acc["text"]
+
+
+# ─── FAQPage ──────────────────────────────────────────────────────────────
+# Required: mainEntity[] with each entry having @type=Question, name,
+# acceptedAnswer.text. Non-empty answers required (deflection answer is
+# acceptable, blank string is not).
+
+class TestFAQPageJsonLD:
+    def test_required_fields_present(self):
+        d = seo.faq_jsonld([
+            ("What is X?", "Open Feynman to learn more."),
+            ("How does Y work?", "Open Feynman to learn more."),
+        ])
+        assert d["@type"] == "FAQPage"
+        assert isinstance(d["mainEntity"], list)
+        assert len(d["mainEntity"]) == 2
+        for entry in d["mainEntity"]:
+            assert entry["@type"] == "Question"
+            assert entry["name"]
+            assert entry["acceptedAnswer"]["@type"] == "Answer"
+            assert entry["acceptedAnswer"]["text"], \
+                "FAQ answer text must be non-empty (Google rejects empty)"
+
+
+# ─── BreadcrumbList ───────────────────────────────────────────────────────
+# Required: itemListElement[] with each entry having @type=ListItem,
+# position, name, item (URL).
+
+class TestBreadcrumbListJsonLD:
+    def test_required_fields_present(self):
+        d = seo.breadcrumb_jsonld([
+            ("Feynman", "https://feynman.wiki"),
+            ("Books", "https://feynman.wiki/#/library"),
+            ("Sapiens", "https://feynman.wiki/book/abc"),
+        ])
+        assert d["@type"] == "BreadcrumbList"
+        items = d["itemListElement"]
+        assert len(items) == 3
+        for i, item in enumerate(items, 1):
+            assert item["@type"] == "ListItem"
+            assert item["position"] == i
+            assert item["name"]
+            assert item["item"].startswith("https://")
+
+
+# ─── Article (used by /insights and /dialogues) ───────────────────────────
+# Required: @type, headline, datePublished or dateModified, author.
+
+class TestArticleJsonLD:
+    def test_insights_article_required_fields(self):
+        d = seo.insights_article_jsonld(
+            headline="AI insights about Sapiens",
+            description="Aggregated AI commentary…",
+            url="https://feynman.wiki/book/abc/insights",
+            about_url="https://feynman.wiki/book/abc",
+            about_type="Book",
+            about_name="Sapiens",
+            site_url="https://feynman.wiki",
+            date_modified="2026-05-27T12:00:00Z",
+            insight_count=10,
+        )
+        assert d["@type"] == "Article"
+        assert d["headline"]
+        # Google requires dateModified or datePublished. Insights pages
+        # use dateModified because the content accumulates over time.
+        assert "dateModified" in d or "datePublished" in d
+        assert d["author"], "Article must declare an author (Google required)"
+
+
+# ─── jsonld_script wrapper ────────────────────────────────────────────────
+# The wrapper has its own contract: must produce a valid <script> tag,
+# must drop None-valued top-level keys (validators reject null leaves),
+# must HTML-safe-escape its content.
+
+class TestJsonldScriptWrapper:
+    def test_wraps_in_script_tag(self):
+        out = seo.jsonld_script({"@type": "Thing", "name": "X"})
+        assert out.startswith('<script type="application/ld+json">')
+        assert out.endswith("</script>")
+
+    def test_drops_none_top_level_keys(self):
+        # Bug class: a builder returns {key: None} expecting wrapper to
+        # drop it. Validators choke on null leaves. Wrapper must strip.
+        out = seo.jsonld_script({
+            "@type": "Book", "name": "X", "wordCount": None, "image": None,
+        })
+        d = _unwrap_script(out)
+        assert "wordCount" not in d
+        assert "image" not in d
+        assert d["name"] == "X"


### PR DESCRIPTION
Two small reliability changes.

## 1. JSON-LD CI validator (Phase 7.4)

The repo had no CI at all. New `.github/workflows/test.yml` runs the
existing pytest suite (258 tests) on every push/PR, plus a dedicated job
for the new JSON-LD regression suite.

New `tests/test_jsonld_regression.py` (10 tests) asserts the
**Google-required subset** of fields per JSON-LD `@type`:

| @type | Required fields tested |
|---|---|
| Book | `name`, `author`, never `numberOfPages: null` |
| Person | `name`, `url`, `sameAs` when available |
| QAPage | `mainEntity.{name, text, answerCount, acceptedAnswer.text}` |
| FAQPage | `mainEntity[].{name, acceptedAnswer.text}` (non-empty) |
| BreadcrumbList | `itemListElement[].{position, name, item}` |
| Article | `headline`, `dateModified` or `datePublished`, `author` |
| jsonld_script wrapper | drops `None` top-level keys |

This is the regression guard the codebase was missing. Commit 89410b8
had to patch QAPage in production because `text` + `answerCount` were
silently missing — exactly the kind of schema regression these tests
catch on every PR before deploy.

## 2. `_learn_agent` self-heal on transient failures

**Before**: any exception in the background learn task (Gemini 429,
network timeout, embedder error) set `status='error'`, which permanently
bricked the agent. The `catalog`-only entry check in `api_chat` meant
the next chat could never re-trigger learning. The book was stuck.

**After**: revert to `status='catalog'` instead, stash the error in
meta as `last_learn_error` + `last_learn_error_at` for debugging. Next
chat fires `_learn_agent` again naturally. Self-healing.

This is a real prod bug — Gemini 429 is common enough that "first chat
of the day permanently bricks the book" was hitting users.

## Tests
268 pass (10 new JSON-LD + 258 existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
