### PR TITLE
fix(seo): template review of /book /mind /q /on — thin-content noindex + fixes

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -55,6 +55,19 @@ export async function generateMetadata({
   if (!data) {
     return { title: "Book not found — Feynman" };
   }
+  // A bare catalog stub — no sample passages, no chapters, no questions — is a
+  // low-unique-value page we can't ground. Keep it out of the index to
+  // concentrate crawl budget on real books (it's already excluded from the
+  // sitemap; this stops indexing via internal links too). It still renders for
+  // users; `follow` keeps its cross-links live. These two fetches are shared
+  // with the body (Next dedupes within the request), so no extra round trips.
+  const [stubQuestions, stubPassages] = await Promise.all([
+    getQuestions(params.id),
+    getSamplePassages(params.id, 3),
+  ]);
+  const isStub =
+    stubPassages.length === 0 && data.chapters.length === 0 && stubQuestions.length === 0;
+
   const canonical = `${SITE_URL}/book/${encodeURIComponent(params.id)}`;
   const ogImage = `${SITE_URL}/book/${encodeURIComponent(params.id)}/og.png`;
   const desc = bookDescription(data.subtitle, data.author);
@@ -62,6 +75,7 @@ export async function generateMetadata({
     title: `${data.title} — Feynman`,
     description: desc,
     alternates: { canonical },
+    ...(isStub ? { robots: { index: false, follow: true } } : {}),
     openGraph: {
       type: "book",
       title: data.title,
@@ -277,7 +291,9 @@ export default async function BookLandingPage({ params }: PageProps) {
       <SamplePassages passages={passages} />
       <TableOfContents chapters={data.chapters} />
       <PopularQuestions questions={questions} bookId={id} />
-      <LiveContentLink entityName={data.title} bookId={id} />
+      {/* A bare stub has had no chats, so /insights is an empty state — don't
+          point readers (or crawlers) at it. */}
+      {isStub ? null : <LiveContentLink entityName={data.title} bookId={id} />}
     </EntityLayout>
   );
 }

--- a/web/app/book/[id]/q/[slug]/page.tsx
+++ b/web/app/book/[id]/q/[slug]/page.tsx
@@ -53,29 +53,46 @@ export async function generateMetadata({
   const resolved = await resolveQuestion(params.id, params.slug);
   if (!resolved) return { title: "Question not found — Feynman" };
 
+  // Grounded-content presence drives BOTH the snippet and indexability. Cached
+  // server-side, so this is not an extra LLM call vs the body's fetch.
+  const qa = await getBookQa(params.id, resolved.question);
+  const answer = (qa?.answer || "").trim();
+  const hasGrounded = Boolean(answer || qa?.passages?.length);
+
   const canonical = `${SITE_URL}/book/${encodeURIComponent(params.id)}/q/${params.slug}`;
+  const ogImage = `${SITE_URL}/book/${encodeURIComponent(params.id)}/og.png`;
   let pageTitle = `${resolved.question} — ${data.title}`;
   if (pageTitle.length > 120) {
     pageTitle = pageTitle.slice(0, 117).replace(/\s+\S*$/, "") + "...";
   }
+  // The synthesized answer is the strongest, least-duplicative snippet; fall
+  // back to boilerplate only when there's no answer yet.
   const desc = clampDescription(
-    `Discuss "${resolved.question}" with the book "${data.title}" on Feynman.`,
+    answer || `Discuss "${resolved.question}" with the book "${data.title}" on Feynman.`,
   );
   return {
     title: pageTitle,
     description: desc,
     alternates: { canonical },
+    // No grounded answer or cited passage yet → keep this thin question page out
+    // of the index (its only on-page content would be generic fallback passages,
+    // not an answer to THIS question). It indexes once the answer is generated +
+    // cached on a later crawl; `follow` keeps link equity flowing meanwhile.
+    ...(hasGrounded ? {} : { robots: { index: false, follow: true } }),
     openGraph: {
       type: "article",
       title: resolved.question,
       description: desc,
       url: canonical,
       siteName: "Feynman",
+      images: [{ url: ogImage, width: 1200, height: 630, alt: data.title }],
     },
     twitter: {
       card: "summary_large_image",
+      site: "@steve_yeow",
       title: resolved.question,
       description: desc,
+      images: [ogImage],
     },
   };
 }

--- a/web/app/mind/[id]/on/[slug]/page.tsx
+++ b/web/app/mind/[id]/on/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   metaDescription,
   mindEssayJsonLd,
   resolveTopicSlug,
+  topicSlug,
 } from "@/lib/seo-mind";
 
 // The imagined essay comes from GET /api/minds/{id}/on/{slug} (mirrors the
@@ -28,22 +29,33 @@ export async function generateMetadata({
 }: {
   params: { id: string; slug: string };
 }): Promise<Metadata> {
-  const [mind, topic] = await Promise.all([
+  const [mind, topic, onTopic] = await Promise.all([
     fetchMind(params.id),
     resolveTopicSlug(params.slug),
+    fetchMindOnTopic(params.id, params.slug),
   ]);
   if (!mind || !topic) {
     return { title: "Not found — Feynman" };
   }
-  const canonical = abs(`/mind/${params.id}/on/${params.slug}`);
+  // Canonical = the one true lowercase slug, regardless of how the URL was
+  // typed (resolveTopicSlug matches case-insensitively).
+  const canonical = abs(`/mind/${params.id}/on/${topicSlug(topic)}`);
   const title = `How ${mind.name} might approach ${topic}`;
   const desc = metaDescription(
     `An imagined perspective on ${topic}, grounded in ${mind.name}'s recorded ideas and methods. Explore it in conversation on Feynman.`,
   );
+  // No generated essay yet → keep this URL out of the index. Without an essay
+  // the page is one of ~1000×15 near-identical framed shells (same three
+  // sentences, only the name/topic swapped) — exactly the thin programmatic
+  // combinations behind the GSC "Discovered – not indexed" problem. `follow`
+  // still passes link equity, and once the essay generates + caches on a later
+  // crawl the page becomes indexable.
+  const hasEssay = Boolean(onTopic?.essay && onTopic.essay.trim());
   return {
     title: `${title} — Feynman`,
     description: desc,
     alternates: { canonical },
+    ...(hasEssay ? {} : { robots: { index: false, follow: true } }),
     openGraph: {
       type: "article",
       title,
@@ -81,7 +93,8 @@ export default async function MindOnTopicPage({
   // and fall back to a framed view when it's absent, so every sitemap /on/ URL
   // resolves 200.
 
-  const canonical = abs(`/mind/${params.id}/on/${params.slug}`);
+  const canonicalSlug = topicSlug(topic);
+  const canonical = abs(`/mind/${params.id}/on/${canonicalSlug}`);
   const mindUrl = abs(`/mind/${params.id}`);
   const readerUrl = `/mind/${params.id}/chat`;
   const desc = `An imagined perspective on ${topic}, grounded in ${mind.name}'s recorded ideas and methods.`;
@@ -157,7 +170,7 @@ export default async function MindOnTopicPage({
         <a className="primary" href={readerUrl}>
           Chat with {mind.name} →
         </a>
-        <Link className="secondary" href={`/topic/${params.slug}`}>
+        <Link className="secondary" href={`/topic/${canonicalSlug}`}>
           {topic} on Feynman
         </Link>
       </p>
@@ -166,7 +179,7 @@ export default async function MindOnTopicPage({
         <small>
           Read more: <Link href={`/mind/${params.id}`}>About {mind.name}</Link>
           {" · "}
-          <Link href={`/topic/${params.slug}`}>{topic} on Feynman</Link>
+          <Link href={`/topic/${canonicalSlug}`}>{topic} on Feynman</Link>
         </small>
       </footer>
     </SeoColumn>

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -138,34 +138,22 @@ export default async function MindPage({
     </>
   );
 
-  const rail = (
-    <>
-      {related.length ? (
-        <div className="seo-rail-card">
-          <h3>Related minds</h3>
-          <ul>
-            {related.slice(0, 8).map((rm) => (
-              <li key={rm.id}>
-                <Link href={`/mind/${rm.id}`}>{rm.name}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-      {matchingTopics.length ? (
-        <div className="seo-rail-card">
-          <h3>Topics</h3>
-          <ul>
-            {matchingTopics.slice(0, 6).map((t) => (
-              <li key={t}>
-                <Link href={`/topic/${topicSlug(t)}`}>{t}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </>
-  );
+  // Rail = genuinely complementary "Related minds" only. The topic list lives in
+  // the body ("How {mind} approaches key topics"); a rail "Topics" card repeated
+  // the same labels on-screen (the bug the /topic review removed), so the
+  // body section now carries BOTH the essay link and the topic-hub link instead.
+  const rail = related.length ? (
+    <div className="seo-rail-card">
+      <h3>Related minds</h3>
+      <ul>
+        {related.slice(0, 8).map((rm) => (
+          <li key={rm.id}>
+            <Link href={`/mind/${rm.id}`}>{rm.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ) : null;
 
   return (
     <EntityLayout hero={hero} rail={rail}>
@@ -191,6 +179,10 @@ export default async function MindPage({
               <li key={t}>
                 <Link href={`/mind/${params.id}/on/${topicSlug(t)}`}>
                   How {mind.name} approaches {t}
+                </Link>
+                {" · "}
+                <Link href={`/topic/${topicSlug(t)}`} className="seo-inline-link">
+                  {t} hub
                 </Link>
               </li>
             ))}

--- a/web/app/topic/[slug]/page.tsx
+++ b/web/app/topic/[slug]/page.tsx
@@ -176,7 +176,7 @@ export default async function TopicPage({
                   href={`/mind/${m.id}/on/${params.slug}`}
                   className="seo-inline-link"
                 >
-                  How {m.name} approaches {topic} →
+                  How {m.name} might approach {topic} →
                 </Link>
               </li>
             ))}

--- a/web/components/seo/book/PopularQuestions.tsx
+++ b/web/components/seo/book/PopularQuestions.tsx
@@ -2,8 +2,10 @@
  * "Popular questions readers ask" — each question links to its own
  * /book/{id}/q/{slug} compound page (the long-tail SEO play). Port of
  * seo.py render_popular_questions (book_id + site_url branch). Uses
- * next/link with real paths (no hash). Companion FAQPage JSON-LD is
- * emitted by the page, not here.
+ * next/link with real paths (no hash). NO FAQPage JSON-LD here, by design:
+ * the answers aren't visible on this page (only the question links are), so
+ * FAQPage markup would violate Google's "answer must be on the page" rule.
+ * Each /q/{slug} page carries the compliant QAPage instead.
  */
 import Link from "next/link";
 import { slugify } from "@/lib/seo-book";

--- a/web/components/seo/mind/MindSections.tsx
+++ b/web/components/seo/mind/MindSections.tsx
@@ -28,7 +28,9 @@ export function Section({
 }) {
   return (
     <section className="seo-section">
-      <h2>{heading}</h2>
+      {/* Skip the heading when empty — DialoguesLink renders its own <h2>, and an
+          empty <h2></h2> is an a11y/SEO nit that would repeat on every page. */}
+      {heading ? <h2>{heading}</h2> : null}
       {children}
     </section>
   );


### PR DESCRIPTION
**#2** from the programmatic-SEO plan — audit the four templates about to be scaled across thousands of pages (the `/topic` review pattern), run via 4 parallel reviewers.

## The dominant finding: thin pages were indexable (ties to the GSC "Discovered – not indexed" problem)
Gate, don't delete — `follow` keeps link equity, pages index once they have real content:
- **`/on` essay** returned an indexable 200 *framed shell* when no essay was generated — up to **~1000×15 near-identical templated pages**. Now `noindex` until the essay exists.
- **`/q` answer**: `noindex` when there's no grounded answer or cited passage (only generic fallback passages otherwise).
- **`/book` stub**: `noindex` bare catalog stubs (no passages/chapters/questions). Already sitemap-excluded; this stops indexing via internal links too.

## Other fixes
- **`/mind` rail dup**: the rail "Topics" card repeated the body's "How {mind} approaches topics" list on-screen (the `/topic` bug class). Dropped it; folded the topic-hub link **into** the body section so the Type-3 internal link survives without the on-screen dupe.
- **`/q` regressions**: restored the per-book OG image (was the generic card + malformed `summary_large_image`), used the synthesized answer as the meta description (was boilerplate-duplicated), restored `twitter:site`.
- **`/on` canonical**: canonical + cross-links use the canonical lowercase slug, not the verbatim request slug.
- **empty `<h2>`**: `Section` skips the empty heading `DialoguesLink` produced on every mind page.
- **`/book`**: don't render the live-insights link for stubs (empty `/insights`).
- **`/topic`**: "approaches" → "might approach" (matches the hedged essay framing).
- **PopularQuestions**: corrected a stale comment (no FAQPage by design — answers aren't on the page, so the markup would be non-compliant; `/q` carries QAPage).

## Verification
7 files, type-safe by inspection (no local node_modules). **Letting the Vercel preview build gate this before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)