### PR TITLE
feat(task2): Hobby-budget-safe expansion machinery

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3208,19 +3208,43 @@ def _verify_cron(request: Request) -> None:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
+# Hobby Active-CPU guard. Book indexing (parse + chunk) is the heaviest
+# on-Vercel CPU, and this cron used to queue _learn_agent for EVERY catalog
+# agent every run — unbounded as the catalog grows (Task-2 scale), which would
+# blow the 4h/mo Hobby cap. Two knobs:
+#   ENABLE_DISCOVER_CRON=false        → skip the cron entirely (do all discovery
+#                                       + indexing off-Vercel via scripts/).
+#   DISCOVER_CRON_MAX_INDEX=<n>       → at most n catalog agents indexed per run
+#                                       (bounds CPU regardless of catalog size).
+_DISCOVER_CRON_ENABLED = os.getenv("ENABLE_DISCOVER_CRON", "true").strip().lower() not in (
+    "0", "false", "no", "off",
+)
+_DISCOVER_CRON_MAX_INDEX = int(os.getenv("DISCOVER_CRON_MAX_INDEX", "5"))
+
+
 @app.get("/api/cron/discover")
 def api_cron_discover(request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
-    """Cron-triggered book discovery. Replaces the daemon discovery loop."""
+    """Cron-triggered book discovery. Replaces the daemon discovery loop.
+
+    On-Vercel indexing is bounded per run (DISCOVER_CRON_MAX_INDEX) so a large
+    catalog can't exhaust the Hobby Active-CPU budget; bulk (re)indexing runs
+    off-Vercel via scripts/reindex_via_gutenberg.py."""
     _verify_cron(request)
+    if not _DISCOVER_CRON_ENABLED:
+        return {"status": "disabled"}
     agents = list_agents(limit=5000)
     if not agents:
         return {"status": "skip", "reason": "no agents yet"}
     _discover_books()
-    # Trigger learning for any new catalog agents
+    # Bounded learning for new catalog agents (cap per run → bounded CPU).
+    queued = 0
     for a in list_agents(limit=5000):
         if a["status"] == "catalog":
             background_tasks.add_task(_learn_agent, a["id"])
-    return {"status": "ok"}
+            queued += 1
+            if queued >= _DISCOVER_CRON_MAX_INDEX:
+                break
+    return {"status": "ok", "indexed_queued": queued}
 
 
 @app.get("/api/cron/indexnow")

--- a/docs/TASK2-runbook.md
+++ b/docs/TASK2-runbook.md
@@ -1,0 +1,89 @@
+# Task 2 — Content Expansion Runbook (Hobby-budget-safe)
+
+**Goal:** grow the unique, citable corpus (the master plan's "fuel") — Gutenberg
+backfill of stub books, minds 50 → 1000 (→ ~20K Type-2 pages), Type-4 clustering
+— **without exceeding the Vercel Hobby caps** (4h Active-CPU/month + the Gemini
+quota).
+
+## The one principle that makes this possible
+
+**Decouple corpus size from Vercel CPU.** All heavy work — book indexing
+(parse/chunk), persona generation, essay/overview/Q&A generation, embeddings —
+runs **off-Vercel** as throttled batch scripts (your machine or CI), writing
+results to the DB. The live Vercel functions then only **serve pre-stored
+content** (cheap DB reads + edge-cached sitemap/OG). Add 20K pages and Vercel
+Active-CPU stays flat; the only thing that scales is your **Gemini quota**, which
+you throttle with `--limit` / `--sleep`.
+
+| Work | Where it runs | Cost it spends |
+|---|---|---|
+| `scripts/*` batches (expand_minds, backfill_overviews, reindex_via_gutenberg, backfill_questions) | **off-Vercel** (your machine/CI) | Gemini quota + your CPU — **never** Vercel CPU |
+| Serving `/book`, `/mind`, `/topic`, `/q`, `/on`, sitemap, OG | Vercel `feynman-pro` | cheap reads (pre-stored) + edge cache |
+| Crons (`discover` etc.) | Vercel `feynman-pro` | **bounded** (see guards) |
+
+## Set the Hobby guards first (Vercel → feynman-pro → Env)
+
+- `DISCOVER_CRON_MAX_INDEX=5` (default) — caps on-Vercel indexing per cron run.
+  On a tight month set `ENABLE_DISCOVER_CRON=false` and do all indexing via the
+  Gutenberg script instead.
+- OG rendering is already `lru_cache`d + cheap (PR #39). Overviews are pre-stored
+  by `backfill_overviews` so `/overview` serves with zero generation.
+
+## Execution waves (run each off-Vercel; `--dry-run` first; watch the meters between)
+
+**Wave 0 — flatten the existing hot path (do now).**
+```bash
+python -m scripts.backfill_overviews --limit 50 --sleep 1   # repeat until drained
+```
+Pre-stores overviews → `/overview` stops generating per crawl. Idempotent.
+
+**Wave 1 — Gutenberg backfill (thin stubs → real text).**
+```bash
+python -m scripts.reindex_via_gutenberg   # see its --help for batch flags
+```
+Turns stub books into substantive, chattable, Q&A-able pages. Heaviest CPU —
+runs off-Vercel, so it doesn't touch the cap. Then fill questions:
+```bash
+python -m scripts.backfill_questions --limit 50
+```
+
+**Wave 2 — mind expansion (the 20K-page lever), in throttled chunks.**
+```bash
+python -m scripts.expand_minds --dry-run                       # eyeball candidates
+python -m scripts.expand_minds --per-domain 20 --limit 50 --sleep 1.5
+# repeat; idempotent. Each new mind × its relevant topics = new Type-2 /on/ pages.
+```
+⚠️ Each `/mind/{id}/on/{topic}` essay is currently **lazy-generated on first
+crawl** (cached after). Small batches (≤50 minds ≈ ≤750 essays) are quota-safe.
+**Before going full 1000**, build the essay pre-store (next section) so 20K
+essays don't each hit Gemini on crawl.
+
+**Wave 3 — essay + Q&A pre-store (CODE TODO, gating prerequisite for full scale).**
+Mirror the overview pre-store: store each `/on/` essay and `/q/` answer in the DB
+(a `mind_essays` / `agent_qa` table, or mind/agent `meta`), add a pre-store
+short-circuit to `api_mind_on_topic` / `api_agent_qa`, and a
+`scripts/backfill_essays.py` / `backfill_qa.py`. Then the 20K essays serve from
+the DB — zero per-crawl Gemini. **This is the remaining engineering piece before
+mass mind-expansion is quota-safe.**
+
+**Wave 4 — Type-4 clustering.** Gated on chat volume (≥1000 publishable assistant
+messages; ~284 today). Fills automatically as traffic from Waves 1–2 drives chat.
+
+## Budget math / decision point
+
+- **Vercel CPU:** with the guards above, Active-CPU stays roughly flat regardless
+  of corpus size — the heavy work is off-Vercel. The one thing to watch is the
+  bounded discover cron; keep `DISCOVER_CRON_MAX_INDEX` small on Hobby.
+- **Gemini quota** is the real throttle on *how fast* you fill content. Run waves
+  in `--limit`/`--sleep` chunks across the quota window.
+- **Hobby vs Pro:** you can *fill* the corpus on Hobby (off-Vercel batches). You'd
+  upgrade to **Pro** only if (a) serving traffic grows enough to push Active-CPU
+  past 4h on reads alone, or (b) you want the discover/index cron to run at scale
+  on Vercel instead of via scripts. Until then, **stay on Hobby + run the batches.**
+
+## Sequencing back-pressure (don't skip)
+
+Expansion only pays off if pages get **indexed**. Don't front-load 20K URLs while
+the existing ~350 are still being (re)crawled — finish Task-1's GSC validation
+first, expand in waves, and watch the indexed-count climb before adding the next
+wave. Scale follows indexation, not the other way around.

--- a/scripts/expand_minds.py
+++ b/scripts/expand_minds.py
@@ -1,0 +1,132 @@
+"""Expand the great-minds roster from Wikidata — the Task-2 entity-scale lever
+(master plan P1: 50 → 1000 minds, which unlocks ~20K Type-2 "how X approaches Y"
+pages Wikipedia structurally can't have).
+
+WHY THIS IS A SCRIPT (and not a cron)
+-------------------------------------
+This is deliberately OFF-Vercel. Creating a mind = a Wikidata/Wikipedia fetch +
+an LLM persona generation + an embedding. Run as a scheduled Vercel function it
+would burn the Hobby 4h Active-CPU cap and the 60s function timeout. Run as a
+local/CI batch it costs only your Gemini quota and your machine's CPU — Vercel
+stays flat. The live site just SERVES the resulting minds (cheap DB reads).
+
+Usage
+-----
+  python -m scripts.expand_minds --dry-run                 # list candidates, no writes/LLM
+  python -m scripts.expand_minds --per-domain 30 --limit 50 --sleep 1.5
+  python -m scripts.expand_minds --no-embed                # skip the embedding backfill pass
+
+Required env vars
+-----------------
+  DATABASE_URL    Same string the app uses to reach Supabase Postgres.
+  GEMINI_API_KEY  (or whichever provider is configured) — persona generation.
+
+Properties
+----------
+- **Idempotent.** Skips Wikidata candidates whose name already exists as a mind.
+  Safe to interrupt/resume; re-run picks up where it left off.
+- **Quota-friendly.** ~1 LLM round trip per NEW mind. --limit / --sleep spread
+  the run across the Gemini quota window; run it in chunks over days if needed.
+- **Hobby-CPU-safe.** Zero Vercel involvement. `link_works=False` by default so
+  it does NOT trigger book discovery/indexing (the CPU-heavy path) — work-linking
+  is a separate, optional pass.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+from app.core import config  # noqa: F401 — ensures env is loaded
+from app.core.db import init_db, list_minds
+from app.core.minds import backfill_mind_embeddings, get_or_create_mind
+from app.core.sources_wikidata import discover_candidates
+
+log = logging.getLogger("expand_minds")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List candidates without LLM calls or writes.")
+    parser.add_argument("--per-domain", type=int, default=30,
+                        help="Wikidata candidates to pull per topic domain (15 domains).")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Create at most this many NEW minds this run (quota control).")
+    parser.add_argument("--sleep", type=float, default=1.0,
+                        help="Seconds to sleep between mind creations (throttle Gemini).")
+    parser.add_argument("--link-works", action="store_true",
+                        help="Link existing catalog books to each mind (off by default — "
+                             "avoid until you want the extra cross-links).")
+    parser.add_argument("--no-embed", action="store_true",
+                        help="Skip the embedding backfill pass at the end.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    print(f"--- expand_minds (dry_run={args.dry_run}) ---", file=sys.stderr)
+    init_db()
+
+    existing = {(m.get("name") or "").strip().lower() for m in list_minds(limit=10000)}
+    print(f"have {len(existing)} minds; querying Wikidata candidates…", file=sys.stderr)
+
+    try:
+        candidates = discover_candidates(per_domain_limit=args.per_domain)
+    except Exception as exc:
+        print(f"Wikidata discovery failed: {exc}", file=sys.stderr)
+        return 2
+
+    fresh = [c for c in candidates if (c.get("name") or "").strip().lower() not in existing]
+    print(f"{len(candidates)} candidates, {len(fresh)} new", file=sys.stderr)
+
+    created = failed = 0
+    start = time.time()
+    for c in fresh:
+        if args.limit is not None and created >= args.limit:
+            break
+        name = (c.get("name") or "").strip()
+        domain = (c.get("domain") or "").strip()
+        if not name:
+            continue
+        if args.dry_run:
+            print(f"  [dry-run] would create {name!r} [{domain}]", file=sys.stderr)
+            created += 1
+            continue
+        try:
+            get_or_create_mind(name, era=c.get("era", ""), domain=domain,
+                               link_works=args.link_works)
+            created += 1
+            print(f"  OK   {name!r} [{domain}]", file=sys.stderr)
+        except Exception as exc:
+            failed += 1
+            print(f"  FAIL {name!r}: {exc}", file=sys.stderr)
+        time.sleep(args.sleep)
+
+    # Embedding backfill so the new minds join the similarity graph (related
+    # minds / topic clustering). Off-Vercel, looped until drained.
+    embedded = 0
+    if not args.dry_run and not args.no_embed and created:
+        print("backfilling embeddings…", file=sys.stderr)
+        while True:
+            n = backfill_mind_embeddings(batch_size=25)
+            if not n:
+                break
+            embedded += n
+            print(f"  embedded {embedded}…", file=sys.stderr)
+
+    elapsed = time.time() - start
+    print(
+        f"--- done in {elapsed:.1f}s: created={created} failed={failed} "
+        f"embedded={embedded} ---",
+        file=sys.stderr,
+    )
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes Task 2 (content expansion) executable without exceeding the Vercel Hobby 4h Active-CPU cap.

**Principle:** decouple corpus size from Vercel CPU — all heavy generation/indexing runs **off-Vercel** as throttled batch scripts (your Gemini quota, not Vercel CPU); the live functions only serve pre-stored content.

- **`scripts/expand_minds.py`** — off-Vercel mind expansion from Wikidata (the master-plan 50→1000 lever → ~20K Type-2 pages). Throttled (`--limit`/`--sleep`), idempotent, `link_works=False` so it doesn't trigger on-Vercel indexing; optional embedding backfill.
- **discover cron bounded + gated** (`app/main.py`) — it queued `_learn_agent` for *every* catalog agent each run (unbounded indexing CPU as the catalog grows). Now `DISCOVER_CRON_MAX_INDEX` (default 5) caps per-run indexing; `ENABLE_DISCOVER_CRON=false` disables it.
- **`docs/TASK2-runbook.md`** — budget-safe execution waves, what-runs-where, Hobby guards, and the essay/Q&A pre-store flagged as the remaining prerequisite before full-scale expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)