### PR TITLE
feat(seo): Type-0 mind sameAs auto-populated from Wikidata

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -394,8 +394,10 @@ def init_db() -> None:
             except Exception:
                 _execute(conn, "ROLLBACK TO SAVEPOINT sp_mem_type")
 
-            # Migration: add embedding columns to minds table
-            for col, col_type in [("embedding", "BLOB"), ("embedding_dim", "INTEGER"), ("embedding_norm", "REAL")]:
+            # Migration: add embedding columns to minds table; plus Wikidata/
+            # Wikipedia identity URLs (for Person JSON-LD sameAs — the
+            # Knowledge-Graph / LLM entity signal on every expanded mind).
+            for col, col_type in [("embedding", "BLOB"), ("embedding_dim", "INTEGER"), ("embedding_norm", "REAL"), ("wikidata_url", "TEXT"), ("wikipedia_url", "TEXT")]:
                 try:
                     _execute(conn, f"SAVEPOINT sp_minds_{col}")
                     _execute(conn, f"ALTER TABLE minds ADD COLUMN {col} {col_type}")
@@ -865,8 +867,9 @@ def init_db() -> None:
             except Exception:
                 pass
 
-            # Migration: add embedding columns to minds table
-            for col, col_type in [("embedding", "BYTEA"), ("embedding_dim", "INTEGER"), ("embedding_norm", "DOUBLE PRECISION")]:
+            # Migration: add embedding columns to minds table; plus Wikidata/
+            # Wikipedia identity URLs for Person JSON-LD sameAs.
+            for col, col_type in [("embedding", "BYTEA"), ("embedding_dim", "INTEGER"), ("embedding_norm", "DOUBLE PRECISION"), ("wikidata_url", "TEXT"), ("wikipedia_url", "TEXT")]:
                 try:
                     _execute(conn, f"SAVEPOINT sp_minds_{col}")
                     _execute(conn, f"ALTER TABLE minds ADD COLUMN {col} {col_type}")
@@ -1596,6 +1599,10 @@ def _row_to_mind(row: dict[str, Any]) -> dict[str, Any]:
         "typical_phrases": json.loads(row["typical_phrases"] or "[]"),
         "works": json.loads(row["works"] or "[]"),
         "avatar_seed": row["avatar_seed"] or "",
+        # Wikidata/Wikipedia identity links (sameAs). `.get` — older rows
+        # predate the migration; absent → "".
+        "wikidata_url": row.get("wikidata_url") or "",
+        "wikipedia_url": row.get("wikipedia_url") or "",
         "version": row["version"],
         "chat_count": row["chat_count"],
         "created_at": row["created_at"],
