### PR TITLE
perf(seo): empty generateStaticParams → dynamic-param routes become ISR-cacheable (egress)

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -30,8 +30,16 @@ import {
 } from "@/lib/seo-book";
 import { fetchTopics } from "@/lib/seo-mind";
 
-// ISR — on-demand revalidation, no generateStaticParams (thousands of books).
+// ISR. The EMPTY generateStaticParams() is load-bearing: it opts this dynamic
+// route into the static/ISR path — prerender NONE at build (there are thousands
+// of books) but render each on-demand on first hit, then CACHE it. Without it,
+// Next 14 renders the route dynamically on EVERY request (Cache-Control:
+// no-store), so every crawl re-hit Supabase — the egress that dominated usage.
 export const revalidate = 86400;
+export const dynamicParams = true;
+export function generateStaticParams() {
+  return [];
+}
 
 interface PageProps {
   params: { id: string };

--- a/web/app/book/[id]/q/[slug]/page.tsx
+++ b/web/app/book/[id]/q/[slug]/page.tsx
@@ -23,7 +23,14 @@ import {
   breadcrumbJsonld,
 } from "@/lib/seo-book";
 
+// Empty generateStaticParams() opts this dynamic route into ISR caching (render
+// on-demand on first hit, then CACHE) instead of dynamic-render-every-request
+// (no-store), which re-hit Supabase on every crawl.
 export const revalidate = 86400;
+export const dynamicParams = true;
+export function generateStaticParams() {
+  return [];
+}
 
 interface PageProps {
   params: { id: string; slug: string };

--- a/web/app/mind/[id]/on/[slug]/page.tsx
+++ b/web/app/mind/[id]/on/[slug]/page.tsx
@@ -23,6 +23,11 @@ import {
 
 export const revalidate = 86400;
 export const dynamicParams = true;
+// Empty generateStaticParams() opts this dynamic route into ISR caching (render
+// on-demand, then CACHE) instead of dynamic-render-every-request (no-store).
+export function generateStaticParams() {
+  return [];
+}
 
 export async function generateMetadata({
   params,

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -30,10 +30,16 @@ import {
   type MindDetail,
 } from "@/lib/seo-mind";
 
-// Daily ISR; no generateStaticParams — minds are minted continuously and the
-// set is large, so we render on-demand and cache.
+// Daily ISR. The EMPTY generateStaticParams() is load-bearing: it opts this
+// dynamic route into the static/ISR path — prerender NONE (minds are minted
+// continuously and the set is large) but render on-demand on first hit, then
+// CACHE. Without it, Next 14 renders dynamically on every request (no-store),
+// so every crawl re-hit Supabase.
 export const revalidate = 86400;
 export const dynamicParams = true;
+export function generateStaticParams() {
+  return [];
+}
 
 function descFor(mind: MindDetail): string {
   const base =

--- a/web/app/topic/[slug]/page.tsx
+++ b/web/app/topic/[slug]/page.tsx
@@ -24,6 +24,11 @@ import {
 
 export const revalidate = 86400;
 export const dynamicParams = true;
+// Empty generateStaticParams() opts this dynamic route into ISR caching (render
+// on-demand, then CACHE) instead of dynamic-render-every-request (no-store).
+export function generateStaticParams() {
+  return [];
+}
 
 function introText(topic: string, bookCount: number, mindCount: number): string {
   const parts: string[] = [];


### PR DESCRIPTION
Follow-up to #57. The SEO dynamic-param routes were still `no-store`/MISS because in Next 14 a dynamic segment **without** `generateStaticParams` renders dynamically every request (`revalidate` alone doesn't enable ISR). Static routes (/, /library, /minds) cache fine (PRERENDER); only the `[id]`/`[slug]` routes were dynamic. Fix: empty `generateStaticParams()` opts each into ISR (prerender none, render-on-demand-then-cache). Verify post-deploy: `x-vercel-cache` flips MISS→HIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)