### PR TITLE
fix(spa): library page first-visit empty state race condition

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1585,7 +1585,20 @@ function navigate() {
       // browsing the catalog is a discovery action, not a personal
       // one. Personal actions (Upload, Delete) still gate themselves
       // when the user clicks them.
-      renderLibrary(); break;
+      renderLibrary();
+      // First-visit guard: if init()'s loadAgents() happened to settle
+      // before this route entry (race with OAuth callback or hash
+      // change ordering), allBooks may be empty at this point and
+      // renderBookGrid renders "No books found" for booksLoadState=
+      // 'ready'+empty. Re-fetch + re-render covers that edge case.
+      // The user previously had to F5 to see books — this fix
+      // eliminates that.
+      if (!allBooks.length && booksLoadState !== 'loading') {
+        loadAgents().then(() => {
+          if (getRoute().page === 'library') renderLibraryGrid();
+        });
+      }
+      break;
     case 'minds': renderMindsPage(); break;
     case 'login': renderLoginPage(); break;
     case 'subscription': renderSubscriptionPage(); break;


### PR DESCRIPTION
User reported: first navigation to /#/library after login shows
"No books found"; refresh fixes it. Data intact (944 agents in
production); pure frontend race.

**Trigger**: `init()` calls `navigate()` before `loadAgents()`
resolves. If the URL hash points to /#/library at that moment
(deep-link, OAuth callback redirect, or sidebar click during
init's await), the first render reads empty `allBooks` while
`booksLoadState` is still `'idle'`. When the load finally completes,
`booksLoadState` transitions to `'ready'` — but only the SECOND
`navigate()` in init() re-renders, and depending on timing of the
SIGNED_IN auth callback it may have already redirected hash to /#/
home.

**Fix**: in the `library` route handler, if `allBooks` is empty
and we're not currently loading, trigger a fresh `loadAgents()` +
re-render the grid. Guard is cheap (length check), only fires
when the bug actually manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
