### PR TITLE
feat(seo+ui): one URL per entity, auth-aware chrome — SEO + product unified

### DIFF
--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -768,14 +768,16 @@ def render_insight_cards(insights: list[dict[str, Any]], max_chars: int = 900) -
 def render_insights_empty_state(entity_name: str, chat_url: str) -> str:
     """Shown when an entity has no publishable AI insights yet (new
     book, low chat volume). Better than 404 — it gives the page a
-    meaningful body and a CTA to seed content."""
+    meaningful body. No duplicate CTA here; the page's bottom CTA
+    section already carries the "Chat with X" button, so a second
+    "Start a chat →" inside this empty state was redundant (caught
+    in screenshot review on 2026-05-27)."""
     return (
         '<section class="insights-empty">'
         f'<p>No AI insights have accumulated yet for {_esc(entity_name)}. '
-        'Start a chat and your conversation will help shape the public '
+        'Start a chat below and your conversation will help shape this '
         '<em>insights</em> page — the AI\'s responses get aggregated here '
         '(your questions stay private).</p>'
-        f'<p><a class="cta-btn" href="{_esc(chat_url)}">Start a chat →</a></p>'
         '</section>'
     )
 
@@ -1345,11 +1347,25 @@ def landing_css_link() -> str:
     return f'<link rel="stylesheet" href="{LANDING_CSS_PATH}?v=1">'
 
 
-def render_landing_header(site_url: str) -> str:
-    """Brand header — Feynman logo + tagline on the left, primary CTA
-    on the right. Same shape across all landing pages so visitors who
-    arrive from search recognize the brand and have one obvious way to
-    open the app."""
+def render_landing_header(site_url: str, is_authenticated: bool = False) -> str:
+    """Top brand header. Same shape across all SSR detail pages so the
+    page is recognizable whether the visitor arrived from Google, a
+    share link, or by clicking "View details" inside the SPA.
+
+    ``is_authenticated``: when True the visitor is a logged-in product
+    user — we hide the marketing-style "Open Feynman →" CTA (they're
+    already in Feynman) and surface a softer "Back to app →" link
+    instead. When False (anonymous / crawler), keep the conversion CTA.
+
+    Logo, nav links, and the brand wordmark stay identical in both
+    states so the page chrome is visually stable when auth state
+    changes (e.g. user signs in mid-session).
+    """
+    primary_cta = (
+        f'<a class="feynman-cta feynman-cta-soft" href="{_esc(site_url)}/#/library">Back to app →</a>'
+        if is_authenticated
+        else f'<a class="feynman-cta" href="{_esc(site_url)}/">Open Feynman →</a>'
+    )
     return (
         '<header class="feynman-header">'
         f'<a class="feynman-brand" href="{_esc(site_url)}/">'
@@ -1365,7 +1381,7 @@ def render_landing_header(site_url: str) -> str:
         '<nav class="feynman-nav">'
         f'<a href="{_esc(site_url)}/#/library">Library</a>'
         f'<a href="{_esc(site_url)}/#/minds">Great Minds</a>'
-        f'<a class="feynman-cta" href="{_esc(site_url)}/">Open Feynman →</a>'
+        f'{primary_cta}'
         '</nav>'
         '</header>'
     )

--- a/app/main.py
+++ b/app/main.py
@@ -1403,31 +1403,15 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
             (q, deflect) for q in questions if q
         ]))
 
-    # ── Decide who sees the landing page vs gets redirected ─────────────
-    # Crawlers: always see the landing page (no redirect, body visible).
-    # In-product clicks with ?details=1: SPA user EXPLICITLY clicked
-    #   "View details" — they want the landing page, not the SPA action.
-    #   Opt-out the auto-redirect. Same query param works for both books
-    #   and minds; checked here via request.query_params.
-    # In-product clicks (Referer = our origin, no ?details): redirect to
-    #   the SPA action so existing UX is unchanged — they expect to land
-    #   in reader/chat.
-    # Everyone else (Google, share links, direct visits, missing referer):
-    #   stay on the landing page so they see what the URL actually offers
-    #   instead of being dropped into an empty reader.
-    referer = request.headers.get("referer", "") or request.headers.get("referrer", "")
-    wants_details = request.query_params.get("details") == "1"
-    show_landing = (
-        wants_details
-        or _is_crawler(request)
-        or not seo_render.is_internal_referer(referer, base)
-    )
-    body_style = '' if show_landing else ' style="opacity:0"'
-    redirect_script = (
-        ''
-        if show_landing
-        else f'<script>window.location.replace({json.dumps(cta_target_url)});</script>'
-    )
+    # The page is the destination for everyone — crawlers, share-link
+    # visitors, and logged-in SPA users alike. Earlier iteration
+    # redirected internal-referer hits to the SPA action; that
+    # fragmented the experience (same URL meant different things
+    # depending on who you were and where you came from) and made
+    # logged-in users miss the rich aggregation content the SSR page
+    # assembles. One URL, one page, one set of content; only the
+    # header chrome adapts via is_authenticated.
+    is_authenticated = _get_user_id(request) is not None
     author_meta = f'<meta property="book:author" content="{html_esc(author_raw)}">' if author_raw else ''
     author_html = f'<p class="book-author">by {html_esc(author_raw)}</p>' if author_raw else ''
 
@@ -1459,8 +1443,8 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {book_ld}
 {breadcrumb_ld}
 {faq_ld}
-</head><body{body_style}>
-{seo_render.render_landing_header(base)}
+</head><body>
+{seo_render.render_landing_header(base, is_authenticated=is_authenticated)}
 <h1>{title}</h1>
 {author_html}
 {about_html}
@@ -1475,7 +1459,6 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {cta_html}
 {explore_footer_html}
 {seo_render.render_site_footer(base)}
-{redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
 
@@ -1655,22 +1638,10 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
         (name_raw, canonical),
     ]))
 
-    # Same referer-aware gate as book_page. ?details=1 opts out of the
-    # auto-redirect so SPA users who explicitly clicked "View profile"
-    # land on the landing page instead of bouncing to the chat.
-    referer = request.headers.get("referer", "") or request.headers.get("referrer", "")
-    wants_details = request.query_params.get("details") == "1"
-    show_landing = (
-        wants_details
-        or _is_crawler(request)
-        or not seo_render.is_internal_referer(referer, base)
-    )
-    body_style = '' if show_landing else ' style="opacity:0"'
-    redirect_script = (
-        ''
-        if show_landing
-        else f'<script>window.location.replace({json.dumps(reader_url)});</script>'
-    )
+    # The page is the destination for everyone — see book_page above for
+    # the rationale. One URL, one page, header chrome adapts via
+    # is_authenticated.
+    is_authenticated = _get_user_id(request) is not None
     if era_raw and domain_raw:
         era_domain_html = f'<p class="mind-meta">{era} · {domain}</p>'
     elif era_raw:
@@ -1710,8 +1681,8 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 {seo_render.landing_css_link()}
 {person_ld}
 {breadcrumb_ld}
-</head><body{body_style}>
-{seo_render.render_landing_header(base)}
+</head><body>
+{seo_render.render_landing_header(base, is_authenticated=is_authenticated)}
 <h1>{name}</h1>
 {era_domain_html}
 {bio_html}
@@ -1727,7 +1698,6 @@ def mind_page(mind_id: str, request: Request) -> HTMLResponse:
 <p class="cta"><a href="{html_esc(reader_url)}">Chat with {name} on Feynman →</a></p>
 {explore_footer_html}
 {seo_render.render_site_footer(base)}
-{redirect_script}
 </body></html>"""
     return HTMLResponse(html, headers={"Cache-Control": "public, max-age=3600, s-maxage=86400"})
 
