### PR TITLE
feat(catalog): dedup books at the SOURCE (minting), not just via cleanup

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -1508,10 +1509,98 @@ def find_existing_upload(name: str) -> dict[str, Any] | None:
         return _row_to_agent(row)
 
 
+_TITLE_SUBTITLE = re.compile(r"[:—]|\s-\s")
+_TITLE_PUNCT = re.compile(r"[.,;:!?'\"()]")
+_TITLE_WS = re.compile(r"\s+")
+
+
+def _norm_title(title: str) -> str:
+    """lowercase, drop punctuation, collapse whitespace — subtitle KEPT. Mirrors
+    the frontend `filterBooksByTopic` normalization so display and data agree."""
+    t = _TITLE_PUNCT.sub("", (title or "").lower())
+    return _TITLE_WS.sub(" ", t).strip()
+
+
+def title_stem(title: str) -> str:
+    """The main title with any subtitle dropped (everything after the first ':',
+    '—', or ' - '), normalized like `_norm_title`. The shared 'same book' key;
+    `scripts/dedup_catalog.py` mirrors it. 'Good to Great', 'Good to Great: Why
+    Some Companies…', and 'A World Brewed,' all collapse to one stem."""
+    head = _TITLE_SUBTITLE.split((title or ""), maxsplit=1)[0]
+    return _norm_title(head)
+
+
+def same_book(a: str, b: str) -> bool:
+    """Do two titles denote the SAME book? True when they're equal once
+    normalized, OR one is the other plus a subtitle (a prefix at a ':' / '—' /
+    ' - ' boundary): 'Good to Great' ≡ 'Good to Great: Why Some Companies…',
+    'A World Brewed' ≡ 'A World Brewed,'. Crucially, two DIFFERENT subtitles of a
+    shared subject stay distinct — 'Wittgenstein: Mind and Will (Vol 4)' is NOT
+    'Wittgenstein: Rules and Grammar (Vol 1)' — which a bare stem-equality check
+    would wrongly merge (and delete a real volume)."""
+    fa, fb = _norm_title(a), _norm_title(b)
+    if not fa or not fb:
+        return False
+    if fa == fb:
+        return True
+    # one side is the bare main title of the other (short ≡ short+subtitle)
+    return title_stem(a) == fb or title_stem(b) == fa
+
+
+def _agent_author(a: dict[str, Any]) -> str:
+    """An agent's author, normalized for comparison. meta.author is canonical;
+    `source` is the fallback (older catalog rows stashed the author there)."""
+    return (((a.get("meta") or {}).get("author")) or a.get("source") or "").strip().lower()
+
+
+def find_agent_by_normalized_name(title: str, author: str = "") -> dict[str, Any] | None:
+    """Dedup-at-SOURCE: find an existing, non-deleted agent that is the SAME BOOK
+    as `title` modulo subtitle / punctuation (via `same_book`) — so the catalog
+    stops minting subtitle/comma variants of one book as separate rows. Prefers a
+    ready/indexing record over a writing one over a bare catalog stub.
+
+    `author` guards against merging two genuinely different books that share a
+    title stem ("Leadership" by X vs by Y): a candidate is rejected only when
+    BOTH it and the incoming book name a (different) author — an empty author on
+    either side (the common catalog-stub case) still merges. Returns None if no
+    such book exists yet.
+
+    Mint is not a hot path (discovery is a background batch; chat book-context is
+    per-conversation), so a lightweight stem-scan is fine — only the handful of
+    stem matches are hydrated. Revisit with a stored stem column if the catalog
+    grows large."""
+    if not _norm_title(title):
+        return None
+    new_author = (author or "").strip().lower()
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            "SELECT id, name, status FROM agents WHERE is_deleted = ?"
+        ), (False if _USE_PG else 0,))
+    cand_ids = [r["id"] for r in rows if same_book(title, r["name"] or "")]
+
+    best: dict[str, Any] | None = None
+    best_rank = -1
+    for cid in cand_ids:
+        a = get_agent(cid)
+        if not a:
+            continue
+        a_author = _agent_author(a)
+        if new_author and a_author and new_author != a_author:
+            continue  # same title, different known author → a different book
+        s = a.get("status") or ""
+        rank = 2 if s in ("ready", "indexing") else 1 if s == "writing" else 0
+        if rank > best_rank:
+            best, best_rank = a, rank
+    return best
+
+
 def create_catalog_agent(title: str, author: str = "", isbn: str | None = None,
                          category: str = "", description: str = "") -> str:
-    """Create a new catalog agent for a dynamically discovered book. Returns agent_id."""
-    existing = find_agent_by_name(title)
+    """Create a new catalog agent for a dynamically discovered book. Returns
+    agent_id. Deduplicates at the SOURCE: if the same book already exists under
+    any subtitle/punctuation variant, returns that row instead of minting a new
+    one (this is the chokepoint every catalog mint funnels through)."""
+    existing = find_agent_by_normalized_name(title, author) or find_agent_by_name(title)
     if existing:
         return existing["id"]
     meta = {"title": title, "author": author, "isbn": isbn, "category": category, "description": description}

