### PR TITLE
chore(scripts): backfill_mind_sameas — --no-init + --skip-names for prod

### DIFF
--- a/scripts/backfill_mind_sameas.py
+++ b/scripts/backfill_mind_sameas.py
@@ -88,10 +88,22 @@ def main() -> int:
                         help="Re-resolve minds that already have a wikidata_url.")
     parser.add_argument("--max-candidates", type=int, default=5,
                         help="Search hits to consider per name before giving up.")
+    parser.add_argument("--no-init", action="store_true",
+                        help="Skip init_db(). Use against PROD: the schema is already "
+                             "managed by the app, and a full init_db() there re-runs every "
+                             "CREATE INDEX / migration (statement-timeout + lock risk). The "
+                             "backfill itself is single-row UPDATEs, which need no schema work.")
+    parser.add_argument("--skip-names", default="",
+                        help="Comma-separated mind names to exclude — junk/fragment names "
+                             "(e.g. \"s'te\", a bare \"Joseph\") that wbsearchentities fuzzy-"
+                             "matches to the wrong real person. These minds want cleanup, not "
+                             "a sameAs link.")
     args = parser.parse_args()
+    skip_names = {s.strip().lower() for s in args.skip_names.split(",") if s.strip()}
 
-    print(f"--- backfill_mind_sameas (apply={args.apply}) ---", file=sys.stderr)
-    init_db()
+    print(f"--- backfill_mind_sameas (apply={args.apply}, no_init={args.no_init}) ---", file=sys.stderr)
+    if not args.no_init:
+        init_db()
 
     minds = list(list_minds(limit=10000))
     todo = [m for m in minds if args.force or not (m.get("wikidata_url") or "").strip()]
@@ -103,6 +115,10 @@ def main() -> int:
             break
         name = (m.get("name") or "").strip()
         if not name:
+            continue
+        if name.lower() in skip_names:
+            skipped += 1
+            print(f"  skip   {name!r} (denylisted — junk name)", file=sys.stderr)
             continue
         try:
             resolved = None


### PR DESCRIPTION
Operational flags found while running the sameAs backfill against prod (follow-up to #46).

- **--no-init**: skip `init_db()`. Prod schema is app-managed; a full `init_db()` re-runs every CREATE INDEX / migration, which hit a statement-timeout/lock on the large prod `chunks` table. The backfill is single-row UPDATEs — no schema work needed.
- **--skip-names**: denylist junk/fragment mind names that `wbsearchentities` fuzzy-matches to the wrong person (the P31=Q5+enwiki gate can't catch a bad *name*): `s'te`→Sarah Teichmann, bare `Joseph`→Joseph Dalton Hooker.

**Prod run result: 164/173 minds linked, 9 skipped (7 no-match + 2 denylisted), 0 mislinks.** Verified via direct SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)