@@ -1852,7 +1822,7 @@ def book_question_page(agent_id: str, question_slug: str, request: Request) -> H
 {qa_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(base)}
+{seo_render.render_landing_header(base, is_authenticated=_get_user_id(request) is not None)}
 <nav class="qa-back"><a href="{book_url}">← {title}</a></nav>
 <h1>{html_esc(question)}</h1>
 {answer_html}
@@ -1969,7 +1939,7 @@ def mind_on_topic_page(mind_id: str, topic_slug: str, request: Request) -> HTMLR
 {article_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(base)}
+{seo_render.render_landing_header(base, is_authenticated=_get_user_id(request) is not None)}
 <nav class="essay-back"><a href="{mind_url}">← {name}</a></nav>
 <h1>How {name} would approach {html_esc(topic)}</h1>
 {essay_html}
@@ -2126,7 +2096,7 @@ def book_insights_page(agent_id: str, request: Request) -> HTMLResponse:
 {article_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(base)}
+{seo_render.render_landing_header(base, is_authenticated=_get_user_id(request) is not None)}
 <nav class="insights-back"><a href="{entity_canonical}">← {entity_name}</a></nav>
 <h1>AI insights about {entity_name}</h1>
 <p class="insights-intro">Accumulated AI-synthesized commentary drawn from