--- a/scripts/dedup_catalog.py
+++ b/scripts/dedup_catalog.py
@@ -8,10 +8,14 @@ stub plus a short-title `ready` record ("Competitive Strategy: Techniques…" vs
 the duplicate rows still waste indexing + overview generation and pollute the
 library / sitemap. This collapses each duplicate group to one canonical row.
 
-Grouping = normalized title (subtitle after colon/dash stripped, punctuation
-removed, CJK kept) + author. Within a group the KEEetainer is the row with the
-best (status, chunk_count): ready/indexing > writing > catalog, then most
-chunks (the keeper). The losers' chunks + agent rows are deleted.
+Grouping = connected components of `db.same_book()` within author-compatible
+buckets — two rows merge when their titles are equal or one is the other plus a
+subtitle ("Good to Great" ≡ "Good to Great: Why…"), but NOT when they're distinct
+subtitles of a shared subject (the Wittgenstein volumes stay separate). This is
+the SAME relation the minting path (`find_agent_by_normalized_name`) uses, so the
+cleanup and the source-dedup never disagree. Within a group the retained row is
+the best (status, chunk_count): ready/indexing > writing > catalog, then most
+chunks. The losers' chunks + agent rows are deleted.
 
 Usage
 -----
@@ -28,7 +32,6 @@ Required env: DATABASE_URL (same as the app). No LLM calls.
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 
 from app.core import config  # noqa: F401 — ensures env is loaded
@@ -38,18 +41,8 @@ from app.core.db import (
     delete_chunks_for_agent,
     init_db,
     list_agents,
+    same_book,
 )
-
-_PUNCT = re.compile(r"[.,;:!?'\"()]")
-_WS = re.compile(r"\s+")
-
-
-def _norm(name: str) -> str:
-    """Normalized title stem for grouping — must mirror the frontend
-    filterBooksByTopic dedupe so display + data agree."""
-    stem = re.split(r"[:—]|\s-\s", (name or "").lower())[0]
-    stem = _PUNCT.sub("", stem)
-    return _WS.sub(" ", stem).strip()
 
 
 def _rank(a: dict) -> int:
@@ -73,15 +66,35 @@ def main() -> int:
     init_db()
 
     agents = list(list_agents(limit=10000))
-    # Author lives in meta; key on title-stem + author so different books that
-    # share a title prefix aren't merged.
-    groups: dict[str, list[dict]] = {}
-    for a in agents:
-        author = ((a.get("meta") or {}).get("author") or "").strip().lower()
-        key = f"{_norm(a.get('name') or '') or a['id']}|{author}"
-        groups.setdefault(key, []).append(a)
+    # Group by CONNECTED COMPONENTS of same_book(), within author-compatible
+    # buckets. same_book() only links a title to itself-plus-a-subtitle, so the
+    # Wittgenstein volumes (distinct subtitles, no bare stem) stay SEPARATE —
+    # a flat title-stem key used to merge (and delete) them. O(n²) over the
+    # roster; fine for a manual review tool at today's scale.
+    def _author(a: dict) -> str:
+        return ((a.get("meta") or {}).get("author") or a.get("source") or "").strip().lower()
 
-    dup_groups = [g for g in groups.values() if len(g) > 1]
+    names = [a.get("name") or "" for a in agents]
+    authors = [_author(a) for a in agents]
+    parent = list(range(len(agents)))
+
+    def _find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(len(agents)):
+        for j in range(i + 1, len(agents)):
+            if authors[i] and authors[j] and authors[i] != authors[j]:
+                continue  # different known authors → different books
+            if same_book(names[i], names[j]):
+                parent[_find(i)] = _find(j)
+
+    comps: dict[int, list[dict]] = {}
+    for i, a in enumerate(agents):
+        comps.setdefault(_find(i), []).append(a)
+    dup_groups = [g for g in comps.values() if len(g) > 1]
     print(f"{len(agents)} agents → {len(dup_groups)} duplicate groups", file=sys.stderr)
 
     chunk_counts = count_chunks_batch([a["id"] for g in dup_groups for a in g]) or {}


### PR DESCRIPTION
**#7** from the programmatic-SEO plan — stop the catalog minting duplicate rows of one book.

## Problem
Every mint path checked for an existing book by **exact** name, so the same book got minted as several rows: a bare title + subtitle/comma variants — "Good to Great" / "Good to Great: Why Some Companies…" / "A World Brewed,". At 1000× scale this multiplies.

## Fix
- **`title_stem`** — subtitle dropped, punctuation removed: the shared canonical key.
- **`same_book(a,b)`** — a *precise* prefix-at-boundary relation: equal, or one is the other plus a subtitle. Crucially **not** two distinct subtitles of a shared subject, so "Wittgenstein: Mind and Will (Vol 4)" and "…Rules and Grammar (Vol 1)" stay separate — a flat stem key wrongly merged (and deleted) them.
- **`find_agent_by_normalized_name(title, author)`** — dedup-at-source lookup, author-guarded (different authors with the same title stay distinct; an empty author on either side, the stub case, still merges). **`create_catalog_agent`** — the chokepoint every catalog mint funnels through — now uses it, so all paths get source-dedup for free.
- **`scripts/dedup_catalog.py`** — regroup by connected components of `same_book` (within author-compatible buckets): the *same* relation as minting, so cleanup and source can't disagree; also fixes the script's old stem-key over-merge.

## Tested
`same_book` unit cases pass (variants merge; distinct subtitles/volumes stay separate); end-to-end, a subtitle/comma variant of an existing book now resolves to it instead of minting a new row (the old exact check missed it); author guard verified (same/empty author merges, different author doesn't).

Pure code — prevents future dups; existing dups handled by the now-corrected cleanup script + frontend display dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)