### PR TITLE
feat(funnel): preserve book intent across SEO/share → signup → resume chat

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -57,6 +57,111 @@ function isProUser() {
   return userTier === 'pro';
 }
 
+// ─── Pending intent (SEO/share → signup → resume chat) ───
+//
+// When an anonymous visitor lands on /book/{id} via search or a shared link
+// and clicks "Chat", we need to keep the *book they came for* alive across
+// the login redirect. Without this, the SPA bounces them to the generic
+// landing page after signup and the original intent is lost — the single
+// biggest funnel leak from the SEO surface.
+//
+// Lifecycle:
+//   1. chatWithBookByAgent saves { bookId, ts } when !currentUser.
+//   2. User signs up; SIGNED_IN handler in initSupabase marks onboarding
+//      done so we skip the topic-picker (they already told us with their feet
+//      which book they want).
+//   3. renderHome calls _restorePendingBookIntent, which waits for allBooks
+//      to load, then selects the book and focuses the composer.
+//   4. Intent expires after 1 day so stale localStorage doesn't hijack a
+//      future unrelated session.
+const _PENDING_INTENT_KEY = 'feynman:pendingChat';
+const _PENDING_INTENT_TTL_MS = 24 * 60 * 60 * 1000;
+
+function _savePendingBookIntent(bookId, opts = {}) {
+  if (!bookId) return;
+  try {
+    localStorage.setItem(_PENDING_INTENT_KEY, JSON.stringify({
+      bookId,
+      question: opts.question || '',
+      via: opts.via || 'reader',
+      ts: Date.now(),
+    }));
+    phTrack('pending_intent_saved', { via: opts.via || 'reader' });
+  } catch (e) { console.warn('pendingChat save failed:', e); }
+}
+
+function _readPendingBookIntent() {
+  try {
+    const raw = localStorage.getItem(_PENDING_INTENT_KEY);
+    if (!raw) return null;
+    const intent = JSON.parse(raw);
+    if (!intent?.bookId) return null;
+    if (intent.ts && Date.now() - intent.ts > _PENDING_INTENT_TTL_MS) {
+      localStorage.removeItem(_PENDING_INTENT_KEY);
+      return null;
+    }
+    return intent;
+  } catch { return null; }
+}
+
+function _clearPendingBookIntent() {
+  try { localStorage.removeItem(_PENDING_INTENT_KEY); } catch {}
+}
+
+async function _restorePendingBookIntent() {
+  const intent = _readPendingBookIntent();
+  if (!intent) return false;
+
+  // Wait up to ~3s for allBooks to populate. The catalog load races with
+  // renderHome on first render; without this poll, the book lookup below
+  // can miss even though the book is about to land in allBooks.
+  for (let i = 0; i < 10 && !allBooks.length; i++) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  let book = allBooks.find(b => b.id === intent.bookId);
+  if (!book) {
+    // Fall back to a direct fetch — happens when the book exists but the
+    // user's catalog filter excludes it (e.g. catalog stub, status='error').
+    try {
+      const agent = await api('/api/agents/' + encodeURIComponent(intent.bookId));
+      if (agent) {
+        const meta = agent.meta || {};
+        book = {
+          id: agent.id, title: agent.name, author: meta.author || agent.source || '',
+          agentId: agent.id, status: agent.status,
+          category: meta.category || agent.type,
+          available: true,
+          isAIGenerated: agent.type === 'ai_book',
+          hasFullText: agent.type === 'ai_book',
+        };
+        allBooks.push(book);
+      }
+    } catch (e) { console.warn('pendingChat fetch failed:', e); }
+  }
+
+  if (!book) {
+    _clearPendingBookIntent();
+    return false;
+  }
+
+  selectedBooks.clear();
+  selectedMinds.clear();
+  selectedBooks.set(book.id, book);
+  renderSelectedChips();
+  renderStarters();
+
+  const input = document.getElementById('home-input');
+  if (input) {
+    if (intent.question) input.value = intent.question;
+    input.focus();
+  }
+
+  phTrack('pending_intent_restored', { via: intent.via, had_question: !!intent.question });
+  _clearPendingBookIntent();
+  return true;
+}
+
 async function loadUserTier() {
   if (!window.FEYNMAN_PRO || !currentUser) { userTier = 'free'; return; }
   try {
@@ -1785,6 +1890,14 @@ function ensurePolling() {
 
 // ─── Home ───
 function renderHome() {
+  // Pending intent (SEO/share → signup) takes priority over topic onboarding.
+  // The user already told us which book they want — making them pick topics
+  // first would discard the strongest activation signal we have.
+  const hasPendingIntent = !!_readPendingBookIntent();
+  if (hasPendingIntent && !localStorage.getItem('onboardingDone')) {
+    localStorage.setItem('onboardingDone', '1');
+  }
+
   if (!localStorage.getItem('onboardingDone')) {
     document.getElementById('home-center-main').classList.add('hidden');
     showOnboarding();
@@ -1794,6 +1907,11 @@ function renderHome() {
   document.getElementById('home-center-main').classList.remove('hidden');
   document.getElementById('greeting').textContent = getGreeting();
   renderStarters();
+
+  if (hasPendingIntent) {
+    // Fire-and-forget: book lookup may need a moment for allBooks to populate.
+    _restorePendingBookIntent();
+  }
 }
 
 // ─── Starter questions ───
@@ -4716,6 +4834,16 @@ function selectBookForChat(bookId) {
 window.selectBookForChat = selectBookForChat;
 
 async function chatWithBookByAgent(agentId) {
+  // Anonymous click from reader/SEO surface: keep the book intent alive
+  // through signup so the user lands back on chat *with this book* instead
+  // of the generic landing page. See _savePendingBookIntent for the full
+  // lifecycle. Skips landing entirely — the user's already past the pitch.
+  if (window.FEYNMAN_PRO && !currentUser) {
+    _savePendingBookIntent(agentId, { via: 'reader' });
+    window.location.hash = '#/login';
+    return;
+  }
+
   let book = allBooks.find(b => b.agentId === agentId);
   if (!book) {
     try {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -2928,7 +2928,7 @@ html.dark .mind-share-opt:hover { background: rgba(255,255,255,0.08); }
 .lp-chat-card {
   flex: 1 1 auto;
   max-width: 620px;
-  height: min(520px, calc(100vh - 140px));
+  height: min(580px, calc(100vh - 140px));
   background: rgba(255,255,255,0.18);
   backdrop-filter: blur(20px) saturate(1.3);
   -webkit-backdrop-filter: blur(20px) saturate(1.3);


### PR DESCRIPTION
## Why

A SQL audit of the 72 registered users surfaced that **87.5% (63/72) never sent a single chat** after signing up. Of the ~9 who did chat, signup-to-first-action was fast (median ~1.5 min) — meaning the activation flow works *if* users engage, but most just bail after signup. The biggest single contributor identified in the review: **anonymous visitors arriving via SEO or shared book links lose their book context at signup.**

Current behaviour for a visitor landing on `/book/{id}` (e.g. from Google "Thinking, Fast and Slow main ideas"):
1. Clicks "Chat about X" CTA → `/#/read/{id}` (reader loads, anonymous-OK)
2. Reads the preview, clicks "Chat" at the end
3. `chatWithBookByAgent` sets hash to `#/` → router sees `!currentUser && FEYNMAN_PRO` → **bounces them to the generic landing page**, the book is dropped from `selectedBooks` across the navigation
4. Click "Get Started Free" → signup → topic-onboarding asking what they're "curious about" (they came for a *specific book*, not a topic)
5. After onboarding, they're in a random book picker — the book they came for is lost

This PR keeps that intent alive.

## What

**`feat(funnel)`** — `app/static/app.js`
- New `_savePendingBookIntent / _read / _clear / _restorePendingBookIntent` helpers (24h TTL, fire-and-forget restore with `allBooks` polling, fallback fetch for catalog stubs).
- `chatWithBookByAgent`: when `!currentUser && FEYNMAN_PRO`, save `{ bookId, ts, via }` to `localStorage` and redirect to `/#/login` instead of bouncing through landing.
- `renderHome`: if pending intent exists, mark `onboardingDone` (skip topic picker — the user already told us their book with their feet), then restore the intent post-render.
- Two PostHog events for funnel measurement: `pending_intent_saved`, `pending_intent_restored`.

**`style(landing)`** — `app/static/styles.css`
- `.lp-chat-card` desktop height `520px → 580px`. ~11.5% taller. Mobile breakpoint untouched.

## Manual verification

1. Logged out, visit `/book/{any-published-book-id}`
2. Click "Chat about X" → lands in reader
3. Scroll to end of preview, click "Chat"
4. **Should land at `/#/login`** (not the generic landing page)
5. Sign up
6. **Should land on home with that book chip already selected and composer focused**
7. No topic-onboarding step
8. PostHog: `pending_intent_saved` fires at step 3; `pending_intent_restored` fires at step 6

## What's NOT in this PR

- **Pro/Free feature list rewrites** — owner is handling separately
- **Onboarding topic-step removal** for non-intent users (Twitter/direct visitors) — separate change
- **Landing demo interactivity** — explicitly scoped out
- **SEO detail page integration in SPA** — will be handled in the SEO session

🤖 Generated with [Claude Code](https://claude.com/claude-code)