@@ -1608,6 +1615,17 @@ def update_mind_embedding(mind_id: str, vector_bytes: bytes, dim: int, norm: flo
         _execute(conn, _q(
             "UPDATE minds SET embedding = ?, embedding_dim = ?, embedding_norm = ? WHERE id = ?"
         ), (blob, dim, norm, mind_id))
+
+
+def update_mind_links(mind_id: str, wikidata_url: str | None = None, wikipedia_url: str | None = None) -> None:
+    """Store a mind's Wikidata/Wikipedia identity URLs — the canonical entity
+    signal rendered into the Person JSON-LD `sameAs` (Knowledge Graph + LLM
+    grounding). Empty strings are normalized to NULL so a blank candidate field
+    never overwrites a previously-resolved link with junk."""
+    with get_conn() as conn:
+        _execute(conn, _q(
+            "UPDATE minds SET wikidata_url = ?, wikipedia_url = ? WHERE id = ?"
+        ), (wikidata_url or None, wikipedia_url or None, mind_id))
 
 
 def list_minds_with_embeddings() -> list[dict[str, Any]]:

--- a/scripts/expand_minds.py
+++ b/scripts/expand_minds.py
@@ -23,8 +23,9 @@ Required env vars
 
 Properties
 ----------
-- **Idempotent.** Skips Wikidata candidates whose name already exists as a mind.
-  Safe to interrupt/resume; re-run picks up where it left off.
+- **Idempotent.** Skips Wikidata candidates whose name already exists as a mind
+  (but still backfills their Wikidata/Wikipedia `sameAs` links — cheap UPDATE, no
+  LLM). Safe to interrupt/resume; re-run picks up where it left off.
 - **Quota-friendly.** ~1 LLM round trip per NEW mind. --limit / --sleep spread
   the run across the Gemini quota window; run it in chunks over days if needed.
 - **Hobby-CPU-safe.** Zero Vercel involvement. `link_works=False` by default so
@@ -39,7 +40,7 @@ import sys
 import time
 
 from app.core import config  # noqa: F401 — ensures env is loaded
-from app.core.db import init_db, list_minds
+from app.core.db import init_db, list_minds, update_mind_links
 from app.core.minds import backfill_mind_embeddings, get_or_create_mind
 from app.core.sources_wikidata import discover_candidates
 
@@ -72,7 +73,10 @@ def main() -> int:
     print(f"--- expand_minds (dry_run={args.dry_run}) ---", file=sys.stderr)
     init_db()
 
-    existing = {(m.get("name") or "").strip().lower() for m in list_minds(limit=10000)}
+    # name → id, so we can attach sameAs links to minds that already exist
+    # (created before #3 landed) without an LLM round trip.
+    existing_by_name = {(m.get("name") or "").strip().lower(): m["id"] for m in list_minds(limit=10000)}
+    existing = set(existing_by_name)
     print(f"have {len(existing)} minds; querying Wikidata candidates…", file=sys.stderr)
 
     try:
@@ -81,26 +85,47 @@ def main() -> int:
         print(f"Wikidata discovery failed: {exc}", file=sys.stderr)
         return 2
 
-    fresh = [c for c in candidates if (c.get("name") or "").strip().lower() not in existing]
-    print(f"{len(candidates)} candidates, {len(fresh)} new", file=sys.stderr)
+    fresh_n = sum(1 for c in candidates if (c.get("name") or "").strip().lower() not in existing)
+    print(f"{len(candidates)} candidates, {fresh_n} new (rest get sameAs backfilled)", file=sys.stderr)
 
-    created = failed = 0
+    created = failed = linked = 0
     start = time.time()
-    for c in fresh:
-        if args.limit is not None and created >= args.limit:
-            break
+    for c in candidates:
         name = (c.get("name") or "").strip()
-        domain = (c.get("domain") or "").strip()
         if not name:
+            continue
+        key = name.lower()
+        domain = (c.get("domain") or "").strip()
+        wd = (c.get("wikidata_url") or "").strip()
+        wp = (c.get("wikipedia_url") or "").strip()
+
+        # Already a mind → just (re)attach Wikidata/Wikipedia sameAs. A cheap
+        # UPDATE, no LLM, NOT capped by --limit — this is how the pre-#3 minds
+        # get their entity links backfilled.
+        if key in existing:
+            if wd or wp:
+                if args.dry_run:
+                    print(f"  [dry-run] would link {name!r} → {wd or wp}", file=sys.stderr)
+                else:
+                    update_mind_links(existing_by_name[key], wd, wp)
+                linked += 1
+            continue
+
+        # New mind = one LLM persona generation → capped by --limit. `continue`
+        # (not `break`) so existing minds further down the list still backfill.
+        if args.limit is not None and created >= args.limit:
             continue
         if args.dry_run:
             print(f"  [dry-run] would create {name!r} [{domain}]", file=sys.stderr)
             created += 1
             continue
         try:
-            get_or_create_mind(name, era=c.get("era", ""), domain=domain,
-                               link_works=args.link_works)
+            m = get_or_create_mind(name, era=c.get("era", ""), domain=domain,
+                                   link_works=args.link_works)
             created += 1
+            if (wd or wp) and m and m.get("id"):
+                update_mind_links(m["id"], wd, wp)
+                linked += 1
             print(f"  OK   {name!r} [{domain}]", file=sys.stderr)
         except Exception as exc:
             failed += 1
@@ -121,8 +146,8 @@ def main() -> int:
 
     elapsed = time.time() - start
     print(
-        f"--- done in {elapsed:.1f}s: created={created} failed={failed} "
-        f"embedded={embedded} ---",
+        f"--- done in {elapsed:.1f}s: created={created} linked={linked} "
+        f"failed={failed} embedded={embedded} ---",
         file=sys.stderr,
     )
     return 0 if failed == 0 else 1

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -23,7 +23,7 @@ import {
   fetchMindLibrary,
   fetchMindThemes,
   isMindTopicRelevant,
-  lookupSameAs,
+  mindSameAs,
   metaDescription,
   personJsonLd,
   topicSlug,
@@ -116,7 +116,7 @@ export default async function MindPage({
     domain: mind.domain || "",
     url: canonical,
     image: ogImage,
-    sameAs: lookupSameAs(mind.name),
+    sameAs: mindSameAs(mind),
     dateModified: mind.created_at || "",
   });
   const breadcrumbLd = breadcrumbJsonLd([

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -37,6 +37,11 @@ export interface MindDetail {
   persona?: string;
   persona_excerpt?: string;
   works?: string[];
+  /** Wikidata/Wikipedia identity URLs — stored per-mind by expand_minds from
+   *  the matched Wikidata candidate. Merged into the Person JSON-LD `sameAs`
+   *  alongside the curated FAMOUS_MIND_SAMEAS table (see mindSameAs). */
+  wikidata_url?: string;
+  wikipedia_url?: string;
   created_at?: string;
   [k: string]: unknown;
 }
@@ -207,6 +212,29 @@ export const FAMOUS_MIND_SAMEAS: Record<string, string[]> = {
 export function lookupSameAs(mindName: string): string[] | undefined {
   if (!mindName) return undefined;
   return FAMOUS_MIND_SAMEAS[mindName.trim().toLowerCase()];
+}
+
+/**
+ * Full `sameAs` set for a mind's Person JSON-LD: the curated
+ * FAMOUS_MIND_SAMEAS table (hand-verified for the ~25 headline thinkers)
+ * UNION the Wikidata/Wikipedia URLs expand_minds stored on the row. This is
+ * what makes the entity link scale past the 25 hardcoded names to every
+ * Wikidata-sourced mind. Deduped, order-stable (curated first, then
+ * Wikipedia, then Wikidata). Returns undefined when empty so dropNulls strips
+ * the key rather than emitting `sameAs: []`.
+ */
+export function mindSameAs(
+  mind: Pick<MindDetail, "name" | "wikidata_url" | "wikipedia_url">,
+): string[] | undefined {
+  const urls = [
+    ...(lookupSameAs(mind.name) || []),
+    mind.wikipedia_url || "",
+    mind.wikidata_url || "",
+  ]
+    .map((u) => (u || "").trim())
+    .filter(Boolean);
+  const deduped = [...new Set(urls)];
+  return deduped.length ? deduped : undefined;
 }
 
 // ─── JSON-LD builders (drop empty leaves, matching jsonld_script) ───────


### PR DESCRIPTION
## What

Scales Person JSON-LD `sameAs` past the 25 hardcoded famous minds to **every Wikidata-sourced mind** — the Knowledge-Graph / LLM entity signal that lets search + GEO resolve a `/mind/{id}` page to a real-world person. This is the highest-leverage, lowest-cost Type-0 fix from the programmatic-SEO/GEO plan.

## Changes
- **db** (`app/core/db.py`): `minds` gains `wikidata_url` + `wikipedia_url` (idempotent migration, both SQLite + Postgres branches); `_row_to_mind` exposes them (`.get`, safe on pre-migration rows); new `update_mind_links()` setter.
- **expand_minds** (`scripts/expand_minds.py`): stores both URLs on each NEW mind **and backfills EXISTING minds** (cheap UPDATE, no LLM, not capped by `--limit`) so the pre-existing roster gets links on re-run.
- **web**: `MindDetail` carries the URLs; new `mindSameAs()` merges curated `FAMOUS_MIND_SAMEAS` with the stored URLs (deduped, curated-first); the mind page Person JSON-LD uses it.

`/api/minds/{id}` already passes the fields through unchanged.

## After merge
Once `feynman-pro` redeploys (init_db adds the columns), run `python -m scripts.expand_minds --limit 0` to backfill existing minds' links — zero LLM cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)