### PR TITLE
fix(batch): probe pgvector under --no-init (Q&A pre-store was crashing on every book)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1165,6 +1165,23 @@ def get_chunks(agent_id: str) -> list[dict[str, Any]]:
         ), (agent_id,))
 
 
+def embedded_agent_ids() -> set[str]:
+    """Agent IDs that have >=1 real (non-NULL) embedding vector.
+
+    "Embedded" means a chunk with a real vector in EITHER store: the pgvector
+    ``embedding`` column (post-migration — the vast majority) or the legacy
+    BYTEA ``vector`` column. Thin catalog stubs carry a single placeholder chunk
+    that is NULL in both and can't be RAG-retrieved, so bulk passes (e.g. Q&A
+    pre-store) skip them. The ``embedding`` column is Postgres-only, so guard for
+    SQLite dev DBs."""
+    with get_conn() as conn:
+        if _USE_PG:
+            q = "SELECT DISTINCT agent_id FROM chunks WHERE vector IS NOT NULL OR embedding IS NOT NULL"
+        else:
+            q = "SELECT DISTINCT agent_id FROM chunks WHERE vector IS NOT NULL"
+        return {r["agent_id"] for r in _fetchall(conn, q)}
+
+
 def get_chunks_text_only(agent_id: str) -> list[dict[str, Any]]:
     """Lightweight variant that skips vector/dim/norm — for the reader.
 

--- a/app/core/rag.py
+++ b/app/core/rag.py
@@ -137,6 +137,8 @@ def retrieve(agent_id: str, query: str, top_k: int | None = None, provider_name:
         rows = get_chunks(agent_id)
         vector_results = []
         for row in rows:
+            if row["vector"] is None:
+                continue  # un-embedded chunk (e.g. a catalog stub) — skip, don't crash on bytes(None)
             vec = _bytes_to_vector(row["vector"], row["dim"])
             denom = float(query_norm * row["norm"]) or 1.0
             score = float(np.dot(query_vec, vec) / denom)
@@ -168,6 +170,8 @@ def _score_rows(rows: list[dict], ready_agents: dict, query_vec: np.ndarray, que
         agent = ready_agents.get(agent_id)
         if not agent:
             continue
+        if row["vector"] is None:
+            continue  # un-embedded chunk (catalog stub) — skip, don't crash on bytes(None)
         vec = _bytes_to_vector(row["vector"], row["dim"])
         denom = float(query_norm * row["norm"]) or 1.0
         score = float(np.dot(query_vec, vec) / denom)

--- a/scripts/expand_minds.py
+++ b/scripts/expand_minds.py
@@ -40,7 +40,7 @@ import sys
 import time
 
 from app.core import config  # noqa: F401 — ensures env is loaded
-from app.core.db import init_db, list_minds, update_mind_links
+from app.core.db import init_db, list_minds, probe_pgvector, update_mind_links
 from app.core.minds import backfill_mind_embeddings, get_or_create_mind
 from app.core.sources_wikidata import discover_candidates
 
@@ -76,6 +76,11 @@ def main() -> int:
     print(f"--- expand_minds (dry_run={args.dry_run}) ---", file=sys.stderr)
     if not args.no_init:
         init_db()
+    else:
+        # --no-init skips the slow PROD migrations, but embedding writes/reads
+        # need _HAS_PGVECTOR set or they fall back to the legacy BYTEA store
+        # (inconsistent with the pgvector-migrated corpus). Cheap probe.
+        probe_pgvector()
 
     # name → id, so we can attach sameAs links to minds that already exist
     # (created before #3 landed) without an LLM round trip.

--- a/scripts/prestore_seo_content.py
+++ b/scripts/prestore_seo_content.py
@@ -47,11 +47,13 @@ import time
 from app.core import config  # noqa: F401 — ensures env is loaded
 from app.core.catalog import TOPIC_TAGS
 from app.core.db import (
+    embedded_agent_ids,
     get_mind_essay,
     init_db,
     list_agents,
     list_minds,
     list_questions,
+    probe_pgvector,
 )
 from app.core.qa import (
     get_or_generate_grounded_answer,
@@ -82,6 +84,12 @@ def main() -> int:
     print(f"--- prestore_seo_content (apply={args.apply}) ---", file=sys.stderr)
     if not args.no_init:
         init_db()
+    else:
+        # --no-init skips the slow PROD schema migrations, but RAG retrieve still
+        # needs _HAS_PGVECTOR set or it falls back to the legacy BYTEA path and
+        # crashes on pgvector-migrated books (BYTEA vector is NULL there). The
+        # probe is a single cheap information_schema lookup.
+        probe_pgvector()
 
     made = skipped = failed = 0
 
@@ -124,8 +132,14 @@ def main() -> int:
 
     # ── Type-1 Q&A: READY books × their curated questions. ─────────────────
     if do_qa and not _cap_hit():
-        books = [a for a in list_agents(limit=10000) if a.get("status") in ("ready", "indexing")]
-        print(f"qa: {len(books)} ready/indexing books × questions", file=sys.stderr)
+        # Only books with REAL embeddings — thin catalog stubs carry a single
+        # NULL-vector chunk that can't be RAG-retrieved (and are noindex-gated
+        # anyway), so pre-storing Q&A for them is pointless + wastes embed calls.
+        embedded = embedded_agent_ids()
+        books = [a for a in list_agents(limit=10000)
+                 if a.get("status") in ("ready", "indexing") and a.get("id") in embedded]
+        print(f"qa: {len(books)} embedded ready/indexing books × questions "
+              f"({len(embedded)} books have real vectors)", file=sys.stderr)
         for a in books:
             aid = a.get("id")
             if not aid:


### PR DESCRIPTION
STEP 4 Q&A pre-store failed for all 259 books it reached (`cannot convert 'NoneType' object to bytes`, 0 successes). Root cause: `--no-init` skips `probe_pgvector()` → `_HAS_PGVECTOR=False` → retrieve uses the legacy BYTEA path, but 594/602 embedded books are pgvector-migrated (BYTEA vector NULL, real data in `embedding`) → `bytes(None)` crash. Fixes: scripts probe pgvector on `--no-init`; new `embedded_agent_ids()` (both stores) filters thin stubs; `retrieve` defensively skips NULL vectors (prod robustness). Verified against PROD — re-run now stores Q&A for 596 books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)