### PR TITLE
feat(seo): Feynman-native mind page — lead with chat + imagined perspectives

### DIFF
--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -135,11 +135,41 @@ export default async function MindPage({
     { label: `Chat with ${mind.name}`, href: chatHref, variant: "primary" },
   ];
 
+  // First-person hook — the mind's own signature line (a real quote, no
+  // generation). Turns the page from "an article about X" into "X's voice".
+  const signatureQuote = (mind.typical_phrases || []).find(
+    (p) => p && p.trim().length > 12,
+  );
+  // Starter prompts deep-link into the chat funnel (/?mind=&q=), preselecting the
+  // mind AND prefilling the question — interaction entries, not a dead-end button.
+  const starters = [
+    ...matchingTopics.slice(0, 3).map((t) => ({
+      label: t,
+      q: `How would you approach ${t}?`,
+    })),
+    { label: "Where might you be wrong?", q: `Where might your own ideas be wrong or incomplete?` },
+  ];
+
   const hero = (
     <>
       <p className="seo-meta">Great mind</p>
       <h1>{mind.name}</h1>
       {eraDomain ? <p className="seo-meta">{eraDomain}</p> : null}
+      {signatureQuote ? (
+        <blockquote className="mind-signature">{`“${signatureQuote}”`}</blockquote>
+      ) : null}
+      <div className="mind-starters">
+        <span className="mind-starters-label">Think with {mind.name}:</span>
+        {starters.map((s) => (
+          <Link
+            key={s.q}
+            href={`/?mind=${encodeURIComponent(params.id)}&q=${encodeURIComponent(s.q)}`}
+            className="mind-starter-chip"
+          >
+            {s.label}
+          </Link>
+        ))}
+      </div>
       <EntityActions actions={actions} shareUrl={canonical} shareTitle={mind.name} />
     </>
   );
@@ -166,35 +196,61 @@ export default async function MindPage({
       <JsonLd data={personLd} />
       <JsonLd data={breadcrumbLd} />
 
-      <MindBio bio={mind.bio_summary} />
-      <MindThinkingStyle style={mind.thinking_style} />
-      <MindPhrases phrases={mind.typical_phrases} />
-      {/* Full persona stays private; the API exposes a bounded excerpt. */}
-      <MindPersonaExcerpt persona={mind.persona_excerpt || mind.persona} />
-      <MindWorks works={mind.works} agents={agents} />
-
+      {/* ① The distinctive supply, up front: imagined, persona-grounded
+          perspectives (Type 2) Wikipedia structurally can't have — as clickable
+          cards, not a buried list. */}
       {matchingTopics.length ? (
         <section className="seo-section">
-          <h2>How {mind.name} approaches key topics</h2>
+          <h2>Think with {mind.name}</h2>
           <p className="seo-meta">
-            Imagined, persona-grounded perspectives — read how {mind.name} would
-            reason about each field, then take the question further in conversation.
+            Imagined, persona-grounded perspectives — how {mind.name} would reason
+            about each field. Read one, then take the question further in conversation.
           </p>
-          <ul className="mind-on-topics">
+          <div className="mind-topic-cards">
             {matchingTopics.slice(0, 8).map((t) => (
-              <li key={t}>
-                <Link href={`/mind/${params.id}/on/${topicSlug(t)}`}>
-                  How {mind.name} approaches {t}
-                </Link>
-                {" · "}
-                <Link href={`/topic/${topicSlug(t)}`} className="seo-inline-link">
-                  {t} hub
-                </Link>
+              <Link
+                key={t}
+                href={`/mind/${params.id}/on/${topicSlug(t)}`}
+                className="mind-topic-card"
+              >
+                <span className="mind-topic-card-eyebrow">How {mind.name} approaches</span>
+                <span className="mind-topic-card-title">{t}</span>
+                <span className="mind-topic-card-cta">Read the perspective →</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {/* ② A LIVING mind: what people actually discuss + recent dialogues (Type 4). */}
+      {themes.length ? (
+        <section className="seo-section">
+          <h2>What people explore with {mind.name}</h2>
+          <p className="seo-meta">
+            Topics readers have actually been discussing with {mind.name} on Feynman.
+            Updates as new conversations happen.
+          </p>
+          <ul className="theme-list">
+            {themes.map((t) => (
+              <li key={t.topic} className="theme-chip">
+                {t.topic}
+                {t.count > 1 ? <span className="theme-count"> ×{t.count}</span> : null}
               </li>
             ))}
           </ul>
         </section>
       ) : null}
+      <DialoguesLink mindId={params.id} name={mind.name} />
+
+      {/* ③ In their voice — signature phrases + core approach (first-person feel). */}
+      <MindPhrases phrases={mind.typical_phrases} />
+      {/* Full persona stays private; the API exposes a bounded excerpt. */}
+      <MindPersonaExcerpt persona={mind.persona_excerpt || mind.persona} />
+
+      {/* ④ Encyclopedic context — demoted below the distinctive content. */}
+      <MindBio bio={mind.bio_summary} />
+      <MindThinkingStyle style={mind.thinking_style} />
+      <MindWorks works={mind.works} agents={agents} />
 
       {libraryExtra.length ? (
         <section className="seo-section">
@@ -208,26 +264,6 @@ export default async function MindPage({
           </ul>
         </section>
       ) : null}
-
-      {themes.length ? (
-        <section className="seo-section">
-          <h2>Recent themes in conversations</h2>
-          <p className="seo-meta">
-            Topics readers have actually been discussing with {mind.name} on
-            Feynman, aggregated across sessions. Updates as new conversations happen.
-          </p>
-          <ul className="theme-list">
-            {themes.map((t) => (
-              <li key={t.topic} className="theme-chip">
-                {t.topic}
-                {t.count > 1 ? <span className="theme-count"> ×{t.count}</span> : null}
-              </li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
-
-      <DialoguesLink mindId={params.id} name={mind.name} />
     </EntityLayout>
   );
 }

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -461,6 +461,40 @@ body { background-color: var(--bg-home); }
 .seo-content .seo-inline-link { color: var(--text-secondary); text-decoration: none; font-size: 0.92em; }
 .seo-content .seo-inline-link:hover { text-decoration: underline; }
 
+/* ── Feynman-native mind hero: first-person signature quote + starter chips ── */
+.mind-signature {
+  margin: 16px 0 0; padding: 2px 0 2px 18px;
+  border-left: 3px solid var(--accent);
+  font-size: 19px; line-height: 1.5; font-style: italic;
+  color: var(--text); max-width: 640px;
+}
+.mind-starters { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 18px; }
+.mind-starters-label { font-size: 13px; color: var(--text-muted); margin-right: 2px; }
+.mind-starter-chip {
+  display: inline-flex; align-items: center;
+  padding: 7px 14px; border-radius: var(--r-pill);
+  font-size: 13px; font-weight: 500; color: var(--text);
+  background: var(--bg-chat); border: 1px solid var(--border-strong);
+  text-decoration: none; transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.mind-starter-chip:hover { border-color: var(--accent); color: var(--accent); background: rgba(128,128,128,0.06); }
+
+/* ── "Think with X" — Type-2 imagined-perspective cards (the distinctive supply) ── */
+.mind-topic-cards {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px; margin-top: 14px;
+}
+.mind-topic-card {
+  display: flex; flex-direction: column; gap: 5px;
+  padding: 16px 18px; border-radius: var(--r-control);
+  background: var(--glass-regular); border: 1px solid var(--glass-edge);
+  text-decoration: none; transition: border-color 0.15s, transform 0.15s;
+}
+.mind-topic-card:hover { border-color: var(--accent); transform: translateY(-1px); }
+.mind-topic-card-eyebrow { font-size: 12px; color: var(--text-muted); }
+.mind-topic-card-title { font-size: 16px; font-weight: 600; color: var(--text); line-height: 1.3; }
+.mind-topic-card-cta { font-size: 13px; color: var(--accent); margin-top: 2px; }
+
 /* Generated "Key concepts" list on the book hub (Bucket B). */
 .seo-content .key-concepts { list-style: none; padding: 0; margin: 0.6em 0; }
 .seo-content .key-concepts li { margin: 0.5em 0; line-height: 1.55; color: var(--text-secondary); }


### PR DESCRIPTION
Reframes /mind from a wiki entry to 'a mind you can think with': first-person signature-quote hero + starter-question chips (deep-link into chat), Type-2 perspective cards + Type-4 dialogues moved up, encyclopedic bio demoted. New Liquid-Glass styles. Follow-ups: generated first-person About + same on /book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)