### PR TITLE
fix(batch): gate Q&A pre-store to >=5-chunk books (match sitemap /q gate)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1165,20 +1165,24 @@ def get_chunks(agent_id: str) -> list[dict[str, Any]]:
         ), (agent_id,))
 
 
-def embedded_agent_ids() -> set[str]:
-    """Agent IDs that have >=1 real (non-NULL) embedding vector.
+def embedded_agent_ids(min_chunks: int = 1) -> set[str]:
+    """Agent IDs that have >= ``min_chunks`` real (non-NULL) embedding vectors.
 
-    "Embedded" means a chunk with a real vector in EITHER store: the pgvector
+    A chunk counts if it has a real vector in EITHER store: the pgvector
     ``embedding`` column (post-migration — the vast majority) or the legacy
     BYTEA ``vector`` column. Thin catalog stubs carry a single placeholder chunk
     that is NULL in both and can't be RAG-retrieved, so bulk passes (e.g. Q&A
-    pre-store) skip them. The ``embedding`` column is Postgres-only, so guard for
-    SQLite dev DBs."""
+    pre-store) skip them with ``min_chunks=1``. Pass ``min_chunks=5`` to mirror
+    the sitemap's ``_MIN_CHUNKS_FOR_Q_URLS`` gate (only books substantial enough
+    to get indexable /q pages). The ``embedding`` column is Postgres-only, so
+    guard for SQLite dev DBs."""
+    cond = "vector IS NOT NULL OR embedding IS NOT NULL" if _USE_PG else "vector IS NOT NULL"
     with get_conn() as conn:
-        if _USE_PG:
-            q = "SELECT DISTINCT agent_id FROM chunks WHERE vector IS NOT NULL OR embedding IS NOT NULL"
+        if min_chunks <= 1:
+            q = f"SELECT DISTINCT agent_id FROM chunks WHERE {cond}"
         else:
-            q = "SELECT DISTINCT agent_id FROM chunks WHERE vector IS NOT NULL"
+            q = (f"SELECT agent_id FROM chunks WHERE {cond} "
+                 f"GROUP BY agent_id HAVING count(*) >= {int(min_chunks)}")
         return {r["agent_id"] for r in _fetchall(conn, q)}
 
 

--- a/scripts/prestore_seo_content.py
+++ b/scripts/prestore_seo_content.py
@@ -132,14 +132,15 @@ def main() -> int:
 
     # ── Type-1 Q&A: READY books × their curated questions. ─────────────────
     if do_qa and not _cap_hit():
-        # Only books with REAL embeddings — thin catalog stubs carry a single
-        # NULL-vector chunk that can't be RAG-retrieved (and are noindex-gated
-        # anyway), so pre-storing Q&A for them is pointless + wastes embed calls.
-        embedded = embedded_agent_ids()
+        # Only books substantial enough to get an INDEXABLE /q page: the sitemap
+        # gates /q on >=5 real chunks (_MIN_CHUNKS_FOR_Q_URLS in main.py), so
+        # books below that are noindex + absent from the sitemap — pre-storing
+        # their Q&A has no SEO value. Match that gate so we generate exactly what
+        # gets indexed (thin books still lazy-gen on a direct hit if ever needed).
+        embedded = embedded_agent_ids(min_chunks=5)
         books = [a for a in list_agents(limit=10000)
                  if a.get("status") in ("ready", "indexing") and a.get("id") in embedded]
-        print(f"qa: {len(books)} embedded ready/indexing books × questions "
-              f"({len(embedded)} books have real vectors)", file=sys.stderr)
+        print(f"qa: {len(books)} books with >=5 real chunks (indexable /q) × questions", file=sys.stderr)
         for a in books:
             aid = a.get("id")
             if not aid:


### PR DESCRIPTION
Q&A pre-store processed all 602 embedded books, but only 57 (>=5 chunks) get indexable /q pages in the sitemap — the other ~545 were noindex/absent, so ~2700 generations had no SEO value. Now mirrors `_MIN_CHUNKS_FOR_Q_URLS`. ~10x less work/egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)