### PR TITLE
fix(seo): topic page — dedup books, drop redundant rail, fix hash routes

### DIFF
--- a/web/app/mind/[id]/dialogues/page.tsx
+++ b/web/app/mind/[id]/dialogues/page.tsx
@@ -88,7 +88,7 @@ export default async function MindDialoguesPage({
   });
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
-    ["Great Minds", `${SITE_URL}/#/minds`],
+    ["Great Minds", `${SITE_URL}/minds`],
     [mind.name, entityCanonical],
     ["Dialogues", canonical],
   ]);

--- a/web/app/mind/[id]/on/[slug]/page.tsx
+++ b/web/app/mind/[id]/on/[slug]/page.tsx
@@ -103,7 +103,7 @@ export default async function MindOnTopicPage({
   });
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
-    ["Great Minds", `${SITE_URL}/#/minds`],
+    ["Great Minds", `${SITE_URL}/minds`],
     [mind.name, mindUrl],
     [topic, canonical],
   ]);

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -121,7 +121,7 @@ export default async function MindPage({
   });
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
-    ["Great Minds", `${SITE_URL}/#/minds`],
+    ["Great Minds", `${SITE_URL}/minds`],
     [mind.name, canonical],
   ]);
 

--- a/web/app/topic/[slug]/page.tsx
+++ b/web/app/topic/[slug]/page.tsx
@@ -102,7 +102,7 @@ export default async function TopicPage({
   });
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
-    ["Topics", `${SITE_URL}/#/library`],
+    ["Topics", `${SITE_URL}/library`],
     [topic, canonical],
   ]);
 
@@ -124,39 +124,12 @@ export default async function TopicPage({
     </>
   );
 
-  const rail = (
-    <>
-      {books.length ? (
-        <div className="seo-rail-card">
-          <h3>Books in this topic</h3>
-          <ul>
-            {books.slice(0, 8).map((b) => (
-              <li key={b.id}>
-                <Link href={`/book/${b.id}`}>{b.name}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-      {topicMinds.length ? (
-        <div className="seo-rail-card">
-          <h3>Great minds</h3>
-          <ul>
-            {topicMinds.slice(0, 8).map((m) => (
-              <li key={m.id}>
-                <Link href={`/mind/${m.id}`}>{m.name}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </>
-  );
-
-  const hasRail = books.length > 0 || topicMinds.length > 0;
-
+  // No right rail on topic pages — the page body IS the books + minds lists, so
+  // a rail of the same items would just duplicate the content on-screen. (Book/
+  // mind pages use the rail for complementary "related" items; a topic hub has
+  // no such secondary content.)
   return (
-    <EntityLayout hero={hero} rail={hasRail ? rail : undefined}>
+    <EntityLayout hero={hero}>
       <JsonLd data={collectionLd} />
       <JsonLd data={breadcrumbLd} />
 
@@ -222,7 +195,7 @@ export default async function TopicPage({
       ) : null}
 
       <p className="seo-cta-row">
-        <a className="primary" href={`${SITE_URL}/#/library`}>
+        <a className="primary" href={`${SITE_URL}/library`}>
           Explore the full Feynman library →
         </a>
       </p>

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -618,22 +618,39 @@ export function filterBooksByTopic(
   limit = 30,
 ): AgentRowLite[] {
   const t = topic.toLowerCase();
-  const out: AgentRowLite[] = [];
-  const seen = new Set<string>();
+  // Dedupe by normalized title: the catalog holds the SAME book as both a
+  // full-title `catalog` stub and a short-title `ready` record ("Competitive
+  // Strategy: Techniques…" vs "Competitive Strategy"; "Good to Great" even has
+  // two stubs differing only in punctuation). Normalize = strip the subtitle
+  // after a colon/dash + punctuation, lowercase, collapse whitespace. On a
+  // collision, prefer the real (ready/indexing) book so the short correct title
+  // wins over the stub — which also makes the page's "N books" count honest.
+  const norm = (a: AgentRowLite) =>
+    (a.name || "")
+      .toLowerCase()
+      .split(/[:—]|\s-\s/)[0]
+      .replace(/[.,;:!?'"()]/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+  const rank = (a: AgentRowLite) =>
+    a.status === "ready" || a.status === "indexing" ? 2 : a.status === "writing" ? 1 : 0;
+
+  const best = new Map<string, AgentRowLite>();
+  const order: string[] = [];
   for (const a of agents) {
     if (a.status === "error" && a.type !== "ai_book") continue;
     const cat = (a.meta?.category || "").toLowerCase();
-    if (cat && (cat === t || cat.includes(t) || t.includes(cat))) {
-      // Dedupe title-vs-subtitle catalog dupes ("Competitive Strategy" vs
-      // "Competitive Strategy: Techniques…") by the title stem before any colon.
-      const key = (a.name || "").toLowerCase().split(":")[0].replace(/\s+/g, " ").trim();
-      if (key && seen.has(key)) continue;
-      if (key) seen.add(key);
-      out.push(a);
-      if (out.length >= limit) break;
+    if (!(cat && (cat === t || cat.includes(t) || t.includes(cat)))) continue;
+    const k = norm(a) || a.id; // fall back to id if the title normalizes empty
+    const cur = best.get(k);
+    if (!cur) {
+      best.set(k, a);
+      order.push(k);
+    } else if (rank(a) > rank(cur)) {
+      best.set(k, a);
     }
   }
-  return out;
+  return order.map((k) => best.get(k)!).slice(0, limit);
 }
 
 /** Minds whose domain is relevant to a topic (uses isMindTopicRelevant). */


### PR DESCRIPTION
Implements the thorough /topic/[slug] review (forwarded from another session):

1. **Duplicate books** — `filterBooksByTopic` now dedupes by normalized title (strip subtitle/punct, keep CJK) and **prefers the `ready` book over the `catalog` stub**, so the short real title wins and the "N books" count is honest. (Competitive Strategy / Good to Great / Lean Startup were each doubled.)
2. **Rail = body** — removed the right rail on topic pages; it duplicated the body's books+minds lists (and the 8-vs-9 slice looked like a dropped item).
3. **Hash routes** — `/#/library` + `/#/minds` (old SPA routes → land on homepage) fixed to `/library` + `/minds` in the topic CTA/breadcrumb and **all three mind-page breadcrumbs**.

Data-layer note (separate): the catalog still has duplicate agent rows (stub + real book per title) — frontend dedup hides it here, but the source dup should be cleaned in catalog minting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)