### PR TITLE
feat(library): floating back-to-top button on scroll

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1643,6 +1643,38 @@ function _updateSidebarActive(page) {
   if (sel) document.querySelector(sel)?.classList.add('active');
 }
 
+// ─── Back to top ───
+// One floating button anchored in .app-main. On each navigation we (re)bind
+// its scroll listener to the active page-view. The long list/grid pages
+// (library, chats, home, subscription) are themselves the scroll containers
+// (overflow-y:auto); chat-style pages scroll an inner .chat-messages instead,
+// so we only arm the button on the page-view-scrolling routes.
+const _BACK_TO_TOP_PAGES = new Set(['library', 'chats', 'home', 'subscription']);
+let _backToTopEl = null;
+let _backToTopScroller = null;
+let _backToTopRaf = 0;
+
+function _backToTopOnScroll() {
+  if (_backToTopRaf) return;
+  _backToTopRaf = requestAnimationFrame(() => {
+    _backToTopRaf = 0;
+    if (!_backToTopEl || !_backToTopScroller) return;
+    _backToTopEl.classList.toggle('visible', _backToTopScroller.scrollTop > 400);
+  });
+}
+
+function bindBackToTop(scroller) {
+  if (_backToTopEl === null) _backToTopEl = document.getElementById('back-to-top');
+  if (!_backToTopEl) return;
+  if (_backToTopScroller) _backToTopScroller.removeEventListener('scroll', _backToTopOnScroll);
+  _backToTopScroller = scroller || null;
+  _backToTopEl.classList.remove('visible');
+  if (_backToTopScroller) {
+    _backToTopScroller.addEventListener('scroll', _backToTopOnScroll, { passive: true });
+    _backToTopOnScroll(); // sync now in case we landed on an already-scrolled page
+  }
+}
+
 function navigate() {
   const route = getRoute();
   // Reader attaches a document-level keydown handler; remove it when leaving #/read
@@ -1655,6 +1687,7 @@ function navigate() {
   const el = document.getElementById('page-' + route.page);
   if (el) el.classList.remove('hidden');
   _updateSidebarActive(route.page);
+  bindBackToTop(_BACK_TO_TOP_PAGES.has(route.page) ? el : null);
 
   const appLayout = document.getElementById('app-layout');
   if (route.page === 'landing') {
@@ -7428,6 +7461,11 @@ async function init() {
   // Sidebar toggle
   document.getElementById('sidebar-toggle-btn').addEventListener('click', toggleSidebar);
   document.getElementById('sidebar-float-btn').addEventListener('click', toggleSidebar);
+
+  // Back to top — smooth-scroll the currently bound page-view to the top
+  document.getElementById('back-to-top').addEventListener('click', () => {
+    if (_backToTopScroller) _backToTopScroller.scrollTo({ top: 0, behavior: 'smooth' });
+  });
   document.querySelector('.sidebar-logo').addEventListener('click', (e) => {
     if (document.getElementById('app-layout').classList.contains('sidebar-collapsed')) {
       e.preventDefault();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -88,7 +88,7 @@
     <script>
       (function(){var t=localStorage.getItem('feynman-theme');if(t)document.documentElement.classList.add(t)})();
     </script>
-    <link rel="stylesheet" href="/static/styles.css?v=108" />
+    <link rel="stylesheet" href="/static/styles.css?v=109" />
   </head>
   <body>
     <div class="app-layout" id="app-layout">
@@ -510,6 +510,13 @@
         <!-- ─── SUBSCRIPTION PAGE ─── -->
         <div id="page-subscription" class="page-view subscription-page hidden"></div>
 
+        <!-- ─── BACK TO TOP ─── -->
+        <!-- Anchored in .app-main (position:relative); its scroll listener is
+             (re)bound to the active scrolling page-view on each navigate(). -->
+        <button id="back-to-top" class="back-to-top" type="button" title="Back to top" aria-label="Back to top">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="4" x2="19" y2="4"/><line x1="12" y1="20" x2="12" y2="9"/><polyline points="7 14 12 9 17 14"/></svg>
+        </button>
+
       </div><!-- .app-main -->
     </div><!-- .app-layout -->
 
@@ -566,6 +573,6 @@
     <script>
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     </script>
-    <script src="/static/app.js?v=125"></script>
+    <script src="/static/app.js?v=126"></script>
   </body>
 </html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -419,6 +419,23 @@ body {
 }
 .sidebar-float-btn:hover { color: var(--text); background: rgba(128,128,128,0.08); }
 
+/* ─── Back-to-top floating button ─── */
+.back-to-top {
+  position: absolute; bottom: 24px; right: 24px; z-index: 40;
+  width: 42px; height: 42px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%; border: 1px solid var(--border);
+  background: var(--bg-chat); color: var(--text-muted);
+  cursor: pointer; box-shadow: var(--shadow-md);
+  opacity: 0; transform: translateY(8px); pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, color 0.15s, box-shadow 0.2s ease;
+}
+.back-to-top.visible { opacity: 1; transform: translateY(0); pointer-events: auto; }
+.back-to-top.visible:hover {
+  color: var(--text); transform: translateY(-2px); box-shadow: var(--shadow-lg);
+}
+.back-to-top.visible:active { transform: translateY(0); }
+
 /* ─── Main Content Area ─── */
 .app-main {
   flex: 1; min-width: 0;
@@ -1739,6 +1756,7 @@ body {
   .chats-content { padding: 16px 16px 48px; }
   .book-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); }
   .card-cover, .card-cover-placeholder { height: 160px; }
+  .back-to-top { bottom: 16px; right: 16px; width: 40px; height: 40px; }
 }
 
 /* ─── Skill badge (on chat messages) ─── */


### PR DESCRIPTION
## What

Adds a floating "back to top" button for long-scroll pages. Primary target is the Library (hundreds of book cards = long scroll, no quick way back without dragging the scrollbar). Also enabled on Chats / Home / Subscription.

## Behavior

- **Where it shows.** Only on routes whose page-view is itself the scroll container (`library` / `chats` / `home` / `subscription`). Chat-style pages scroll an inner `.chat-messages`, not the page-view, so the button is correctly never armed there.
- **When it shows.** rAF-throttled scroll handler toggles `.visible` once `scrollTop > 400`. Listener is rebound to the active page-view inside `navigate()`, so the wiring follows the user across routes.
- **What clicking does.** Smooth-scrolls the bound scroller back to the top.

## Design

- Anchored in `.app-main` (which is `position: relative`), so it floats over content but never overlaps the sidebar.
- 42 px circle, bottom-right with a 24 px gutter (16 px / 40 px on mobile).
- Reuses existing design tokens — `--bg-chat`, `--border`, `--text-muted`, `--shadow-md/lg` — so **dark mode comes for free**; no separate dark rule needed.
- Visual language matches `.sidebar-float-btn` (subtle secondary float) plus the book-card hover (slight lift + deeper shadow on hover). Icon is a stroke-based "arrow-up-to-line" matching the rest of the app's SVG vocabulary.

## Files

- `app/static/index.html` — button markup, asset cache bust (`styles.css?v=109`, `app.js?v=126`)
- `app/static/styles.css` — `.back-to-top` rules + mobile tweak
- `app/static/app.js` — `bindBackToTop()` rebound inside `navigate()`, click handler bound in `init()`

## Verification

Locally via the preview MCP (FastAPI on :8001, Library with 297 cards):

- ✅ Scroller correctly binds to `page-library` after navigate
- ✅ Threshold logic `scrollTop > 400` evaluates true at 1200
- ✅ Hidden state: `opacity: 0`, `pointer-events: none`
- ✅ `.visible` state: `opacity: 1`, `pointer-events: auto`, `border-radius: 50%`, `position: absolute` (transition bypassed to read true target opacity, since the headless preview tab is backgrounded and freezes the compositor)
- ✅ Click invokes `scrollTo({ top: 0, behavior: 'smooth' })` on the **bound** scroller
- ✅ `node --check app/static/app.js` passes, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)