### PR TITLE
fix(chat): composer band matches chat bg

### DIFF
--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -992,7 +992,9 @@ body {
 .chat-input-area {
   padding: 12px 32px 20px;
   flex-shrink: 0;
-  background: var(--bg-chat);
+  /* Match the message scroll area above (which shows the body's --bg-home);
+     the rounded composer pill keeps its own --bg-chat for floating contrast. */
+  background: var(--bg-home);
   position: relative;
   z-index: 10;
 }


### PR DESCRIPTION
## Problem

The chat composer's full-width wrapper (`.chat-input-area`) painted `background: var(--bg-chat)`, but the message scroll area and all its ancestors set **no** background — so they show the body's `var(--bg-home)`. The result was a lighter band at the bottom of the chat that didn't match the column above it.

| Region | Background | Dark | Light |
|---|---|---|---|
| `.chat-messages` + ancestors | shows `body` → `--bg-home` | `#1c1c1e` | `#f5f5f7` |
| `.chat-input-area` (the band) | `var(--bg-chat)` | `#2c2c2e` | `#ffffff` |

## Fix

Paint `.chat-input-area` with `var(--bg-home)` so the band is seamless with the message area above. The rounded composer pill (`.chat-composer-inline`) keeps its own `--bg-chat` + glass, so it still reads as a floating control — only the seam behind it is gone.

One-line CSS token swap, no behavioral change. Verify on the Vercel preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)