### PR TITLE
fix(egress): 6h edge cache on public book-read endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3035,11 +3035,19 @@ def api_public_read_book(agent_id: str, request: Request):
 
     cache_key = f"public_book:{agent_id}"
     cached = _cache_get(cache_key, _BOOK_CACHE_TTL)
+    # Cache headers tuned 2026-05-28 for egress conservatism:
+    # books are static once indexed (chunk text doesn't mutate after
+    # `_learn_agent` completes), so we can let Vercel's edge serve
+    # cache hits for 6h before re-validating. Previously s-maxage=1800
+    # (30 min) drove repeat egress on popular books — a 320 KB book
+    # × 100 crawler/share visits in a day × 12 cache rotations =
+    # ~380 MB/day from a single book. 6h cache cuts that by 12×.
+    cache_ttl_header = "public, max-age=600, s-maxage=21600"
     if cached is not None:
         return JSONResponse(
             content=cached,
             headers={
-                "Cache-Control": "public, max-age=300, s-maxage=1800",
+                "Cache-Control": cache_ttl_header,
                 "X-Cache": "HIT",
             },
         )
@@ -3053,7 +3061,7 @@ def api_public_read_book(agent_id: str, request: Request):
     return JSONResponse(
         content=payload,
         headers={
-            "Cache-Control": "public, max-age=300, s-maxage=1800",
+            "Cache-Control": cache_ttl_header,
             "X-Cache": "MISS",
         },
     )


### PR DESCRIPTION
Tightens the second-largest egress hot path after PR #28.

`/api/public/book/{id}/read` returns the entire reassembled book
payload (200 KB to 1.5 MB per book) on every cache miss. Previously
served with `s-maxage=1800` (30 min edge cache) which forced full
re-egress every 30 min per popular book per edge node.

Books are static once indexed (chunk text doesn't mutate after
`_learn_agent` completes), so **6-hour edge cache** is safe. Cuts
repeat egress on popular books by 12× without freshness regression.

**Worked example**: a 320 KB book hit 100× per day across SSR
landing + share-link + crawler paths was driving ~380 MB/day egress
on the old 30-min cache. 6h cache cuts that to ~32 MB/day for the
same book.

Part of the "prevent re-hitting Supabase free tier" hardening:
- PR #28: SSR sample passages — 99% bandwidth cut
- This: public book-read — 12× cache TTL
- Plus: daily `supabase-usage-monitor` scheduled task (alerts +
  auto-pauses backfill loop at 70% threshold; not in code, lives
  in scheduled-tasks).
- Plus: backfill loop now has a 70% safety gate that aborts before
  running if DB or egress is close to limit.

275 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
