### PR TITLE
feat(seo): in-page chat composer on /book + /q — activation bridge

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -11,6 +11,7 @@ import SamplePassages from "@/components/seo/book/SamplePassages";
 import TableOfContents from "@/components/seo/book/TableOfContents";
 import PopularQuestions from "@/components/seo/book/PopularQuestions";
 import LiveContentLink from "@/components/seo/book/LiveContentLink";
+import EntityComposer from "@/components/chat/EntityComposer";
 
 import {
   SITE_URL,
@@ -145,21 +146,16 @@ export default async function BookLandingPage({ params }: PageProps) {
     { name: "Books", url: `${SITE_URL}/library` },
     { name: data.title, url: canonical },
   ]);
-  // ── Top actions (per product direction) ───────────────────────────────
-  // Chat ALWAYS available → routes to the conversational surface (home
-  // composer preselects the book), NOT the reader — so catalog stubs with no
-  // readable text still start a chat (fixes the dead-end). Read/Preview appear
-  // only when the book actually has content, and go to the reader.
-  const chatHref = `/?book=${encodeURIComponent(id)}`;
+  // ── Top actions ───────────────────────────────────────────────────────
+  // Chat now lives in the in-page <EntityComposer> right below the hero (the
+  // real grounded chat, book pre-set) — so the hero keeps only Read/Preview (a
+  // redundant "Chat about this book" button would just duplicate the composer).
+  // Catalog stubs simply have no Read/Preview; the composer is their entry.
   const actions: EntityAction[] = [];
   if (caps.read) {
     actions.push({ label: `Read`, href: `/read/${encodeURIComponent(id)}`, variant: "primary" });
-    actions.push({ label: `Chat about this book`, href: chatHref, variant: "secondary" });
   } else if (caps.preview) {
     actions.push({ label: `Preview`, href: `/read/${encodeURIComponent(id)}`, variant: "primary" });
-    actions.push({ label: `Chat about this book`, href: chatHref, variant: "secondary" });
-  } else {
-    actions.push({ label: `Chat about this book`, href: chatHref, variant: "primary" });
   }
 
   const metaBits: string[] = [];
