### PR TITLE
fix(seo): book→topic link 404s on non-canonical categories

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -22,9 +22,11 @@ import {
   detectCapabilities,
   clampDescription,
   slugify,
+  canonicalTopicForCategory,
   bookJsonld,
   breadcrumbJsonld,
 } from "@/lib/seo-book";
+import { fetchTopics } from "@/lib/seo-mind";
 
 // ISR — on-demand revalidation, no generateStaticParams (thousands of books).
 export const revalidate = 86400;
@@ -82,12 +84,18 @@ export default async function BookLandingPage({ params }: PageProps) {
   if (!data) notFound();
 
   // Enrichment — all independent, all degrade to empty on failure.
-  const [questions, passages, related, overview] = await Promise.all([
+  const [questions, passages, related, overview, topics] = await Promise.all([
     getQuestions(id),
     getSamplePassages(id, 3),
     getRelatedForBook(id),
     getBookOverview(id),
+    fetchTopics(),
   ]);
+
+  // Map the book's free-form category to a canonical topic hub (or null) so the
+  // "Topic" rail links to a real /topic/{slug} instead of 404'ing on ad-hoc
+  // categories like "Business" (→ "Business & Strategy") or junk values.
+  const canonicalTopic = canonicalTopicForCategory(data.category, topics);
 
   const caps = detectCapabilities(data.agent);
   const chapterCount = data.chapters.length;
@@ -191,12 +199,12 @@ export default async function BookLandingPage({ params }: PageProps) {
           </ul>
         </div>
       ) : null}
-      {data.category ? (
+      {canonicalTopic ? (
         <div className="seo-rail-card">
           <h3>Topic</h3>
           <ul>
             <li>
-              <Link href={`/topic/${slugify(data.category)}`}>More on {data.category}</Link>
+              <Link href={`/topic/${slugify(canonicalTopic)}`}>More on {canonicalTopic}</Link>
             </li>
           </ul>
         </div>

--- a/web/lib/seo-book.ts
+++ b/web/lib/seo-book.ts
@@ -66,6 +66,34 @@ export function findQuestionBySlug(
   return null;
 }
 
+/**
+ * Map a book's free-form `meta.category` to one of the 15 canonical topic
+ * hubs, so the "More on …" link resolves to a real /topic/{slug} (200) instead
+ * of 404'ing. Books carry 46+ ad-hoc categories ("Business" vs the canonical
+ * "Business & Strategy", plus "Chemistry", "Contemporary Fiction", and some
+ * leaked chat prompts) — only those that map to a canonical topic get a link;
+ * the rest return null and the caller omits the link rather than sending a
+ * crawler to a dead end. `topics` is the canonical list from /api/topics.
+ */
+export function canonicalTopicForCategory(
+  category: string,
+  topics: string[],
+): string | null {
+  const cat = (category || "").trim().toLowerCase();
+  if (!cat || !topics?.length) return null;
+  const catSlug = slugify(category);
+  // 1) exact slug match (Psychology, Economics, Computer Science, …)
+  for (const t of topics) {
+    if (slugify(t) === catSlug) return t;
+  }
+  // 2) loose containment either way (Business → Business & Strategy)
+  for (const t of topics) {
+    const tl = t.toLowerCase();
+    if (tl.includes(cat) || cat.includes(tl)) return t;
+  }
+  return null;
+}
+
 // ─── JSON-LD schema builders (ported from seo.py) ──────────────────────
 
 type Json = Record<string, unknown>;


### PR DESCRIPTION
## The bug (reported via a 404 on `/topic/business`)

Books carry **46+ free-form `meta.category` values**, but there are only **15 canonical `/topic` hubs**. The book hub's "Topic" rail linked to `/topic/{slugify(category)}`, so every book whose category isn't an exact tag sent Google to a dead end:

- `/topic/business` → 404 (canonical is `business-strategy`)
- `/topic/chemistry`, `/topic/contemporary-fiction`, `/topic/biography` → 404
- junk categories (leaked chat prompts) → `/topic/who-are-you`, `/topic/how-to-fix-the-scaling-issue…` → 404

These are self-inflicted 404s on URLs Google crawls — the same crawl-budget poison we've been removing.

## Fix

`canonicalTopicForCategory(category, topics)` — exact slug match, then loose containment either way — maps the category to a real hub, and the book page **only renders the Topic link when it maps**; otherwise it omits the card. `Business → Business & Strategy`; unmappable or junk categories get no link (no 404).

## Audit note

I checked **every** constructed internal link across the SEO pages — this category→topic link was the **only** 404-prone one. All others (`/mind/{id}`, `/book/{id}`, `/q/`, `/on/`, mind/topic-rail links) use canonical topics or real entity IDs.

Separately surfaced (not in this PR — it's a data issue): several books have **garbage categories** that are leaked chat prompts (`"who are you"`, `"does this company worth buying"`). Those junk books should be noindex'd / excluded from the sitemap (catalog-hygiene follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