@@ -2251,7 +2221,7 @@ def mind_dialogues_page(mind_id: str, request: Request) -> HTMLResponse:
 {article_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(base)}
+{seo_render.render_landing_header(base, is_authenticated=_get_user_id(request) is not None)}
 <nav class="insights-back"><a href="{entity_canonical}">← {entity_name}</a></nav>
 <h1>AI dialogues with {entity_name}</h1>
 <p class="insights-intro">Accumulated AI agent responses from real user
@@ -2393,7 +2363,7 @@ def topic_page(slug: str, request: Request) -> HTMLResponse:
 {collection_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(base)}
+{seo_render.render_landing_header(base, is_authenticated=_get_user_id(request) is not None)}
 <h1>{html_esc(topic)}</h1>
 {intro_html}
 {books_html}
@@ -2748,7 +2718,7 @@ def _render_public_discussions_page(
 {forum_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(_SITE_URL)}
+{seo_render.render_landing_header(_SITE_URL, is_authenticated=_get_user_id(request) is not None)}
 <nav class="back-link"><a href="{entity_canonical}">← {html_esc(entity_name)}</a></nav>
 <h1>Discussions about {html_esc(entity_name)}</h1>
 {posts_html}
@@ -2967,7 +2937,7 @@ def public_session_page(session_id: str, request: Request) -> HTMLResponse:
 {forum_post_ld}
 {breadcrumb_ld}
 </head><body>
-{seo_render.render_landing_header(base)}
+{seo_render.render_landing_header(base, is_authenticated=_get_user_id(request) is not None)}
 <h1>{title}</h1>
 <p class="post-byline">Shared by {handle}</p>
 {post_html}

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3364,31 +3364,35 @@ async function deleteBook(agentId) {
 window.deleteBook = deleteBook;
 
 // ─── Detail-page entry points (book + mind) ───
-// Routes the user IN-SPA, same tab, to the existing SPA-native detail
-// surfaces (#/book/{id} and #/mind/{id}). Earlier iteration opened a new
-// tab to the SSR /book/{id} / /mind/{id} URLs — that's the SEO landing
-// page meant for external crawlers + share-link visitors. Logged-in
-// product users hit it without auth context (different chrome, "Open
-// Feynman →" CTA, different design system) and the cohesion broke.
+// One URL per entity, same page for everyone — Google crawlers, share-
+// link visitors, AND logged-in product users. The SSR /book/{id} and
+// /mind/{id} pages are auth-aware: when a logged-in user lands on them
+// the chrome adapts (Feynman wordmark + "Back to app →" instead of the
+// "Open Feynman" marketing CTA), the body uses the same Inter type
+// family + color tokens as the SPA, and all the rich aggregation
+// content blocks (Sample Passages, Popular Questions, Discussed by
+// Great Minds, Related Books, Insights, Dialogues) render identically.
 //
-// Keeping the SPA hash routes preserves:
-//   * the proper Feynman logo + topbar
-//   * auth context (sidebar, user profile menu)
-//   * the unified design system (SPA tokens, sans-serif, light/dark mode)
-//   * navigation history (back button works inside SPA)
+// Earlier iterations tried multiple alternatives that didn't work:
+//   * new-tab to /book/{id}?details=1 — anonymous landing chrome,
+//     "Open Feynman" CTA showed even though user was logged in
+//   * same-tab to #/book/{id} hash route — only renders the existing
+//     SPA chat-with-sidebar view, missing all the SEO aggregations
+// The right model is the one the user landed on: one canonical URL,
+// auth-aware chrome, full aggregations always present.
 //
-// The SSR /book/{id} and /mind/{id} URLs stay reachable for crawlers
-// and external share traffic — they're indexed by Google and cited by
-// LLMs; SPA users just don't open them directly.
+// Same-tab navigation means a real page load (we leave the SPA). The
+// SSR page is rich and SPA-styled enough that this is not jarring;
+// the back button returns to the SPA.
 function openBookDetails(agentId) {
   if (!agentId) return;
-  window.location.hash = '#/book/' + encodeURIComponent(agentId);
+  window.location.href = '/book/' + encodeURIComponent(agentId);
 }
 window.openBookDetails = openBookDetails;
 
 function openMindDetails(mindId) {
   if (!mindId) return;
-  window.location.hash = '#/mind/' + encodeURIComponent(mindId);
+  window.location.href = '/mind/' + encodeURIComponent(mindId);
 }
 window.openMindDetails = openMindDetails;
 
@@ -6530,14 +6534,32 @@ function _renderMindsGraph(vectorLinks, layoutPositions) {
             <div class="tt-name">${n.name}</div>
             <div class="tt-era">${n.era}</div>
           </div>
-          <button class="tt-chat-icon-btn" data-mind-id="${n.id}" title="Chat with ${n.name}">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-            <span>Chat</span>
-          </button>
+          <div class="tt-actions">
+            <button class="tt-profile-btn" data-mind-id="${n.id}" title="View ${n.name}'s profile">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+              <span>Profile</span>
+            </button>
+            <button class="tt-chat-icon-btn" data-mind-id="${n.id}" title="Chat with ${n.name}">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+              <span>Chat</span>
+            </button>
+          </div>
         </div>
         <div class="tt-domains">${domains}</div>
         <div class="tt-bio">${n.bio}</div>
         ${discoverBtn}`;
+      const profileBtn = tooltip.querySelector('.tt-profile-btn');
+      if (profileBtn) {
+        profileBtn.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          tooltip.classList.add('hidden');
+          _tooltipNode = null;
+          // Profile is FREE for all users — open SSR /mind/{id} which
+          // is now auth-aware and shows the rich aggregation page with
+          // proper SPA chrome for logged-in visitors.
+          openMindDetails(profileBtn.dataset.mindId);
+        });
+      }
       const chatBtn = tooltip.querySelector('.tt-chat-icon-btn');
       if (chatBtn) {
         chatBtn.addEventListener('click', (ev) => {

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -3364,28 +3364,31 @@ async function deleteBook(agentId) {
 window.deleteBook = deleteBook;
 
 // ─── Detail-page entry points (book + mind) ───
-// Books: from library card body → /book/{id}?details=1 in a new tab.
-// Minds: from minds-graph node body → /mind/{id}?details=1 in a new tab.
-// The ?details=1 query param bypasses the server-side referer auto-redirect
-// (see book_page / mind_page handlers) so the SSR landing page actually
-// renders for the logged-in user instead of bouncing to the SPA reader/chat.
+// Routes the user IN-SPA, same tab, to the existing SPA-native detail
+// surfaces (#/book/{id} and #/mind/{id}). Earlier iteration opened a new
+// tab to the SSR /book/{id} / /mind/{id} URLs — that's the SEO landing
+// page meant for external crawlers + share-link visitors. Logged-in
+// product users hit it without auth context (different chrome, "Open
+// Feynman →" CTA, different design system) and the cohesion broke.
 //
-// Splits "exploration" (free, no paywall) from "engagement" (Chat button,
-// paywall on minds). Discovery is free; conversion ask happens at the
-// moment of value.
+// Keeping the SPA hash routes preserves:
+//   * the proper Feynman logo + topbar
+//   * auth context (sidebar, user profile menu)
+//   * the unified design system (SPA tokens, sans-serif, light/dark mode)
+//   * navigation history (back button works inside SPA)
+//
+// The SSR /book/{id} and /mind/{id} URLs stay reachable for crawlers
+// and external share traffic — they're indexed by Google and cited by
+// LLMs; SPA users just don't open them directly.
 function openBookDetails(agentId) {
   if (!agentId) return;
-  // selectedBooks doesn't change — the user's chat composer keeps whatever
-  // it had. They're just opening a side view of the book.
-  window.open('/book/' + encodeURIComponent(agentId) + '?details=1', '_blank',
-              'noopener,noreferrer');
+  window.location.hash = '#/book/' + encodeURIComponent(agentId);
 }
 window.openBookDetails = openBookDetails;
 
 function openMindDetails(mindId) {
   if (!mindId) return;
-  window.open('/mind/' + encodeURIComponent(mindId) + '?details=1', '_blank',
-              'noopener,noreferrer');
+  window.location.hash = '#/mind/' + encodeURIComponent(mindId);
 }
 window.openMindDetails = openMindDetails;
 
@@ -4846,10 +4849,10 @@ async function renderReader(agentId) {
   const _rTweetText = encodeURIComponent(`${d.title} — by ${_rAuthor || 'AI'} on feynman.wiki`);
   const _rTweetUrl = encodeURIComponent(_rShareUrl);
   const _rTweetIntentUrl = `https://twitter.com/intent/tweet?text=${_rTweetText}&url=${_rTweetUrl}`;
-  // Details button — opens /book/{id}?details=1 in new tab. Single entry
-  // point; the detail page itself surfaces Popular Questions + AI Insights
-  // + Discussed-by-Great-Minds + Related Books (the SEO long-tail
-  // content blocks that have no SPA-native equivalent).
+  // Details button — navigates to the SPA-native book detail view at
+  // #/book/{id} (NOT the SSR landing). Keeps the user in the same tab
+  // with proper SPA chrome, logo, and auth context. openBookDetails()
+  // uses window.location.hash so the back button works.
   const _rTopbarDetailsHtml = `
       <button type="button" class="reader-topbar-details-btn" aria-label="Book details" title="Book details" onclick="openBookDetails('${esc(agentId)}')">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>

--- a/app/static/seo-landing.css
+++ b/app/static/seo-landing.css
@@ -18,7 +18,13 @@
  *    visitors during the JS redirect; CSS must not interfere.
  */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Libre+Baskerville:wght@400;700&display=swap');
+/* Single sans-serif (Inter) across both SEO landing pages and the SPA
+   ensures a logged-in user navigating from /#/library to /book/{id}
+   doesn't feel any font/typeface shift. Earlier iteration loaded
+   Libre Baskerville serif here too — produced a "marketing brochure"
+   feel that clashed with the rest of the product when a user
+   actually arrived from inside the app. */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
   --feynman-text: #1d1d1f;
@@ -111,6 +117,20 @@ html, body {
   background: var(--feynman-accent-hover);
   color: #fff;
 }
+/* Authenticated-user variant: visitor is already a logged-in user
+   arriving from inside the SPA. "Open Feynman →" doesn't make sense
+   anymore; surface a softer "Back to app →" link without the loud
+   filled-pill marketing styling. */
+.feynman-header .feynman-nav a.feynman-cta.feynman-cta-soft {
+  background: transparent;
+  color: var(--feynman-text);
+  border: 1px solid var(--feynman-border-strong);
+  font-weight: 500;
+}
+.feynman-header .feynman-nav a.feynman-cta.feynman-cta-soft:hover {
+  background: var(--feynman-bg-subtle);
+  color: var(--feynman-text);
+}
 
 /* ─── Main content container ─────────────────────────────────────── */
 
@@ -129,24 +149,28 @@ body > h1 { margin-top: 36px; }
 
 /* ─── Typography ────────────────────────────────────────────────── */
 
+/* All headings use the same Inter face as body copy. Hierarchy comes
+   from size + weight + letter-spacing, not typeface contrast. */
 h1, h2, h3 {
-  font-family: 'Libre Baskerville', Georgia, 'Times New Roman', serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-weight: 700;
   color: var(--feynman-text);
-  letter-spacing: -0.01em;
-  line-height: 1.25;
+  letter-spacing: -0.022em;
+  line-height: 1.2;
 }
 h1 {
-  font-size: 36px;
-  margin: 0.4em 0 0.6em;
+  font-size: 34px;
+  margin: 0.4em 0 0.5em;
+  letter-spacing: -0.028em;
 }
 h2 {
-  font-size: 24px;
+  font-size: 20px;
   margin: 2em 0 0.6em;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--feynman-border);
+  letter-spacing: -0.015em;
 }
-h3 { font-size: 19px; margin: 1.6em 0 0.4em; }
+h3 { font-size: 17px; margin: 1.6em 0 0.4em; letter-spacing: -0.01em; }
 
 p { margin: 0.6em 0; color: var(--feynman-text); }
 
@@ -185,7 +209,6 @@ blockquote footer { color: var(--feynman-text-tertiary); font-size: 13px; }
 
 q {
   display: inline-block;
-  font-family: 'Libre Baskerville', Georgia, serif;
   font-style: italic;
   color: var(--feynman-text);
 }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1876,13 +1876,20 @@ body {
   font-size: 11px;
   color: var(--text-muted);
 }
-.minds-tooltip .tt-chat-icon-btn {
+/* Tooltip action row: Profile (free, secondary) + Chat (paywall, primary).
+   Stack them with a small gap so the eye groups them clearly as two
+   distinct actions, not one big button. */
+.minds-tooltip .tt-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.minds-tooltip .tt-chat-icon-btn,
+.minds-tooltip .tt-profile-btn {
   flex-shrink: 0;
   padding: 4px 10px;
   border-radius: 8px;
-  border: none;
-  background: var(--accent);
-  color: #fff;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -1892,8 +1899,21 @@ body {
   font-family: inherit;
   transition: all 0.15s;
 }
-.minds-tooltip .tt-chat-icon-btn:hover {
-  opacity: 0.85;
+.minds-tooltip .tt-chat-icon-btn {
+  border: none;
+  background: var(--accent);
+  color: #fff;
+}
+.minds-tooltip .tt-chat-icon-btn:hover { opacity: 0.85; }
+/* Profile button is the "free exploration" path — softer styling so the
+   accent-color Chat button stays the primary visual call to action. */
+.minds-tooltip .tt-profile-btn {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border-strong, rgba(255,255,255,0.18));
+}
+.minds-tooltip .tt-profile-btn:hover {
+  background: var(--hover-bg, rgba(255,255,255,0.06));
 }
 .minds-tooltip .tt-domains {
   display: flex;

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1347,12 +1347,17 @@ class TestPhase8Renderers:
         from app.core import seo
         assert seo.render_insight_cards([]) == ""
 
-    def test_empty_state_includes_cta(self):
+    def test_empty_state_explains_what_is_missing(self):
+        # Renamed from test_empty_state_includes_cta — the empty state
+        # used to inline its own "Start a chat →" button which duplicated
+        # the page's bottom CTA. Removed that button after screenshot
+        # review showed it as a redundant second Chat affordance.
         from app.core import seo
         out = seo.render_insights_empty_state("Sapiens", "https://x.com/#/chat/abc")
         assert "Sapiens" in out
-        assert "https://x.com/#/chat/abc" in out
-        assert "No AI insights" in out or "Start a chat" in out
+        assert "No AI insights" in out or "haven't accumulated" in out
+        # No inline CTA — the page's own bottom CTA handles that.
+        assert "cta-btn" not in out
 
     def test_article_jsonld_structure(self):
         from app.core import seo


### PR DESCRIPTION
**One URL per entity, auth-aware chrome, same rich page for everyone.**

Per user direction: don't fragment SEO and product into separate
routes. Reshape the SSR pages so they're beautiful enough to serve
both Google crawlers AND logged-in product users from the same URL.

## What was wrong

Three competing surfaces for the same conceptual page:

| Route | Audience | Chrome | Content |
|---|---|---|---|
| `#/book/{id}` SPA | Logged in | SPA | Chat + sidebar (no aggregations) |
| `/book/{id}` SSR (anon referer) | External / SEO | Marketing + serif | Full aggregations |
| `/book/{id}?details=1` | SPA users via "View details" | Marketing + serif | Full aggregations |

User feedback (screenshots): "I'm logged in and this page looks like
a marketing landing — different logo, different fonts, 'Open Feynman'
CTA showing as if I'm anonymous. Why isn't this part of the product?"

## What's fixed

- **One URL** `/book/{id}` and `/mind/{id}` for everyone. SSR.
- **Auth-aware chrome**: `_get_user_id(request)` decides whether to
  show the marketing "Open Feynman →" filled CTA (anonymous) or a
  soft "Back to app →" outline link (logged in). Brand wordmark, nav
  links unchanged either way for visual stability.
- **Unified typography**: Inter sans-serif throughout. Removed Libre
  Baskerville serif headings.
- **Removed referer redirect** + `?details=1` opt-out. The page IS
  the destination for everyone.
- SPA `openBookDetails` / `openMindDetails` navigate to the plain URL
  via `window.location.href` — page reload, back button returns to SPA.
- **Mind tooltip** gets explicit "Profile" button next to "Chat".
  Profile free, Chat paywalled.
- **Insights empty state** no longer inlines its own "Start a chat" —
  duplicated the page's bottom CTA (the screenshot's "two Chat buttons"
  complaint).

275 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