@@ -247,6 +243,14 @@ export default async function BookLandingPage({ params }: PageProps) {
     <EntityLayout hero={hero} rail={rail}>
       <JsonLd data={bookLd} />
       <JsonLd data={breadcrumbLd} />
+
+      {/* Activation bridge: start the real grounded chat right here (book
+          pre-set, free, great minds auto-join) instead of bouncing off a
+          static page. */}
+      <EntityComposer
+        book={{ id, title: data.title, author: data.author }}
+        source="book"
+      />
 
       <section className="seo-section">
         {overview ? (

--- a/web/app/book/[id]/q/[slug]/page.tsx
+++ b/web/app/book/[id]/q/[slug]/page.tsx
@@ -9,6 +9,7 @@ import JsonLd from "@/components/seo/JsonLd";
 import QaAnswer from "@/components/seo/book/QaAnswer";
 import QaPassages from "@/components/seo/book/QaPassages";
 import SiblingQuestions from "@/components/seo/book/SiblingQuestions";
+import EntityComposer from "@/components/chat/EntityComposer";
 
 import {
   SITE_URL,
@@ -118,10 +119,6 @@ export default async function BookQuestionPage({ params }: PageProps) {
 
   const bookUrl = `${SITE_URL}/book/${encodeURIComponent(id)}`;
   const canonical = `${bookUrl}/q/${slug}`;
-  // Chat ALWAYS routes to the conversational composer (preselects the book),
-  // never the reader — catalog stubs have no readable text, so /read would be
-  // a dead end here.
-  const chatHref = `/?book=${encodeURIComponent(id)}`;
   const createdAt = data.agent.created_at || "";
 
   const qaLd = qaPageJsonld({
@@ -140,9 +137,8 @@ export default async function BookQuestionPage({ params }: PageProps) {
     { name: "Q&A", url: canonical },
   ]);
 
-  const actions: EntityAction[] = [
-    { label: `Chat about this book`, href: chatHref, variant: "primary" },
-  ];
+  // Chat lives in the in-page composer below the answer (no redundant button).
+  const actions: EntityAction[] = [];
 
   const hero = (
     <>
@@ -178,6 +174,18 @@ export default async function BookQuestionPage({ params }: PageProps) {
       <QaPassages
         passages={passages.map((p) => ({ text: p.text, chunk_index: p.index }))}
       />
+
+      {/* Activation: read the answer, then keep going — start the real grounded
+          chat (book pre-set, great minds can join) instead of bouncing. */}
+      <section className="seo-section">
+        <h2>Continue the conversation</h2>
+        <EntityComposer
+          book={{ id, title: data.title, author: data.author }}
+          source="q"
+          placeholder={`Ask a follow-up about ${data.title} — great minds will join in…`}
+        />
+      </section>
+
       <SiblingQuestions
         siblings={questions}
         bookId={id}

--- a/web/components/chat/Composer.tsx
+++ b/web/components/chat/Composer.tsx
@@ -33,6 +33,8 @@ export default function Composer({
   onToggleMind,
   onRemoveBook,
   onRemoveMind,
+  direction = "up",
+  placeholder: placeholderProp,
 }: {
   books: Map<string, SelectedBook>;
   minds: Map<string, SelectedMind>;
@@ -44,6 +46,11 @@ export default function Composer({
   onToggleMind: (mind: SelectedMind) => void;
   onRemoveBook: (id: string) => void;
   onRemoveMind: (id: string) => void;
+  /** Popover open direction. "up" (default) for the bottom-of-chat composer;
+   *  "down" when the composer sits near the TOP of the page (SEO entity pages). */
+  direction?: "up" | "down";
+  /** Override the textarea placeholder (default: the in-chat "Ask a follow-up…"). */
+  placeholder?: string;
 }) {
   const [value, setValue] = useState("");
   const [booksOpen, setBooksOpen] = useState(false);
@@ -69,9 +76,10 @@ export default function Composer({
   // The @-hint shows when minds are mentionable — chip-selected OR auto-joined
   // (port of _updateComposerMentionHint: activeMinds ∪ selectedMinds).
   const hasMinds = minds.size > 0 || mentionable.length > 0;
+  const basePlaceholder = placeholderProp ?? "Ask a follow-up question...";
   const placeholder = hasMinds
-    ? "Ask a follow-up question... Type @ to mention a mind"
-    : "Ask a follow-up question...";
+    ? `${basePlaceholder} Type @ to mention a mind`
+    : basePlaceholder;
 
   return (
     <div className="chat-composer chat-composer-inline">
@@ -124,7 +132,7 @@ export default function Composer({
             </button>
             <BookPopover
               open={booksOpen}
-              direction="up"
+              direction={direction}
               selected={books}
               onToggle={onToggleBook}
               onClose={() => setBooksOpen(false)}
@@ -146,7 +154,7 @@ export default function Composer({
             </button>
             <MindsPopover
               open={mindsOpen}
-              direction="up"
+              direction={direction}
               selected={minds}
               onToggle={onToggleMind}
               onClose={() => setMindsOpen(false)}

--- a/web/components/chat/EntityComposer.tsx
+++ b/web/components/chat/EntityComposer.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * In-page chat composer for the SEO/GEO entity pages (/book, /book/q, …).
+ *
+ * The activation bridge. Instead of a small "Chat about this book" link that
+ * drops the reader on the home composer (losing the page context), this starts
+ * the REAL core chat right here, with the book pre-selected as a chip — so a
+ * free reader lands straight in a grounded conversation, turning "read the
+ * answer and bounce" into "read it and start talking".
+ *
+ * It WRAPS the same canonical <Composer> the in-chat surface uses (identical
+ * styling + components: books / invite-great-minds popovers, chips, send), so
+ * the experience is unified. Inviting specific minds stays the pro path (gated
+ * on send exactly like the home composer); a plain book chat is free.
+ *
+ * Reuses the home/chat machinery: createSession → sessionStorage handoff
+ * (feynman:pendingChat) → /chat/{id}, where ChatView fires /api/chat.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createSession, bumpSessions } from "@/lib/chat";
+import { useProGate } from "@/components/pro/ProOverlay";
+import { track } from "@/lib/analytics";
+import Composer from "./Composer";
+import type { SelectedBook, SelectedMind } from "./ComposerPickers";
+
+const PENDING_KEY = "feynman:pendingChat";
+
+export default function EntityComposer({
+  book,
+  source,
+  placeholder,
+}: {
+  book: { id: string; title: string; author?: string };
+  /** analytics tag for where the chat was started (e.g. "book", "q"). */
+  source?: string;
+  placeholder?: string;
+}) {
+  const router = useRouter();
+  const { requirePro } = useProGate();
+  const [books, setBooks] = useState<Map<string, SelectedBook>>(
+    () =>
+      new Map([
+        [book.id, { id: book.id, agentId: book.id, title: book.title, author: book.author || "" }],
+      ]),
+  );
+  const [minds, setMinds] = useState<Map<string, SelectedMind>>(new Map());
+  const [busy, setBusy] = useState(false);
+
+  const start = async (message: string) => {
+    const msg = message.trim();
+    if (!msg || busy) return;
+    // Inviting minds is the pro path — same backstop as the home composer.
+    if (minds.size && !requirePro()) return;
+    setBusy(true);
+    try {
+      const session = await createSession({ title: "New chat", sessionType: "chat" });
+      bumpSessions();
+      try {
+        sessionStorage.setItem(
+          PENDING_KEY,
+          JSON.stringify({
+            sessionId: session.id,
+            message: msg,
+            books: [...books.values()],
+            minds: [...minds.values()],
+          }),
+        );
+      } catch {
+        /* sessionStorage unavailable — ChatView shows an empty chat */
+      }
+      try {
+        track("seo_chat_started", { source: source || "entity", book_id: book.id });
+      } catch {
+        /* analytics best-effort */
+      }
+      router.push(`/chat/${session.id}`);
+    } catch (e) {
+      console.warn("Failed to start chat:", e);
+      setBusy(false);
+    }
+  };
+
+  const toggleBook = (b: SelectedBook) =>
+    setBooks((prev) => {
+      const next = new Map(prev);
+      if (next.has(b.id)) next.delete(b.id);
+      else next.set(b.id, b);
+      return next;
+    });
+  const toggleMind = (m: SelectedMind) =>
+    setMinds((prev) => {
+      const next = new Map(prev);
+      if (next.has(m.id)) next.delete(m.id);
+      else next.set(m.id, m);
+      return next;
+    });
+  const removeBook = (id: string) =>
+    setBooks((prev) => {
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  const removeMind = (id: string) =>
+    setMinds((prev) => {
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+
+  return (
+    <div className="entity-composer">
+      <Composer
+        books={books}
+        minds={minds}
+        mentionable={[...minds.values()].map((m) => ({ name: m.name, era: m.era, domain: m.domain }))}
+        disabled={busy}
+        direction="down"
+        placeholder={placeholder || `Ask ${book.title} anything — great minds will join in…`}
+        onSend={start}
+        onToggleBook={toggleBook}
+        onToggleMind={toggleMind}
+        onRemoveBook={removeBook}
+        onRemoveMind={removeMind}
+      />
+    </div>
+  );
+}

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -1000,6 +1000,12 @@ body {
   max-width: 720px; margin: 0 auto;
 }
 
+/* SEO entity-page composer (the activation bridge). Reuses the in-chat
+   <Composer> verbatim for a unified UI; fills the content column so it aligns
+   with the article body rendered below it. */
+.entity-composer { margin: 18px 0 30px; }
+.entity-composer .chat-composer-inline { max-width: 100%; }
+
 /* Messages */
 .chat-message {
   font-size: 14px; line-height: 1.7; word-break: break-word; margin-bottom: 24px;


### PR DESCRIPTION
**Activation, not just acquisition.** SEO/GEO pages were content-rich dead-ends — a reader lands from search (the GSC example: "central thesis" → a `/q` page), reads the answer, bounces. The only path into the product was a small "Chat about this book" link that hops to the home composer and **loses the page context**. This puts the real grounded chat **in the page**.

## What
- **`EntityComposer`** (new): **wraps the canonical in-chat `<Composer>` verbatim** — same styling + components (books / invite-great-minds popovers, chips, send), so the experience is unified. The page's book is **pre-selected as a chip**; on send it reuses the proven home/chat machinery (`createSession` → `sessionStorage` handoff → `/chat/{id}`). **Free** for anonymous visitors; inviting specific minds stays the pro path (gated on send, exactly like home). The invite-minds icon is right there → "great minds join in" is conveyed in the composer itself.
- **`Composer`**: two backward-compatible props — `direction` ("down" for top-of-page) + `placeholder` override.
- **`/book`**: composer at the top of the body; dropped the redundant "Chat about this book" hero button (Read/Preview + Share remain).
- **`/q`**: composer after the answer under "Continue the conversation"; dropped the redundant hero button.

## SEO-safe
The composer is **SSR'd** (Next renders client components server-side), **additive** (no content / JSON-LD / canonical changed), page stays **ISR + indexable**.

## Verify on preview
Open a `/book/{id}` or `/book/{id}/q/{slug}` preview — the composer should match the in-chat composer exactly; typing + send should start a grounded chat with the book pre-set.

## Follow-ups (P1)
Interactive "Great minds on this book" rail, `/mind` + `/on` composers, SEO-page theme consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)