### PR TITLE
feat(seo): Type-1/2 pre-store (essay + Q&A) so /on /q don't gen per crawl

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -41,7 +41,7 @@ GEMINI_CHAT_MODEL = os.getenv("GEMINI_CHAT_MODEL", "gemini-2.5-flash").strip()
 # personas), not live user chat. Empty → fall back to GEMINI_CHAT_MODEL. Set to a
 # cheaper tier (e.g. gemini-2.5-flash-lite) to cut scale costs further; combined
 # with thinking-off (bulk_chat) it's the lever for the programmatic supply.
-GEMINI_BULK_CHAT_MODEL = os.getenv("GEMINI_BULK_CHAT_MODEL", "").strip()
+GEMINI_BULK_CHAT_MODEL = os.getenv("GEMINI_BULK_CHAT_MODEL", "gemini-2.5-flash-lite").strip()
 GEMINI_EMBED_MODEL = os.getenv("GEMINI_EMBED_MODEL", "gemini-embedding-001").strip()
 
 KIMI_API_KEY = os.getenv("KIMI_API_KEY", "").strip()

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -398,7 +398,7 @@ def init_db() -> None:
             # Migration: add embedding columns to minds table; plus Wikidata/
             # Wikipedia identity URLs (for Person JSON-LD sameAs — the
             # Knowledge-Graph / LLM entity signal on every expanded mind).
-            for col, col_type in [("embedding", "BLOB"), ("embedding_dim", "INTEGER"), ("embedding_norm", "REAL"), ("wikidata_url", "TEXT"), ("wikipedia_url", "TEXT")]:
+            for col, col_type in [("embedding", "BLOB"), ("embedding_dim", "INTEGER"), ("embedding_norm", "REAL"), ("wikidata_url", "TEXT"), ("wikipedia_url", "TEXT"), ("meta_json", "TEXT")]:
                 try:
                     _execute(conn, f"SAVEPOINT sp_minds_{col}")
                     _execute(conn, f"ALTER TABLE minds ADD COLUMN {col} {col_type}")
@@ -870,7 +870,7 @@ def init_db() -> None:
 
             # Migration: add embedding columns to minds table; plus Wikidata/
             # Wikipedia identity URLs for Person JSON-LD sameAs.
-            for col, col_type in [("embedding", "BYTEA"), ("embedding_dim", "INTEGER"), ("embedding_norm", "DOUBLE PRECISION"), ("wikidata_url", "TEXT"), ("wikipedia_url", "TEXT")]:
+            for col, col_type in [("embedding", "BYTEA"), ("embedding_dim", "INTEGER"), ("embedding_norm", "DOUBLE PRECISION"), ("wikidata_url", "TEXT"), ("wikipedia_url", "TEXT"), ("meta_json", "TEXT")]:
                 try:
                     _execute(conn, f"SAVEPOINT sp_minds_{col}")
                     _execute(conn, f"ALTER TABLE minds ADD COLUMN {col} {col_type}")
