### PR TITLE
fix(seo): stop & hide leaked chat-query book categories

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -463,6 +463,26 @@ def _learn_agent(agent_id: str) -> None:
 
 # ─── Scheduled discovery ───
 
+def _clean_catalog_category(topic: str) -> str:
+    """Topic discovery passes the user's raw chat query as ``topic``; storing it
+    verbatim as a book's category pollutes the catalog (e.g. "how game theory
+    can be used in hiring", "who are you", CJK queries) and self-propagates
+    through scheduled discovery, which re-discovers by existing category. Keep it
+    as the category only when it actually looks like a category — short,
+    Title-Case ASCII, not a question/sentence — else return "" so we never
+    persist a chat prompt as a category. Mirrors the frontend isCleanCategory."""
+    t = (topic or "").strip()
+    if not t or "?" in t:
+        return ""
+    if not (t[:1].isascii() and t[:1].isupper()):
+        return ""
+    if len(t.split()) > 4:
+        return ""
+    if re.match(r"(?i)^(how|what|who|why|does|is|are|should|can|will|we|i|my)\b", t):
+        return ""
+    return t
+
+
 def _discover_books_for_topic(topic: str, count: int = TOPIC_DISCOVER_COUNT, exclude_titles: list[str] | None = None) -> tuple[list[dict[str, Any]], dict[str, int]]:
     """Use LLM to discover top books for a topic. Returns (books, usage)."""
     exclude_clause = ""
@@ -498,7 +518,8 @@ def _discover_books_for_topic(topic: str, count: int = TOPIC_DISCOVER_COUNT, exc
             continue
         already_existed = find_agent_by_name(title) is not None
         agent_id = create_catalog_agent(
-            title=title, author=author, category=topic, description=desc,
+            title=title, author=author,
+            category=_clean_catalog_category(topic), description=desc,
         )
         results.append({"id": agent_id, "title": title, "author": author, "new": not already_existed})
         log.info("Discovered book: %s by %s [%s] new=%s", title, author, topic, not already_existed)

--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   clampDescription,
   slugify,
   canonicalTopicForCategory,
+  isCleanCategory,
   bookJsonld,
   breadcrumbJsonld,
 } from "@/lib/seo-book";
@@ -96,6 +97,9 @@ export default async function BookLandingPage({ params }: PageProps) {
   // "Topic" rail links to a real /topic/{slug} instead of 404'ing on ad-hoc
   // categories like "Business" (→ "Business & Strategy") or junk values.
   const canonicalTopic = canonicalTopicForCategory(data.category, topics);
+  // Only surface the category in display chrome when it's a real category, not
+  // a leaked chat query stored as the category by topic-discovery.
+  const cleanCategory = isCleanCategory(data.category) ? data.category : "";
 
   const caps = detectCapabilities(data.agent);
   const chapterCount = data.chapters.length;
@@ -159,7 +163,7 @@ export default async function BookLandingPage({ params }: PageProps) {
         <span>{coverInitials(data.title)}</span>
       </div>
       <div className="seo-hero-body">
-        <p className="seo-meta">Book{data.category ? ` · ${data.category}` : ""}</p>
+        <p className="seo-meta">Book{cleanCategory ? ` · ${cleanCategory}` : ""}</p>
         <h1>{data.title}</h1>
         {data.author ? <p className="seo-author">by {data.author}</p> : null}
         {metaBits.length ? <p className="seo-meta">{metaBits.join(" · ")}</p> : null}
@@ -219,7 +223,7 @@ export default async function BookLandingPage({ params }: PageProps) {
     data.subtitle?.trim() ||
     [
       data.author ? `${data.title} by ${data.author}` : data.title,
-      data.category ? `a work on ${data.category}` : "",
+      cleanCategory ? `a work on ${cleanCategory}` : "",
     ]
       .filter(Boolean)
       .join(" — ") +

--- a/web/lib/seo-book.ts
+++ b/web/lib/seo-book.ts
@@ -94,6 +94,24 @@ export function canonicalTopicForCategory(
   return null;
 }
 
+/**
+ * Whether a book's `meta.category` is a real, displayable category rather than
+ * a leaked chat query. Topic-discovery stored the user's raw prompt as the
+ * category for ~50 books ("how game theory can be used in hiring", "who are
+ * you", CJK queries). Those are real books we keep indexed — we just must not
+ * render the junk as "Book · {category}". Real categories are short,
+ * Title-Case and ASCII; chat queries start lowercase / non-Latin, run long, or
+ * are questions.
+ */
+export function isCleanCategory(category: string): boolean {
+  const c = (category || "").trim();
+  if (!c || c.includes("?")) return false;
+  if (!/^[A-Z]/.test(c)) return false; // Title-Case ASCII; chat queries / CJK aren't
+  if (c.split(/\s+/).length > 4) return false; // real categories are short
+  if (/^(How|What|Who|Why|Does|Is|Are|Should|Can|Will|We|My)\b/.test(c)) return false;
+  return true;
+}
+
 // ─── JSON-LD schema builders (ported from seo.py) ──────────────────────
 
 type Json = Record<string, unknown>;


### PR DESCRIPTION
## What & why

These are **real books** (Predictably Irrational, Nudge, Designing ML Systems…) whose `meta.category` was overwritten with the user's **raw chat query** during topic-discovery — `create_catalog_agent(category=topic)`. ~50 books carry junk categories like `"how game theory can be used in hiring"`, `"who are you"`, or CJK queries, and **scheduled discovery re-discovers by category, self-propagating it.** The books are legit and stay indexed — only the category is bad.

## Fix (two parts)

- **Backend — stop the pollution at source:** `_clean_catalog_category()` keeps `topic` as the category only when it looks like a real category (short, Title-Case ASCII, not a question/sentence); otherwise stores `""`.
- **Frontend — hide existing junk:** `isCleanCategory()` gates the `Book · {category}` hero line + about-line so the ~50 already-polluted books don't render junk. (The `/topic` link was already gated by `canonicalTopicForCategory` in #37.)

Backend and frontend heuristics verified to agree on keep/drop across real + junk samples.

## Not included
A one-time re-categorization of the ~50 existing books (to put them back under their real topic hubs) — optional follow-up; not needed to stop the visible junk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
