### PR TITLE
perf(llm): disable Gemini thinking for bulk SEO generation (~3× cheaper)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -37,6 +37,11 @@ GEMINI_API_KEYS = [k.strip() for k in os.getenv("GEMINI_API_KEY", "").split(",")
 GEMINI_API_KEY = GEMINI_API_KEYS[0] if GEMINI_API_KEYS else ""
 GEMINI_BASE_URL = os.getenv("GEMINI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta").strip()
 GEMINI_CHAT_MODEL = os.getenv("GEMINI_CHAT_MODEL", "gemini-2.5-flash").strip()
+# Model used ONLY for bulk programmatic generation (SEO essays/Q&A/overviews/
+# personas), not live user chat. Empty → fall back to GEMINI_CHAT_MODEL. Set to a
+# cheaper tier (e.g. gemini-2.5-flash-lite) to cut scale costs further; combined
+# with thinking-off (bulk_chat) it's the lever for the programmatic supply.
+GEMINI_BULK_CHAT_MODEL = os.getenv("GEMINI_BULK_CHAT_MODEL", "").strip()
 GEMINI_EMBED_MODEL = os.getenv("GEMINI_EMBED_MODEL", "gemini-embedding-001").strip()
 
 KIMI_API_KEY = os.getenv("KIMI_API_KEY", "").strip()

--- a/app/core/minds.py
+++ b/app/core/minds.py
@@ -26,7 +26,7 @@ from .db import (
     update_mind_embedding,
     upsert_compiled_memory,
 )
-from .providers import ProviderError, chat_with_fallback, pick_provider
+from .providers import ProviderError, bulk_chat, chat_with_fallback, pick_provider
 from .rag import build_context, retrieve_cross_book
 
 log = logging.getLogger(__name__)
@@ -474,7 +474,7 @@ def get_or_create_mind(name: str, era: str = "", domain: str = "", link_works: b
 
     prompt = _generate_persona_prompt(name, era, domain)
     try:
-        result, _ = chat_with_fallback(
+        result, _ = bulk_chat(
             system="You are an expert on intellectual history. Return only valid JSON.",
             user=prompt,
             timeout=90,
@@ -594,7 +594,7 @@ def create_mind_from_content(
     )
 
     try:
-        result, _ = chat_with_fallback(
+        result, _ = bulk_chat(
             system="You are an expert at analyzing writing to build persona profiles. Return only valid JSON.",
             user=prompt,
             timeout=90,
@@ -752,7 +752,7 @@ def suggest_minds_hybrid(
         "Return ONLY a JSON array: [{\"name\": \"...\", \"reason\": \"one-sentence why\"}]"
     )
     try:
-        result, _ = chat_with_fallback(
+        result, _ = bulk_chat(
             system="You are an expert on intellectual history selecting panelists.",
             user=prompt,
             provider_order=["gemini", "deepseek", "openai", "kimi", "anthropic"],
@@ -827,7 +827,7 @@ def suggest_minds_for_book(
         "Return ONLY a JSON array: [{\"name\": \"...\", \"era\": \"...\", "
         "\"domain\": \"...\", \"reason\": \"...\"}]"
     )
-    result, _ = chat_with_fallback(
+    result, _ = bulk_chat(
         system="You are an expert on intellectual history.",
         user=prompt,
     )
@@ -876,7 +876,7 @@ def suggest_minds_for_topic(
         "Return ONLY a JSON array: [{\"name\": \"...\", \"era\": \"...\", "
         "\"domain\": \"...\", \"reason\": \"...\"}]"
     )
-    result, _ = chat_with_fallback(
+    result, _ = bulk_chat(
         system="You are an expert on intellectual history.",
         user=prompt,
     )

--- a/app/core/overview.py
+++ b/app/core/overview.py
@@ -24,7 +24,7 @@ import logging
 import os
 from typing import Any
 
-from .providers import chat_with_fallback, ProviderError
+from .providers import bulk_chat, ProviderError
 from .rag import retrieve, build_context
 
 log = logging.getLogger(__name__)
@@ -183,7 +183,7 @@ def generate_book_overview(
         user += f'\n\n(The book\'s own subtitle/description: "{subtitle}")'
 
     try:
-        chat_result, provider_obj = chat_with_fallback(system=system, user=user)
+        chat_result, provider_obj = bulk_chat(system=system, user=user)
         text = (chat_result.content or "").strip()
         provider_name = getattr(provider_obj, "name", "") or ""
     except ProviderError as exc:
@@ -230,7 +230,7 @@ def generate_topic_overview(topic: str) -> dict[str, Any]:
         "those are shown separately on the page. No headings."
     )
     try:
-        chat_result, provider_obj = chat_with_fallback(system=system, user=user)
+        chat_result, provider_obj = bulk_chat(system=system, user=user)
         text = (chat_result.content or "").strip()
         provider_name = getattr(provider_obj, "name", "") or ""
     except ProviderError as exc:

--- a/app/core/providers.py
+++ b/app/core/providers.py
@@ -209,7 +209,7 @@ class GeminiProvider(BaseProvider):
                 all_embeddings.append(item.get("values", []))
         return all_embeddings
 
-    def chat(self, system: str, user: str, history: list[dict[str, str]] | None = None, use_grounding: bool = False, timeout: int | None = None) -> ChatResult:
+    def chat(self, system: str, user: str, history: list[dict[str, str]] | None = None, use_grounding: bool = False, timeout: int | None = None, thinking_budget: int | None = None, model: str | None = None) -> ChatResult:
         parts: list[dict[str, str]] = []
         prompt = system.strip()
         if prompt:
@@ -224,9 +224,16 @@ class GeminiProvider(BaseProvider):
                 }
             ]
         }
+        # thinking_budget=0 disables gemini-2.5-flash's (default-on) thinking. The
+        # thinking tokens bill as OUTPUT ($2.50/1M), so disabling it is ~3× cheaper
+        # for the programmatic generators that don't need deep reasoning. None =
+        # model default (kept for live user chat). `model` overrides the chat model
+        # per-call (e.g. a cheaper bulk tier) without affecting live chat.
+        if thinking_budget is not None:
+            payload["generationConfig"] = {"thinkingConfig": {"thinkingBudget": thinking_budget}}
         if use_grounding:
             payload["tools"] = [{"google_search": {}}]
-        path = f"/models/{self.chat_model}:generateContent"
+        path = f"/models/{model or self.chat_model}:generateContent"
         data = self._post(path, payload, timeout=timeout)
         candidates = data.get("candidates", [])
         if not candidates:
@@ -407,8 +414,15 @@ def chat_with_fallback(
     max_total_seconds: float | None = None,
     timeout: int | None = None,
     provider_order: list[str] | None = None,
+    thinking_budget: int | None = None,
+    gemini_model: str | None = None,
 ) -> tuple[ChatResult, BaseProvider]:
     """Try each provider in order until one succeeds. Returns (result, provider).
+
+    *thinking_budget* and *gemini_model* apply ONLY to the Gemini provider (other
+    providers ignore them): thinking_budget=0 disables thinking, gemini_model
+    swaps the model per call. See bulk_chat() for the programmatic-generation
+    preset that uses both.
 
     *timeout* is the per-provider HTTP timeout (defaults to _CHAT_TIMEOUT = 30s).
     Callers expecting long outputs (e.g. mind persona generation) should pass a
@@ -432,12 +446,20 @@ def chat_with_fallback(
         if not provider.has_key():
             continue
         try:
+            # thinking_budget / model are Gemini-only kwargs; don't pass them to
+            # providers whose chat() signature doesn't accept them.
+            extra: dict[str, Any] = {}
+            if isinstance(provider, GeminiProvider):
+                extra["thinking_budget"] = thinking_budget
+                if gemini_model:
+                    extra["model"] = gemini_model
             result = provider.chat(
                 system=system,
                 user=user,
                 history=history,
                 use_grounding=use_grounding and isinstance(provider, GeminiProvider),
                 timeout=per_timeout,
+                **extra,
             )
             return result, provider
         except Exception as exc:
@@ -445,3 +467,16 @@ def chat_with_fallback(
             errors.append(f"{name}: {exc}")
             continue
     raise ProviderError("All providers failed: " + "; ".join(errors))
+
+
+def bulk_chat(system: str, user: str, **kwargs: Any) -> tuple[ChatResult, BaseProvider]:
+    """chat_with_fallback tuned for PROGRAMMATIC BULK generation — SEO essays,
+    grounded Q&A, book overviews, mind personas, mind suggestions. Disables
+    Gemini thinking (~3× cheaper output; these tasks don't need deep reasoning)
+    and uses the optional cheaper bulk model (config.GEMINI_BULK_CHAT_MODEL, e.g.
+    gemini-2.5-flash-lite). LIVE user chat (mind_chat, book RAG, book writing)
+    does NOT route through here — it keeps full thinking + the primary model.
+    Extra kwargs (timeout, provider_order, …) pass through unchanged."""
+    kwargs.setdefault("thinking_budget", 0)
+    kwargs.setdefault("gemini_model", config.GEMINI_BULK_CHAT_MODEL or None)
+    return chat_with_fallback(system, user, **kwargs)

--- a/app/core/qa.py
+++ b/app/core/qa.py
@@ -25,7 +25,7 @@ import os
 import re
 from typing import Any
 
-from .providers import chat_with_fallback, ProviderError
+from .providers import bulk_chat, ProviderError
 from .rag import retrieve, build_context
 
 log = logging.getLogger(__name__)
@@ -168,7 +168,7 @@ def generate_mind_on_topic_essay(
         f"underlying problem they would have recognized."
     )
     try:
-        chat_result, provider_obj = chat_with_fallback(system=system, user=user)
+        chat_result, provider_obj = bulk_chat(system=system, user=user)
         text = (chat_result.content or "").strip()
         provider_name = getattr(provider_obj, "name", "") or ""
     except ProviderError as exc:
@@ -246,7 +246,7 @@ def generate_grounded_answer(
         "say what they do say and what's missing."
     )
     try:
-        chat_result, provider_obj = chat_with_fallback(system=system, user=user)
+        chat_result, provider_obj = bulk_chat(system=system, user=user)
         text = (chat_result.content or "").strip()
         provider_name = getattr(provider_obj, "name", "") or ""
     except ProviderError as exc:


### PR DESCRIPTION
Prod runs `PROVIDER_ORDER="gemini,..."` → all generation hits **gemini-2.5-flash**, whose **thinking is on by default**, and thinking tokens bill as **output ($2.50/1M)**. The programmatic generators don't need deep reasoning, so thinking on ~15K essays + ~5K Q&A at scale is ~3× wasted spend.

## Change
- **`bulk_chat`** preset (providers.py): Gemini thinking off (`thinkingConfig.thinkingBudget=0`) + optional cheaper bulk model.
- `GeminiProvider.chat` gains `thinking_budget` + per-call `model`; `chat_with_fallback` threads both to Gemini only (others ignore).
- **`GEMINI_BULK_CHAT_MODEL`** (env, empty → primary model). Set to `gemini-2.5-flash-lite` for another ~3× (≈10× combined).
- Routed through `bulk_chat`: essay, grounded Q&A, overview, persona, `create_mind_from_content`, the 3 `suggest_minds_*`.

## Explicitly NOT changed (keep full thinking + primary model)
Live `mind_chat`, book RAG (`rag.py`), book writing (`ai_writer.py`), and per-chat memory summarizers. Default behavior unchanged until the env var is set; thinking-off applies immediately to the bulk paths.

## Cost impact (gemini-2.5-flash)
| | per essay | full scale (~15K essay + 5K Q&A + 1K overview + 950 persona) |
|---|---|---|
| before (thinking on) | ~$0.005 | ~$110–130 |
| thinking off (this PR) | ~$0.0015 | ~$35–45 |
| + flash-lite bulk model | ~$0.0005 | ~$12–18 |

212 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)