### PR TITLE
feat(seo): backfill mind sameAs by name + harden the JSON-LD merge

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1575,7 +1575,8 @@ def list_minds(limit: int | None = None) -> list[dict[str, Any]]:
     """
     sql = (
         "SELECT id, name, era, domain, bio_summary, persona, thinking_style, "
-        "typical_phrases, works, avatar_seed, version, chat_count, created_at "
+        "typical_phrases, works, avatar_seed, wikidata_url, wikipedia_url, "
+        "version, chat_count, created_at "
         "FROM minds ORDER BY chat_count DESC, created_at ASC"
     )
     params: tuple[Any, ...] = ()

--- a/scripts/backfill_mind_sameas.py
+++ b/scripts/backfill_mind_sameas.py
@@ -1,0 +1,133 @@
+"""Backfill Wikidata/Wikipedia `sameAs` links onto EXISTING minds by name.
+
+WHY A SEPARATE SCRIPT (not expand_minds)
+----------------------------------------
+expand_minds only ever sees the top-N candidates per domain that Wikidata's
+SPARQL endpoint returns — it cannot reach an arbitrary mind already in the
+roster (one ranked #60 in its domain, or minted from a chat). This closes that
+gap: for every mind missing a `wikidata_url` it resolves the entity through
+Wikidata's MediaWiki *action* API (wbsearchentities -> wbgetentities), which is
+a DIFFERENT service from the flaky / outage-prone SPARQL endpoint — so it works
+even while WDQS is rate-limiting.
+
+CORRECTNESS OVER COVERAGE
+-------------------------
+A WRONG `sameAs` is worse than none — it tells search engines and LLMs the mind
+IS some other real person. So a match is accepted ONLY when the resolved entity
+is `P31=Q5` (an instance of human) AND has an English Wikipedia article. The
+top relevance-ranked hit that clears both gates wins; ambiguous, non-person, or
+article-less names are skipped and left unlinked. The famous-25 already render
+their curated sameAs via the frontend's mindSameAs() regardless, so skipping
+here only ever leaves a mind exactly as it was.
+
+Usage
+-----
+  python -m scripts.backfill_mind_sameas                  # DRY-RUN: report matches
+  python -m scripts.backfill_mind_sameas --apply
+  python -m scripts.backfill_mind_sameas --apply --limit 20 --sleep 0.4
+  python -m scripts.backfill_mind_sameas --apply --force  # re-resolve linked minds too
+
+Required env: DATABASE_URL (same as the app). No LLM / Gemini quota. Off-Vercel,
+so zero Vercel CPU — the live site just serves the resulting links.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from app.core import config  # noqa: F401 — ensures env is loaded
+from app.core.db import init_db, list_minds, update_mind_links
+from app.core.sources_wikidata import _http_get
+
+_API = "https://www.wikidata.org/w/api.php"
+
+
+def _search_qids(name: str, limit: int) -> list[str]:
+    """Top candidate QIDs for a name label, in Wikidata relevance order
+    (exact label matches rank first)."""
+    data = _http_get(_API, params={
+        "action": "wbsearchentities", "search": name, "language": "en",
+        "type": "item", "limit": str(limit), "format": "json",
+    }) or {}
+    return [h.get("id") for h in data.get("search", []) if h.get("id")]
+
+
+def _resolve_person(qid: str) -> tuple[str, str] | None:
+    """(wikidata_url, wikipedia_url) iff `qid` is a human (P31=Q5) WITH an
+    English Wikipedia article — else None. This pair of gates is what keeps a
+    same-name non-person (a band, a book, a place) from being mislinked."""
+    data = _http_get(_API, params={
+        "action": "wbgetentities", "ids": qid,
+        "props": "claims|sitelinks/urls", "languages": "en",
+        "sitefilter": "enwiki", "format": "json",
+    }) or {}
+    ent = (data.get("entities") or {}).get(qid) or {}
+    p31 = (ent.get("claims") or {}).get("P31") or []
+    is_human = any(
+        ((((c.get("mainsnak") or {}).get("datavalue") or {}).get("value") or {}).get("id") == "Q5")
+        for c in p31
+    )
+    if not is_human:
+        return None
+    wp = ((ent.get("sitelinks") or {}).get("enwiki") or {}).get("url") or ""
+    if not wp:
+        return None
+    return (f"https://www.wikidata.org/wiki/{qid}", wp)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="Write the links (default: dry-run, read-only).")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Process at most this many minds this run.")
+    parser.add_argument("--sleep", type=float, default=0.4,
+                        help="Seconds between Wikidata API calls (be polite).")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-resolve minds that already have a wikidata_url.")
+    parser.add_argument("--max-candidates", type=int, default=5,
+                        help="Search hits to consider per name before giving up.")
+    args = parser.parse_args()
+
+    print(f"--- backfill_mind_sameas (apply={args.apply}) ---", file=sys.stderr)
+    init_db()
+
+    minds = list(list_minds(limit=10000))
+    todo = [m for m in minds if args.force or not (m.get("wikidata_url") or "").strip()]
+    print(f"{len(minds)} minds, {len(todo)} need resolving", file=sys.stderr)
+
+    linked = skipped = failed = 0
+    for m in todo:
+        if args.limit is not None and (linked + skipped + failed) >= args.limit:
+            break
+        name = (m.get("name") or "").strip()
+        if not name:
+            continue
+        try:
+            resolved = None
+            for qid in _search_qids(name, args.max_candidates):
+                resolved = _resolve_person(qid)
+                if resolved:
+                    break
+                time.sleep(args.sleep)
+            if not resolved:
+                skipped += 1
+                print(f"  skip   {name!r} (no human+enwiki match)", file=sys.stderr)
+                continue
+            wd, wp = resolved
+            if args.apply:
+                update_mind_links(m["id"], wd, wp)
+            print(f"  {'LINK' if args.apply else 'would link'} {name!r} → {wd}", file=sys.stderr)
+            linked += 1
+        except Exception as exc:
+            failed += 1
+            print(f"  FAIL {name!r}: {exc}", file=sys.stderr)
+        time.sleep(args.sleep)
+
+    print(f"--- done: linked={linked} skipped={skipped} failed={failed} ---", file=sys.stderr)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -116,7 +116,7 @@ export const FAMOUS_MIND_SAMEAS: Record<string, string[]> = {
   ],
   "friedrich engels": [
     "https://en.wikipedia.org/wiki/Friedrich_Engels",
-    "https://www.wikidata.org/wiki/Q33760",
+    "https://www.wikidata.org/wiki/Q34787",
   ],
   "adam smith": [
     "https://en.wikipedia.org/wiki/Adam_Smith",
@@ -215,26 +215,28 @@ export function lookupSameAs(mindName: string): string[] | undefined {
 }
 
 /**
- * Full `sameAs` set for a mind's Person JSON-LD: the curated
- * FAMOUS_MIND_SAMEAS table (hand-verified for the ~25 headline thinkers)
- * UNION the Wikidata/Wikipedia URLs expand_minds stored on the row. This is
- * what makes the entity link scale past the 25 hardcoded names to every
- * Wikidata-sourced mind. Deduped, order-stable (curated first, then
- * Wikipedia, then Wikidata). Returns undefined when empty so dropNulls strips
- * the key rather than emitting `sameAs: []`.
+ * Full `sameAs` set for a mind's Person JSON-LD. The Wikidata/Wikipedia URLs
+ * stored on the row (resolved + verified from Wikidata's action API by
+ * expand_minds / backfill_mind_sameas — P31=Q5 + enwiki-gated) are
+ * AUTHORITATIVE and SUPERSEDE the curated FAMOUS_MIND_SAMEAS table: same two
+ * URL kinds, but correct by construction. The hand-curated table doesn't scale
+ * to 1000 minds and had at least one copy-paste error (Engels pointed at
+ * Russell's QID), so for any mind we've actually resolved we don't risk
+ * re-introducing a curated mistake. The table is the fallback ONLY for minds
+ * without stored links (the few Wikidata can't resolve by name). Deduped;
+ * undefined when empty so dropNulls strips the key rather than emit `sameAs: []`.
  */
 export function mindSameAs(
   mind: Pick<MindDetail, "name" | "wikidata_url" | "wikipedia_url">,
 ): string[] | undefined {
-  const urls = [
-    ...(lookupSameAs(mind.name) || []),
-    mind.wikipedia_url || "",
-    mind.wikidata_url || "",
-  ]
+  const stored = [mind.wikipedia_url || "", mind.wikidata_url || ""]
     .map((u) => (u || "").trim())
     .filter(Boolean);
-  const deduped = [...new Set(urls)];
-  return deduped.length ? deduped : undefined;
+  if (stored.length) return [...new Set(stored)];
+  const curated = (lookupSameAs(mind.name) || [])
+    .map((u) => (u || "").trim())
+    .filter(Boolean);
+  return curated.length ? [...new Set(curated)] : undefined;
 }
 
 // ─── JSON-LD builders (drop empty leaves, matching jsonld_script) ───────


### PR DESCRIPTION
Follow-up to #45 — completes the Type-0 `sameAs` work.

## What
- **`scripts/backfill_mind_sameas.py`** (new): resolves every existing mind to its Wikidata entity via the MediaWiki **action API** (`wbsearchentities` → `wbgetentities`) — a *different service* from the outage-prone SPARQL endpoint `expand_minds` uses, so it works even while WDQS is rate-limiting. **Gated on `P31=Q5` (human) + an enwiki article** so it can't mislink a same-name non-person. Dry-run by default.
  - Ran against prod: **74/81 linked, 7 skipped, 0 mislinks**. Skips are correct (test minds, the deity 太上老君, bare "Van"). Spot-verified the tricky case: Bertrand Russell = Q33760 (and found the curated table had Engels wrongly pointing there).
- **db** (`list_minds`): now SELECTs `wikidata_url`/`wikipedia_url`. It already built rows via `_row_to_mind` (which exposes them), but the SELECT omitted the columns, so the *list* path always saw `""` — breaking the backfill's skip-already-linked check. The *detail* path (`get_mind`, used by the mind page) was always correct.
- **web** (`mindSameAs`): now **prefers the authoritative stored links** over the curated `FAMOUS_MIND_SAMEAS` table (same two URL kinds, but verified). Fixed the curated copy-paste error: **Engels → Q33760 (Russell) corrected to Q34787**.

## Verified
74 prod minds now carry correct `wikidata_url`+`wikipedia_url` (raw-SQL confirmed). After this deploys, the mind-page Person JSON-LD `sameAs` resolves from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)