### PR TITLE
fix(spa): open /#/library to anonymous visitors (public catalog browsing)

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1579,7 +1579,12 @@ function navigate() {
       if (window.FEYNMAN_PRO && !currentUser) { window.location.hash = '#/login'; return; }
       renderChatsPage(); break;
     case 'library':
-      if (window.FEYNMAN_PRO && !currentUser) { window.location.hash = '#/login'; return; }
+      // Library is a public catalog browser — anyone can view the
+      // shared collection of books. Earlier the Pro-mode branch
+      // forced anonymous visitors to /#/login here, which was wrong:
+      // browsing the catalog is a discovery action, not a personal
+      // one. Personal actions (Upload, Delete) still gate themselves
+      // when the user clicks them.
       renderLibrary(); break;
     case 'minds': renderMindsPage(); break;
     case 'login': renderLoginPage(); break;


### PR DESCRIPTION
In Pro mode the SPA redirected anonymous users to /#/login when they
hit /#/library. That was wrong: library is a PUBLIC CATALOG anyone
can browse, not a personal collection. A visitor arriving from
Google or a share link should be able to discover what's available
before being asked to sign in.

Personal actions still gate themselves correctly (upload, delete,
sending chat messages — all via POST endpoints with auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
