### PR TITLE
fix(seo): sitemap discussions gate — emit only entities with ≥1 approved session

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2225,6 +2225,65 @@ def list_assistant_messages_for_mind(
             return []
 
 
+def count_approved_public_sessions_per_agent(
+    agent_ids: list[str],
+) -> dict[str, int]:
+    """How many approved public chat sessions each book has — used by the
+    sitemap to decide whether to include /book/{id}/discussions URLs.
+
+    Without this gate, sitemap emits a /discussions URL for every ready
+    book (754 of them in production as of 2026-05-28), most of which
+    render an empty aggregation page because no user has actually
+    shared a discussion yet. Google reads those as thin content and
+    drags the site-wide quality score down. Gate at >=1 approved
+    session, just like /insights gates at >=3 publishable messages.
+
+    Schema: chat_sessions.session_type='book' sets mind_id to the
+    book's agent_id (legacy column naming).
+    """
+    if not agent_ids:
+        return {}
+    placeholders = ",".join(["?"] * len(agent_ids))
+    with get_conn() as conn:
+        try:
+            rows = _fetchall(conn, _q(
+                f"""SELECT mind_id AS agent_id, COUNT(*) AS n
+                    FROM chat_sessions
+                    WHERE public_status = 'approved'
+                      AND session_type = 'book'
+                      AND mind_id IN ({placeholders})
+                    GROUP BY mind_id"""
+            ), tuple(agent_ids))
+            return {r["agent_id"]: int(r["n"]) for r in rows}
+        except Exception:
+            return {}
+
+
+def count_approved_public_sessions_per_mind(
+    mind_ids: list[str],
+) -> dict[str, int]:
+    """How many approved public chat sessions each mind has — same
+    rationale as the per-agent variant above. Schema:
+    chat_sessions.session_type IN ('chat', 'mind') AND mind_id = mind.id.
+    """
+    if not mind_ids:
+        return {}
+    placeholders = ",".join(["?"] * len(mind_ids))
+    with get_conn() as conn:
+        try:
+            rows = _fetchall(conn, _q(
+                f"""SELECT mind_id, COUNT(*) AS n
+                    FROM chat_sessions
+                    WHERE public_status = 'approved'
+                      AND session_type IN ('chat', 'mind')
+                      AND mind_id IN ({placeholders})
+                    GROUP BY mind_id"""
+            ), tuple(mind_ids))
+            return {r["mind_id"]: int(r["n"]) for r in rows}
+        except Exception:
+            return {}
+
+
 def count_assistant_messages_batch(
     agent_ids: list[str], min_chars: int = 200,
 ) -> dict[str, int]:

--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,8 @@ from .core.db import (
     list_agents,
     list_chat_sessions,
     approve_chat_session_public,
+    count_approved_public_sessions_per_agent,
+    count_approved_public_sessions_per_mind,
     count_assistant_messages_batch,
     count_assistant_messages_for_minds_batch,
     count_chunks_batch,
@@ -902,12 +904,22 @@ def sitemap_xml():
   </url>
 """
 
-        # Phase 6 — public discussion pages. Only included when the
-        # feature flag is on, so the sitemap stays consistent with the
-        # actual route surface. Flip ENABLE_PUBLIC_DISCUSSIONS to surface
-        # these to Google.
+        # Phase 6 — public discussion aggregation pages. Gated on the
+        # feature flag AND on the entity having ≥1 approved public
+        # session, so we don't emit 754 thin/empty pages (which was
+        # the production state observed in GSC on 2026-05-28: every
+        # /book/{id}/discussions and /mind/{id}/discussions URL was
+        # being advertised regardless of whether any user had actually
+        # shared a discussion). Empty aggregation pages drag site-wide
+        # quality score down. Single batched COUNT(*) per corpus keeps
+        # the sitemap render cheap.
         if ugc_module.is_enabled():
+            agent_discussion_counts = count_approved_public_sessions_per_agent(
+                [a["id"] for a in ready_agents]
+            )
             for agent in ready_agents:
+                if agent_discussion_counts.get(agent["id"], 0) < 1:
+                    continue
                 urls += f"""  <url>
     <loc>{_SITE_URL}/book/{agent["id"]}/discussions</loc>
     <lastmod>{today}</lastmod>
@@ -915,7 +927,12 @@ def sitemap_xml():
     <priority>0.4</priority>
   </url>
 """
+            mind_discussion_counts = count_approved_public_sessions_per_mind(
+                [m["id"] for m in all_minds]
+            )
             for mind in all_minds:
+                if mind_discussion_counts.get(mind["id"], 0) < 1:
+                    continue
                 urls += f"""  <url>
     <loc>{_SITE_URL}/mind/{mind["id"]}/discussions</loc>
     <lastmod>{today}</lastmod>


### PR DESCRIPTION
Audit on 2026-05-28 found the sitemap was emitting 754
`/book/{id}/discussions` and `/mind/{id}/discussions` URLs
unconditionally for every ready entity when ENABLE_PUBLIC_DISCUSSIONS=true.
Most of these pages render empty (no user has shared a discussion
yet). Google reads empty aggregation pages as thin content and
drags site-wide quality score down — same anti-pattern that prompted
the `chunks ≥ 5` gate on `/q/` URLs and the `assistant_messages ≥ 3`
gate on `/insights` URLs.

New `count_approved_public_sessions_per_{agent,mind}` helpers
(single batched `COUNT(*)` per corpus, cheap) gate sitemap inclusion
at ≥1 approved session. Until users actually opt in and admin
approves, these URLs simply don't appear in the sitemap.

The `/book/{id}/discussions` route itself still works for direct
hits (renders an empty aggregation; that's fine for stray crawls).

**Expected sitemap drop on next read**: 1960 → ~1206 URLs (-39%),
entirely in the `/discussions` bucket which had near-zero content
density. Once we actually have approved sessions (Phase 6.1
editorial showcase), those entities re-enter the sitemap naturally.

275 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
