### PR TITLE
feat(seo): slug Stage 2b+3 — sitemap emits slug + 301 UUID→slug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -859,9 +859,10 @@ def sitemap_xml():
         chunks_by_agent = count_chunks_batch(ready_ids)
         for agent in ready_agents:
             agent_id = agent["id"]
+            aslug = agent.get("slug") or agent_id  # descriptive URL; UUID fallback
             priority = "0.7" if agent.get("type") == "ai_book" else "0.5"
             urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent_id}</loc>
+    <loc>{_SITE_URL}/book/{aslug}</loc>
     <lastmod>{today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>{priority}</priority>
@@ -878,7 +879,7 @@ def sitemap_xml():
                 if not qslug:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent_id}/q/{qslug}</loc>
+    <loc>{_SITE_URL}/book/{aslug}/q/{qslug}</loc>
     <lastmod>{today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
@@ -887,7 +888,7 @@ def sitemap_xml():
         all_minds = list_minds(limit=5000)
         for mind in all_minds:
             urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind["id"]}</loc>
+    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}</loc>
     <lastmod>{today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
@@ -904,7 +905,7 @@ def sitemap_xml():
                 if not tslug:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind["id"]}/on/{tslug}</loc>
+    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}/on/{tslug}</loc>
     <lastmod>{today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
@@ -937,7 +938,7 @@ def sitemap_xml():
                 if agent_insight_counts.get(agent["id"], 0) < insight_count_min:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent["id"]}/insights</loc>
+    <loc>{_SITE_URL}/book/{agent.get("slug") or agent["id"]}/insights</loc>
     <lastmod>{today}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -950,7 +951,7 @@ def sitemap_xml():
                 if mind_insight_counts.get(mind["id"], 0) < insight_count_min:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind["id"]}/dialogues</loc>
+    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}/dialogues</loc>
     <lastmod>{today}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -974,7 +975,7 @@ def sitemap_xml():
                 if agent_discussion_counts.get(agent["id"], 0) < 1:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent["id"]}/discussions</loc>
+    <loc>{_SITE_URL}/book/{agent.get("slug") or agent["id"]}/discussions</loc>
     <lastmod>{today}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
@@ -987,7 +988,7 @@ def sitemap_xml():
                 if mind_discussion_counts.get(mind["id"], 0) < 1:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind["id"]}/discussions</loc>
+    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}/discussions</loc>
     <lastmod>{today}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * UUID→slug 301 redirects (final stage of the descriptive-URL migration).
+ *
+ * Old links and already-indexed pages use `/book/{uuid}` and `/mind/{uuid}`.
+ * We 301 them to the canonical `/book/{slug}` / `/mind/{slug}` so search engines
+ * consolidate ranking signals onto the descriptive URL. Pages requested with a
+ * slug (the new normal) pass straight through with no work — only UUID segments
+ * trigger a resolution fetch. Resolution failures fall through (the page still
+ * renders via the UUID), so this can never take the catalog down.
+ *
+ * og.png is left alone — it's rewritten to the API at the edge (vercel.json) and
+ * the API resolves the slug itself, so a redirect here would just add a hop.
+ */
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "https://api.feynman.wiki";
+
+export const config = {
+  matcher: ["/book/:path*", "/mind/:path*"],
+};
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (pathname.endsWith("/og.png")) return NextResponse.next();
+
+  const m = pathname.match(/^\/(book|mind)\/([^/]+)(\/.*)?$/);
+  if (!m) return NextResponse.next();
+  const kind = m[1];
+  const seg = m[2];
+  const rest = m[3] || "";
+  if (!UUID.test(seg)) return NextResponse.next(); // already a slug → no work
+
+  try {
+    const api = kind === "book" ? "agents" : "minds";
+    const res = await fetch(`${API_BASE}/api/${api}/${seg}`, {
+      headers: { accept: "application/json" },
+      next: { revalidate: 86400 }, // cache the uuid→slug resolution for a day
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { slug?: string };
+      if (data?.slug && data.slug !== seg) {
+        const url = req.nextUrl.clone();
+        url.pathname = `/${kind}/${data.slug}${rest}`;
+        return NextResponse.redirect(url, 301);
+      }
+    }
+  } catch {
+    /* resolution failed — fall through; the page still renders via the UUID */
+  }
+  return NextResponse.next();
+}


### PR DESCRIPTION
Sitemap <loc>s emit descriptive slugs; `web/middleware.ts` 301s `/book/{uuid}`→`/book/{slug}` (and minds). Slug requests pass through (no fetch); UUID requests resolve+301; failures fall through safely. UUID pages 301 → slug pages self-canonical, so no per-page canonical edits needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)