### PR TITLE
feat(seo): /book + /q chat button (not in-page composer) + detail-page curation + anon funnel fix

### DIFF
--- a/app/core/overview.py
+++ b/app/core/overview.py
@@ -138,21 +138,28 @@ def generate_book_overview(
     if passages:
         context = build_context(passages)
         system = (
-            "You write concise, accurate book overviews for a reading app. "
-            "Use ONLY the provided passages — do not invent claims the "
-            "passages don't support. Neutral, informative tone. Begin "
-            "immediately, no preamble."
+            "You write concise, accurate, SPECIFIC book overviews for a reading "
+            "app. Use ONLY the provided passages — do not invent claims they "
+            "don't support. Lead with the book's actual central argument in "
+            "concrete terms and name its real ideas, models, and terms, so a "
+            "reader learns something only THIS book offers. Avoid generic "
+            "filler — never write phrases like 'explores the fundamental "
+            "principle', 'delves into', 'provides a framework for', 'in today's "
+            "world', or 'Readers engage with this book to…'. Neutral, "
+            "informative tone. Begin immediately, no preamble."
         )
         user = (
             f'Book: "{title}"{by}\n'
             f"Passages from the book:\n{context}\n\n"
             "Write the output in exactly this format:\n"
-            "OVERVIEW:\n<2 short paragraphs (120-200 words) describing what "
-            "this book is about, its central argument, and why a reader would "
-            "engage with it — grounded in the passages>\n\n"
-            "CONCEPTS:\n- <Key idea>: <one-sentence explanation>\n"
-            "- <Key idea>: <one-sentence explanation>\n"
-            "(4-6 concepts, each a real idea from the passages.)"
+            "OVERVIEW:\n<2 short paragraphs (120-200 words). Open with the "
+            "book's central argument stated concretely, then its main themes "
+            "and what a reader takes away — all grounded in the passages>\n\n"
+            "CONCEPTS:\n- <Specific idea/model/term>: <one-sentence "
+            "explanation>\n"
+            "- <Specific idea/model/term>: <one-sentence explanation>\n"
+            "(4-6 concepts, each a real, specifically-named idea from the "
+            "passages — not a generic theme.)"
         )
         grounded = True
     else:
@@ -160,22 +167,26 @@ def generate_book_overview(
         # published book, with a hard guard against fabrication.
         cat = f" It is generally shelved under {category}." if category else ""
         system = (
-            "You write concise, accurate overviews of real published books. "
-            "If you are confident about the specific book, summarize what it "
-            "actually covers. If you are NOT confident about this exact title, "
-            "do NOT invent specifics — instead describe the subject area and "
-            "what a reader could explore, and keep claims general. Neutral "
-            "tone. Begin immediately, no preamble."
+            "You write concise, accurate, SPECIFIC overviews of real published "
+            "books. If you are confident about the exact book, state its actual "
+            "central thesis and name its real key ideas — be concrete, not "
+            "generic. If you are NOT confident about this exact title, do NOT "
+            "invent specifics — instead describe the subject area in general "
+            "terms. Avoid filler — never write phrases like 'explores the "
+            "fundamental principle', 'delves into', 'provides a framework for', "
+            "'in today's world', or 'Readers engage with this book to…'. "
+            "Neutral tone. Begin immediately, no preamble."
         )
         user = (
             f'Book: "{title}"{by}.{cat}\n\n'
             "Write the output in exactly this format:\n"
-            "OVERVIEW:\n<2 short paragraphs (120-200 words) on what this book "
-            "is about and why a reader would engage with it>\n\n"
-            "CONCEPTS:\n- <Key theme>: <one-sentence explanation>\n"
-            "- <Key theme>: <one-sentence explanation>\n"
-            "(4-6 concepts. If unsure about the specific book, make these "
-            "about the subject area, not invented plot/claims.)"
+            "OVERVIEW:\n<2 short paragraphs (120-200 words). Open with the "
+            "book's central thesis stated concretely (if you know it), then its "
+            "main ideas and what a reader takes away>\n\n"
+            "CONCEPTS:\n- <Specific idea/term>: <one-sentence explanation>\n"
+            "- <Specific idea/term>: <one-sentence explanation>\n"
+            "(4-6 concepts, specifically named. If unsure about the exact book, "
+            "make these about the subject area, not invented plot/claims.)"
         )
         grounded = False
 

--- a/web/app/book/[id]/discussions/page.tsx
+++ b/web/app/book/[id]/discussions/page.tsx
@@ -40,7 +40,7 @@ export default async function BookDiscussionsPage({
   const canonical = abs(`/book/${params.id}/discussions`);
   const chatHref = `/?book=${encodeURIComponent(params.id)}`;
   const actions: EntityAction[] = [
-    { label: `Chat about this book`, href: chatHref, variant: "primary" },
+    { label: `Chat with this book`, href: chatHref, variant: "primary" },
     { label: `About ${book.title}`, href: `/book/${params.id}`, variant: "secondary" },
   ];
 

--- a/web/app/book/[id]/insights/page.tsx
+++ b/web/app/book/[id]/insights/page.tsx
@@ -90,7 +90,7 @@ export default async function BookInsightsPage({ params }: PageProps) {
   ]);
 
   const actions: EntityAction[] = [
-    { label: `Chat about this book`, href: chatHref, variant: "primary" },
+    { label: `Chat with this book`, href: chatHref, variant: "primary" },
   ];
 
   const hero = (

--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -11,7 +11,6 @@ import SamplePassages from "@/components/seo/book/SamplePassages";
 import TableOfContents from "@/components/seo/book/TableOfContents";
 import PopularQuestions from "@/components/seo/book/PopularQuestions";
 import LiveContentLink from "@/components/seo/book/LiveContentLink";
-import EntityComposer from "@/components/chat/EntityComposer";
 
 import {
   SITE_URL,
@@ -154,16 +153,21 @@ export default async function BookLandingPage({ params }: PageProps) {
     { name: "Books", url: `${SITE_URL}/library` },
     { name: data.title, url: canonical },
   ]);
-  // ── Top actions ───────────────────────────────────────────────────────
-  // Chat now lives in the in-page <EntityComposer> right below the hero (the
-  // real grounded chat, book pre-set) — so the hero keeps only Read/Preview (a
-  // redundant "Chat about this book" button would just duplicate the composer).
-  // Catalog stubs simply have no Read/Preview; the composer is their entry.
+  // ── Top actions (per product direction) ───────────────────────────────
+  // Chat ALWAYS available → routes to the conversational surface (home composer
+  // preselects the book), NOT the reader — so catalog stubs with no readable
+  // text still start a chat (fixes the dead-end). Read/Preview appear only when
+  // the book actually has content, and go to the reader.
+  const chatHref = `/?book=${encodeURIComponent(id)}`;
   const actions: EntityAction[] = [];
   if (caps.read) {
     actions.push({ label: `Read`, href: `/read/${encodeURIComponent(id)}`, variant: "primary" });
+    actions.push({ label: `Chat with this book`, href: chatHref, variant: "secondary" });
   } else if (caps.preview) {
     actions.push({ label: `Preview`, href: `/read/${encodeURIComponent(id)}`, variant: "primary" });
+    actions.push({ label: `Chat with this book`, href: chatHref, variant: "secondary" });
+  } else {
+    actions.push({ label: `Chat with this book`, href: chatHref, variant: "primary" });
   }
 
   const metaBits: string[] = [];
@@ -252,14 +256,6 @@ export default async function BookLandingPage({ params }: PageProps) {
       <JsonLd data={bookLd} />
       <JsonLd data={breadcrumbLd} />
 
-      {/* Activation bridge: start the real grounded chat right here (book
-          pre-set, free, great minds auto-join) instead of bouncing off a
-          static page. */}
-      <EntityComposer
-        book={{ id, title: data.title, author: data.author }}
-        source="book"
-      />
-
       <section className="seo-section">
         {overview ? (
           overview.overview
@@ -281,15 +277,15 @@ export default async function BookLandingPage({ params }: PageProps) {
               <line x1="12" y1="8" x2="12" y2="12" />
               <line x1="12" y1="16" x2="12.01" y2="16" />
             </svg>
-            Full text isn&apos;t indexed yet — chat still works, drawing on general
-            knowledge and the book&apos;s metadata.
+            Full text isn&apos;t indexed yet — this overview draws on general
+            knowledge of the book and its metadata, and chat works the same way.
           </p>
         ) : null}
       </section>
 
       {overview && overview.concepts.length ? (
         <section className="seo-section">
-          <h2>Key concepts in {data.title}</h2>
+          <h2>Key concepts</h2>
           <ul className="key-concepts">
             {overview.concepts.map((c, i) => (
               <li key={i}>

--- a/web/app/book/[id]/q/[slug]/page.tsx
+++ b/web/app/book/[id]/q/[slug]/page.tsx
@@ -9,7 +9,6 @@ import JsonLd from "@/components/seo/JsonLd";
 import QaAnswer from "@/components/seo/book/QaAnswer";
 import QaPassages from "@/components/seo/book/QaPassages";
 import SiblingQuestions from "@/components/seo/book/SiblingQuestions";
-import EntityComposer from "@/components/chat/EntityComposer";
 
 import {
   SITE_URL,
@@ -126,6 +125,10 @@ export default async function BookQuestionPage({ params }: PageProps) {
 
   const bookUrl = `${SITE_URL}/book/${encodeURIComponent(id)}`;
   const canonical = `${bookUrl}/q/${slug}`;
+  // Chat ALWAYS routes to the conversational composer (preselects the book),
+  // never the reader — catalog stubs have no readable text, so /read would be
+  // a dead end here.
+  const chatHref = `/?book=${encodeURIComponent(id)}`;
   const createdAt = data.agent.created_at || "";
 
   const qaLd = qaPageJsonld({
@@ -144,8 +147,9 @@ export default async function BookQuestionPage({ params }: PageProps) {
     { name: "Q&A", url: canonical },
   ]);
 
-  // Chat lives in the in-page composer below the answer (no redundant button).
-  const actions: EntityAction[] = [];
+  const actions: EntityAction[] = [
+    { label: `Chat with this book`, href: chatHref, variant: "primary" },
+  ];
 
   const hero = (
     <>
@@ -181,17 +185,6 @@ export default async function BookQuestionPage({ params }: PageProps) {
       <QaPassages
         passages={passages.map((p) => ({ text: p.text, chunk_index: p.index }))}
       />
-
-      {/* Activation: read the answer, then keep going — start the real grounded
-          chat (book pre-set, great minds can join) instead of bouncing. */}
-      <section className="seo-section">
-        <h2>Continue the conversation</h2>
-        <EntityComposer
-          book={{ id, title: data.title, author: data.author }}
-          source="q"
-          placeholder={`Ask a follow-up about ${data.title} — great minds will join in…`}
-        />
-      </section>
 
       <SiblingQuestions
         siblings={questions}

--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -21,7 +21,7 @@ import { createSession, bumpSessions } from "@/lib/chat";
 import { startWriteBook } from "@/lib/writeBook";
 import { useAuth } from "@/lib/auth";
 import { useProGate } from "@/components/pro/ProOverlay";
-import { restorePendingBookIntent } from "@/lib/pendingIntent";
+import { restorePendingBookIntent, savePendingBookIntent } from "@/lib/pendingIntent";
 import { track } from "@/lib/analytics";
 import {
   SelectedChips,
@@ -255,6 +255,21 @@ export default function HomeComposer() {
   const submit = async () => {
     const msg = value.trim();
     if (!msg || busy) return;
+    // Anonymous visitor on the hosted build: stash the book + question they came
+    // for, then bounce through login. After sign-up the composer restores the
+    // intent and resumes the chat (mirrors Reader.askQuestion + the
+    // pending-intent system). The cross-surface "Chat" CTAs route anonymous
+    // users into this composer with a book preselected, so this is the single
+    // funnel gate that keeps the book from being lost through login.
+    if (authEnabled && !user) {
+      const book = [...books.values()][0];
+      if (book) {
+        savePendingBookIntent(book.agentId || book.id, { question: msg, via: "home_composer" });
+      }
+      track("pending_intent_saved", { via: "home_composer" });
+      router.push("/login");
+      return;
+    }
     // Inviting minds requires pro on the hosted build (legacy app.js 3149).
     // The minds popover already gates selection; this is the backstop on send.
     if (minds.size && !requirePro()) return;

--- a/web/components/landing/HomeOrLanding.tsx
+++ b/web/components/landing/HomeOrLanding.tsx
@@ -31,12 +31,25 @@ export default function HomeOrLanding() {
 
   // Tracks the localStorage flag. `null` = not yet read (SSR / first paint).
   const [landed, setLanded] = useState<boolean | null>(null);
+  // A cross-surface chat link — /?book, /?q or /?mind — means the visitor came
+  // to chat about something specific (the SEO, Reader and library "Chat" CTAs
+  // all route through these params). Such a visitor must drop into the composer
+  // with the book preselected, NEVER the marketing landing page — otherwise an
+  // anonymous arrival from Google/an SEO page silently loses the book they came
+  // for. `null` = not yet read (SSR / first paint).
+  const [hasChatIntent, setHasChatIntent] = useState<boolean | null>(null);
 
   useEffect(() => {
     try {
       setLanded(window.localStorage.getItem(LANDED_KEY) === "1");
     } catch {
       setLanded(true); // storage blocked -> behave as "already landed" (show home)
+    }
+    try {
+      const sp = new URLSearchParams(window.location.search);
+      setHasChatIntent(sp.has("book") || sp.has("q") || sp.has("mind"));
+    } catch {
+      setHasChatIntent(false);
     }
   }, []);
 
@@ -67,14 +80,17 @@ export default function HomeOrLanding() {
   // hosted build briefly sees the app home, then it swaps to the landing
   // (a backwards flash). Rendering null until `ready` avoids that while still
   // never flashing the landing to returning/auth'd users.
-  if (!ready || landed === null) {
+  if (!ready || landed === null || hasChatIntent === null) {
     return null;
   }
 
   // Legacy getRoute() (app.js 679-684):
   //   authEnabled  -> landing whenever there's no signed-in user
   //   !authEnabled -> landing once, until the visitor dismisses it (feynman-landed)
-  const showLanding = authEnabled ? !user : !landed;
+  // A cross-surface chat link overrides both: honor the book/question intent and
+  // open the composer regardless of auth (HomeComposer gates anonymous SEND to
+  // login from there, so the intent survives sign-up instead of being lost here).
+  const showLanding = !hasChatIntent && (authEnabled ? !user : !landed);
   if (showLanding) {
     // CTA copy mirrors the legacy ternary on window.FEYNMAN_PRO (authEnabled).
     const ctaLabel = authEnabled ? "Get Started Free" : "Start Exploring";

--- a/web/components/library/BookCard.tsx
+++ b/web/components/library/BookCard.tsx
@@ -95,7 +95,7 @@ export default function BookCard({
         className="card-cover-wrap"
         role="link"
         tabIndex={0}
-        aria-label={overlay ? `${overlay} ${book.title}` : `Chat about ${book.title}`}
+        aria-label={overlay ? `${overlay} ${book.title}` : `Chat with ${book.title}`}
         onClick={() => router.push(coverHref)}
         onKeyDown={(e) => {
           if (e.key === "Enter") router.push(coverHref);

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -283,7 +283,7 @@ body { background-color: var(--bg-home); }
   font-size: 34px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.15;
   margin: 0 0 0.25em; color: var(--text);
 }
-.seo-hero .seo-author { color: var(--text-secondary); font-size: 18px; margin: 0 0 2px; }
+.seo-hero .seo-author { color: var(--text-secondary); font-size: 16px; margin: 0 0 2px; }
 .seo-hero .seo-meta { color: var(--text-muted); font-size: 14px; margin: 0; }
 .seo-hero .seo-backlink { display: inline-block; color: var(--text-muted); font-size: 14px; margin-bottom: 12px; }
 
@@ -379,7 +379,7 @@ body { background-color: var(--bg-home); }
 /* Two-column: main content + right info rail (desktop); stacks on mobile. */
 .seo-grid { display: block; }
 .seo-grid.has-rail { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 40px; align-items: start; }
-.seo-content { min-width: 0; color: var(--text); font-size: 17px; line-height: 1.7; }
+.seo-content { min-width: 0; color: var(--text); font-size: 16px; line-height: 1.7; }
 /* h1 inside content (single-column SeoColumn pages put the title in-content,
    whereas EntityLayout pages put it in the hero). */
 .seo-content > h1 {
@@ -387,7 +387,7 @@ body { background-color: var(--bg-home); }
   font-size: 30px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.15;
   margin: 0.2em 0 0.4em; color: var(--text);
 }
-.seo-content .seo-author { color: var(--text-secondary); font-size: 18px; margin: 0 0 2px; }
+.seo-content .seo-author { color: var(--text-secondary); font-size: 16px; margin: 0 0 2px; }
 .seo-content .seo-meta { color: var(--text-muted); font-size: 14px; }
 .seo-content .seo-backlink { display: inline-block; color: var(--text-muted); font-size: 14px; margin-bottom: 10px; }
 .seo-content h2 {
@@ -415,7 +415,9 @@ body { background-color: var(--bg-home); }
   background: var(--bg-chat); border: 1px solid var(--border); border-radius: 12px;
 }
 .seo-content .empty-state-headline { font-weight: 600; margin: 0 0 8px; color: var(--text); }
-.seo-content .book-about { font-size: 18px; line-height: 1.6; color: var(--text-secondary); }
+/* Lead/overview paragraph — same 16px as the body so it never out-sizes the
+   document; set apart only by the muted secondary color. */
+.seo-content .book-about { color: var(--text-secondary); }
 
 /* Right info rail — meta card + related links. */
 .seo-rail { display: flex; flex-direction: column; gap: 20px; position: sticky; top: 24px; }


### PR DESCRIPTION
## What

- **Revert #54's in-page composer** on `/book` and `/book/q` back to a **"Chat with this book" button** (→ `/?book=`), per product direction — the input box wasn't wanted on content pages. `EntityComposer.tsx` is left in place but unused.
- **CTA rename**: "Chat about this book" → "Chat with this book" across the book detail / q / insights / discussions pages + the library `BookCard` aria-label.
- **Anonymous funnel fix**: `/?book=`, `/?q=`, `/?mind=` now always open the real composer (`HomeOrLanding` honors the cross-surface intent) instead of dropping a signed-out visitor on the marketing landing page, which silently lost the book. The composer gates anonymous **send** to `/login`, preserving the book via `pendingIntent`.
- **SEO type scale**: harmonize entity-page fonts — body / `book-about` / author 17–18px → 16px (the over-large lead paragraph on the detail page).
- **Detail-page curation**: `Key concepts in {long title}` heading → `Key concepts` (the long book title made it an unreadable run-on); clearer stub disclosure; and rewrite the `/api/agents/{id}/overview` generation prompt (`app/core/overview.py`) to demand specific, concrete prose and ban boilerplate ("explores the fundamental principle", "Readers engage with this book to…").

## Notes for review

- `web/` has no `node_modules` locally — relying on the **feynman-web Vercel build** to typecheck/build.
- The overview prompt change only affects **newly-generated** overviews; pre-stored (`meta.overview`) and cached ones keep old text until re-generated.
- Spans `web/` + one backend file (`app/core/overview.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
