### PR TITLE
feat(seo): graceful empty-state for catalog-stub book detail pages

### DIFF
--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -308,6 +308,33 @@ def _drop_nulls(obj: Any) -> Any:
 
 # ─── Book page section builders ───────────────────────────────────────
 
+def render_book_empty_state(title: str, author: str) -> str:
+    """Render the "not indexed yet" notice for catalog-stub books.
+
+    Roughly 575 of 932 catalog books in production are stubs with 1-4
+    metadata chunks but no full text — Gutenberg can't serve them
+    (modern in-copyright) and no user has uploaded a copy. The SSR
+    detail page for those books otherwise degrades to just <h1>Title</h1>
+    + author + topic link + chat CTA, which looks empty enough that
+    visitors (per user screenshot review on 2026-05-27) wonder if the
+    page is broken. This section gives the page a meaningful body
+    explaining the state, while letting the page's bottom CTA matrix
+    handle the actual Chat button (no duplicate CTAs)."""
+    author_phrase = f' by {_esc(author)}' if author else ''
+    return (
+        '<section class="empty-state">'
+        f'<p class="empty-state-headline">Full text isn\'t indexed yet for '
+        f'<em>{_esc(title)}</em>{author_phrase}.</p>'
+        '<p>This title sits in our catalog but its primary text wasn\'t '
+        'available from public-domain sources (Project Gutenberg, '
+        'OpenLibrary, etc.) and no reader has uploaded a copy. You can '
+        'still chat with Feynman about it — the AI draws on general '
+        'knowledge and the book\'s metadata even when the book passages '
+        'aren\'t available for retrieval.</p>'
+        '</section>'
+    )
+
+
 def render_book_about(subtitle: str, author: str) -> str:
     """Top-of-page 1-2 sentence summary. The subtitle (from outline) is the
     best signal we have for what the book is *about* in the author's own

--- a/app/main.py
+++ b/app/main.py
@@ -1319,6 +1319,19 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
     cta_target_url = reader_url
 
     # ── Build content sections ──────────────────────────────────────────
+    # Stub detection: catalog book with no chunks, no chapters, no questions.
+    # The other content renderers gracefully no-op on empty input, which
+    # leaves the page nearly bare. Render an explicit empty-state so
+    # visitors (logged in or anonymous) understand WHY content is thin
+    # rather than wondering if the page is broken. The page's bottom CTA
+    # matrix still carries the Chat button — empty-state itself doesn't
+    # duplicate that affordance.
+    is_stub = not chunks and not chapters and not questions
+    empty_state_html = (
+        seo_render.render_book_empty_state(title_raw, author_raw)
+        if is_stub else ""
+    )
+
     about_html = seo_render.render_book_about(subtitle_raw, author_raw)
     stats_html = seo_render.render_stats(total_words, chapter_count)
     toc_html = seo_render.render_toc(chapters)
@@ -1447,6 +1460,7 @@ def book_page(agent_id: str, request: Request) -> HTMLResponse:
 {seo_render.render_landing_header(base, is_authenticated=is_authenticated)}
 <h1>{title}</h1>
 {author_html}
+{empty_state_html}
 {about_html}
 {stats_html}
 {samples_html}

--- a/app/static/seo-landing.css
+++ b/app/static/seo-landing.css
@@ -227,6 +227,25 @@ article.insight-card p,
 article.public-post p { margin: 0.5em 0; }
 
 p.book-author { color: var(--feynman-text-secondary); font-size: 18px; margin-top: 0; }
+
+/* Empty-state block — rendered on catalog-stub book pages where the
+   page would otherwise feel suspiciously thin. Same color treatment
+   as a quote/aside, no border, slightly muted so it reads as
+   metadata-about-the-page rather than primary content. */
+section.empty-state {
+  background: var(--feynman-bg-subtle);
+  border-radius: 10px;
+  padding: 22px 24px;
+  margin: 28px auto;
+}
+section.empty-state .empty-state-headline {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--feynman-text);
+  margin: 0 0 8px;
+}
+section.empty-state p { margin: 0.5em 0; color: var(--feynman-text-secondary); }
+section.empty-state p:last-child { margin-bottom: 0; }
 p.book-stats, p.mind-meta { color: var(--feynman-text-secondary); font-size: 14px; }
 p.book-about { font-size: 19px; line-height: 1.55; }
 


### PR DESCRIPTION
Catalog stubs (575 of 932 books in production — modern in-copyright
titles Gutenberg can't serve and no user has uploaded) have no chunks,
no chapters, and no questions. Their `/book/{id}` SSR page degraded
to just title + author + topic link + chat CTA — visitors wondered if
the page was broken.

book_page now detects the stub state and renders an explicit
empty-state block between the author line and the rest of the page,
explaining why content is thin and inviting the user to chat anyway
(the AI works on general knowledge + metadata when book passages
aren't available for RAG).

No CTA inside the empty-state — the page's existing CTA matrix at the
bottom still carries the Chat button. Avoids the "two Chat buttons"
duplication that bit us on the insights page earlier.

Styling: same `.feynman-quote-bg` + rounded card pattern as other
muted asides, so it reads as page-metadata rather than primary
content.

275 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