@@ -1716,6 +1716,40 @@ def update_mind_links(mind_id: str, wikidata_url: str | None = None, wikipedia_u
         _execute(conn, _q(
             "UPDATE minds SET wikidata_url = ?, wikipedia_url = ? WHERE id = ?"
         ), (wikidata_url or None, wikipedia_url or None, mind_id))
+
+
+def get_mind_meta(mind_id: str) -> dict[str, Any]:
+    """A mind's PRIVATE meta dict — pre-stored SEO content (Type-2 essays under
+    `essays`). Deliberately NOT surfaced by `_row_to_mind` / the public mind API,
+    so it never leaks; read it explicitly where needed."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q("SELECT meta_json FROM minds WHERE id = ?"), (mind_id,))
+    if not row:
+        return {}
+    try:
+        return json.loads(row.get("meta_json") or "{}") or {}
+    except Exception:
+        return {}
+
+
+def get_mind_essay(mind_id: str, topic: str) -> str | None:
+    """A pre-stored Type-2 essay for (mind, topic), or None — the check-first
+    half of the lazy-gen+cache pattern (mirrors overview's meta.overview)."""
+    essay = (get_mind_meta(mind_id).get("essays") or {}).get(topic)
+    return essay or None
+
+
+def save_mind_essay(mind_id: str, topic: str, essay: str) -> None:
+    """Persist a generated Type-2 essay into the mind's meta so the hot path
+    serves it without re-generating (read-modify-write of meta.essays)."""
+    if not (essay or "").strip():
+        return
+    meta = get_mind_meta(mind_id)
+    essays = meta.get("essays") or {}
+    essays[topic] = essay
+    meta["essays"] = essays
+    with get_conn() as conn:
+        _execute(conn, _q("UPDATE minds SET meta_json = ? WHERE id = ?"), (json.dumps(meta), mind_id))
 
 
 def list_minds_with_embeddings() -> list[dict[str, Any]]:

--- a/app/core/qa.py
+++ b/app/core/qa.py
@@ -25,6 +25,7 @@ import os
 import re
 from typing import Any
 
+from . import db
 from .providers import bulk_chat, ProviderError
 from .rag import retrieve, build_context
 
@@ -187,6 +188,26 @@ def generate_mind_on_topic_essay(
     return result
 
 
+def get_or_generate_mind_essay(mind: dict[str, Any], topic: str) -> dict[str, Any]:
+    """Check-first wrapper for the Type-2 essay (lazy-gen + PERSISTENT cache,
+    mirroring overview's meta.overview): return the pre-stored essay if present
+    (zero LLM), else generate AND persist it so the next crawl is free. The /on
+    endpoint and the pre-store script both call this — keeping ~15K programmatic
+    essays off the per-crawl LLM path (the master-plan quota-blowout risk)."""
+    mind_id = mind.get("id") or ""
+    if mind_id:
+        cached = db.get_mind_essay(mind_id, topic)
+        if cached:
+            return {"essay": cached, "provider": "cache"}
+    result = generate_mind_on_topic_essay(mind, topic)
+    if mind_id and result.get("essay"):
+        try:
+            db.save_mind_essay(mind_id, topic, result["essay"])
+        except Exception as exc:
+            log.warning("save_mind_essay failed for %s/%s: %s", mind_id, topic, exc)
+    return result
+
+
 def generate_grounded_answer(
     agent_id: str,
     question: str,
@@ -262,4 +283,37 @@ def generate_grounded_answer(
         text = text[:_QA_ANSWER_MAX_CHARS].rsplit(" ", 1)[0] + "…"
     result["answer"] = text
     result["provider"] = provider_name
+    return result
+
+
+def get_or_generate_grounded_answer(
+    agent_id: str,
+    question: str,
+    *,
+    book_title: str = "",
+) -> dict[str, Any]:
+    """Check-first wrapper for the Type-1 grounded answer (lazy-gen + PERSISTENT
+    cache in the book's meta.qa): return the pre-stored {answer, passages} if
+    present (zero LLM + zero retrieval), else generate AND persist it. The /q
+    endpoint and the pre-store script both call this — keeping the programmatic
+    Q&A answers off the per-crawl LLM path. Cache key is the full question text,
+    so editing a question naturally invalidates its stored answer."""
+    agent = db.get_agent(agent_id)
+    if agent:
+        stored = ((agent.get("meta") or {}).get("qa") or {}).get(question)
+        if stored and stored.get("answer"):
+            return {
+                "answer": stored.get("answer", ""),
+                "passages": stored.get("passages", []),
+                "provider": "cache",
+            }
+    result = generate_grounded_answer(agent_id, question, book_title=book_title)
+    if agent and result.get("answer"):
+        try:
+            meta = agent.get("meta") or {}
+            qa = meta.get("qa") or {}
+            qa[question] = {"answer": result.get("answer", ""), "passages": result.get("passages", [])}
+            db.update_agent_meta(agent_id, {"qa": qa})
+        except Exception as exc:
+            log.warning("save book qa failed for %s: %s", agent_id, exc)
     return result

--- a/app/main.py
+++ b/app/main.py
@@ -3932,7 +3932,9 @@ def api_agent_qa(agent_id: str, question: str) -> JSONResponse:
         raise HTTPException(status_code=404, detail="Agent not found")
     title_raw = agent.get("name", "") or ""
     try:
-        qa_result = qa_module.generate_grounded_answer(
+        # Check-first: serve the pre-stored answer if present, else generate +
+        # persist into the book's meta.qa — keeps programmatic Q&A off the LLM path.
+        qa_result = qa_module.get_or_generate_grounded_answer(
             agent_id, question, book_title=title_raw,
         )
     except Exception as exc:
@@ -4188,7 +4190,9 @@ def api_mind_on_topic(mind_id: str, topic_slug: str) -> JSONResponse:
     if not topic or not qa_module.is_mind_topic_relevant(mind, topic):
         raise HTTPException(status_code=404, detail="Not found")
     try:
-        essay_result = qa_module.generate_mind_on_topic_essay(mind, topic)
+        # Check-first: serve the pre-stored essay if present, else generate +
+        # persist (so the next crawl is free) — keeps ~15K essays off the LLM path.
+        essay_result = qa_module.get_or_generate_mind_essay(mind, topic)
     except Exception as exc:
         log.error("mind essay failed for %s/%s: %s", mind_id, topic, exc)
         essay_result = {"essay": ""}

--- a/scripts/prestore_seo_content.py
+++ b/scripts/prestore_seo_content.py
@@ -1,0 +1,166 @@
+"""Pre-generate Type-1 (grounded Q&A) + Type-2 (imagined-perspective essay) SEO
+content into the DB, so the live `/q/` and `/on/` endpoints serve it WITHOUT a
+per-crawl LLM call — and so each page flips from `noindex` (thin-content gate,
+#49) to indexable the moment its content exists.
+
+WHY THIS EXISTS (master-plan P0 #1)
+-----------------------------------
+`/q/` and `/on/` were lazy-generated on every cache miss with NO persistent
+store — minds 50→1000 = ~15K essays each hitting Gemini on crawl = quota
+blowout + slow crawl. This script (with the new `meta.essays` / `meta.qa`
+check-first cache in qa.py) pre-fills that store off-Vercel, so the hot path is
+free and Google sees real content immediately.
+
+CHEAP NOW
+---------
+Generation runs through `bulk_chat` (Gemini thinking OFF, optional
+`GEMINI_BULK_CHAT_MODEL=gemini-2.5-flash-lite`) — ~3–10× cheaper than the old
+default. The whole programmatic surface is roughly $12–45 of Gemini depending on
+those levers.
+
+Usage
+-----
+  python -m scripts.prestore_seo_content                  # DRY-RUN: count what's missing
+  python -m scripts.prestore_seo_content --apply
+  python -m scripts.prestore_seo_content --apply --essays-only --limit 200
+  python -m scripts.prestore_seo_content --apply --qa-only --max-questions 5
+  python -m scripts.prestore_seo_content --apply --no-init   # against PROD (schema app-managed)
+
+Properties
+----------
+- **Idempotent.** The check-first wrappers skip anything already stored, so
+  re-runs only fill gaps. Safe to interrupt/resume.
+- **Quota-friendly.** ~1 LLM round trip per NEW essay/answer; --limit / --sleep
+  spread the run across the Gemini window; run in chunks over days if needed.
+- **Off-Vercel / Hobby-safe.** Zero Vercel CPU — the live site just serves the
+  stored rows. Against PROD, export the prod DATABASE_URL + pass --no-init
+  (see scripts/backfill_mind_sameas.py header).
+
+Required env: DATABASE_URL, GEMINI_API_KEY (or the configured provider).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from app.core import config  # noqa: F401 — ensures env is loaded
+from app.core.catalog import TOPIC_TAGS
+from app.core.db import (
+    get_mind_essay,
+    init_db,
+    list_agents,
+    list_minds,
+    list_questions,
+)
+from app.core.qa import (
+    get_or_generate_grounded_answer,
+    get_or_generate_mind_essay,
+    is_mind_topic_relevant,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="Generate + store (default: dry-run, counts what's missing, no LLM).")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Generate at most this many NEW items this run (quota control).")
+    parser.add_argument("--sleep", type=float, default=0.5,
+                        help="Seconds between generations (throttle the provider).")
+    parser.add_argument("--essays-only", action="store_true", help="Type-2 essays only.")
+    parser.add_argument("--qa-only", action="store_true", help="Type-1 Q&A only.")
+    parser.add_argument("--max-questions", type=int, default=None,
+                        help="Cap questions pre-stored per book.")
+    parser.add_argument("--no-init", action="store_true",
+                        help="Skip init_db() — use against PROD (schema is app-managed).")
+    args = parser.parse_args()
+
+    do_essays = not args.qa_only
+    do_qa = not args.essays_only
+
+    print(f"--- prestore_seo_content (apply={args.apply}) ---", file=sys.stderr)
+    if not args.no_init:
+        init_db()
+
+    made = skipped = failed = 0
+
+    def _cap_hit() -> bool:
+        return args.limit is not None and made >= args.limit
+
+    # ── Type-2 essays: minds × RELEVANT topics (the same gate the sitemap +
+    #    the /on endpoint use, so we only fill what's actually served). ──────
+    if do_essays:
+        minds = list(list_minds(limit=10000))
+        print(f"essays: {len(minds)} minds × relevant topics", file=sys.stderr)
+        for m in minds:
+            mid = m.get("id")
+            if not mid:
+                continue
+            for topic in TOPIC_TAGS:
+                if not is_mind_topic_relevant(m, topic):
+                    continue
+                if get_mind_essay(mid, topic):
+                    skipped += 1
+                    continue
+                if _cap_hit():
+                    break
+                if not args.apply:
+                    made += 1  # dry-run: would-generate count
+                    continue
+                try:
+                    res = get_or_generate_mind_essay(m, topic)
+                    if res.get("essay"):
+                        made += 1
+                        print(f"  essay OK  {m.get('name')!r} × {topic}", file=sys.stderr)
+                    else:
+                        failed += 1
+                except Exception as exc:
+                    failed += 1
+                    print(f"  essay FAIL {m.get('name')!r} × {topic}: {exc}", file=sys.stderr)
+                time.sleep(args.sleep)
+            if _cap_hit():
+                break
+
+    # ── Type-1 Q&A: READY books × their curated questions. ─────────────────
+    if do_qa and not _cap_hit():
+        books = [a for a in list_agents(limit=10000) if a.get("status") in ("ready", "indexing")]
+        print(f"qa: {len(books)} ready/indexing books × questions", file=sys.stderr)
+        for a in books:
+            aid = a.get("id")
+            if not aid:
+                continue
+            stored = ((a.get("meta") or {}).get("qa") or {})
+            questions = list_questions(aid) or []
+            if args.max_questions is not None:
+                questions = questions[: args.max_questions]
+            for q in questions:
+                if stored.get(q, {}).get("answer"):
+                    skipped += 1
+                    continue
+                if _cap_hit():
+                    break
+                if not args.apply:
+                    made += 1
+                    continue
+                try:
+                    res = get_or_generate_grounded_answer(aid, q, book_title=a.get("name", ""))
+                    if res.get("answer"):
+                        made += 1
+                        print(f"  qa OK  {a.get('name')!r}: {q[:50]}", file=sys.stderr)
+                    else:
+                        failed += 1
+                except Exception as exc:
+                    failed += 1
+                    print(f"  qa FAIL {a.get('name')!r}: {exc}", file=sys.stderr)
+                time.sleep(args.sleep)
+            if _cap_hit():
+                break
+
+    verb = "generated" if args.apply else "would generate"
+    print(f"--- done: {verb}={made} already_stored={skipped} failed={failed} ---", file=sys.stderr)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Master-plan P0 #1** — the gating item before scaling minds, and now cheap to run.

## Problem
`/q` and `/on` were lazy-generated on every cache miss with **no persistent store** → minds 50→1000 = ~15K essays hitting Gemini on crawl = quota blowout. And with the thin-content `noindex` gate (#49), an un-generated page stays `noindex` — so a page only indexes once its content exists.

## Change
- **db**: minds gains a private `meta_json` column (migration, both dialects; NOT surfaced by the public API). `get_mind_meta` / `get_mind_essay` / `save_mind_essay`.
- **qa**: check-first wrappers mirroring overview's `meta.overview` — `get_or_generate_mind_essay` (`meta.essays[topic]`) and `get_or_generate_grounded_answer` (book `meta.qa[question]`): serve stored content with zero LLM, else generate **and persist**.
- **main**: the `/on` + `/q` JSON endpoints call the wrappers.
- **`scripts/prestore_seo_content.py`**: off-Vercel batch (minds × *relevant* topics + ready books × questions). Dry-run default; `--apply`, `--limit/--sleep`, `--essays-only/--qa-only`, `--no-init` for prod. Idempotent.
- **config**: `GEMINI_BULK_CHAT_MODEL` now defaults to `gemini-2.5-flash-lite` so bulk gen is cheapest by default (~10× vs thinking-on). Revert to `gemini-2.5-flash` if essay/persona prose needs the bigger model.

## Composes with #49
Pre-store fills content → `/q` and `/on` flip `noindex → indexable`.

## Verified
meta store roundtrip; dry-run (447 items on local); **212 backend tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)