### PR TITLE
feat(seo): first-person voice About on mind pages

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1794,6 +1794,9 @@ def _row_to_mind(row: dict[str, Any]) -> dict[str, Any]:
         "era": row["era"] or "",
         "domain": row["domain"] or "",
         "bio_summary": row["bio_summary"] or "",
+        # First-person "voice" self-intro (generated; meta_json.voice). Drives the
+        # Feynman-native first-person About. `.get` — absent on list SELECTs / older rows.
+        "voice": (json.loads(row["meta_json"]) if row.get("meta_json") else {}).get("voice") or "",
         "persona": row["persona"],
         "thinking_style": row["thinking_style"] or "",
         "typical_phrases": json.loads(row["typical_phrases"] or "[]"),

--- a/scripts/generate_mind_voice.py
+++ b/scripts/generate_mind_voice.py
@@ -1,0 +1,98 @@
+"""Generate a first-person "voice" self-introduction for each mind, stored in
+minds.meta_json.voice — the Feynman-native first-person About on the mind page.
+
+WHY first-person: a third-person bio ("X was a philosopher who…") reads like
+Wikipedia. A first-person voice ("I read the mind as a historian reads an era…")
+makes it unmistakably a persona you can think WITH. Clearly labelled as an
+imagined synthesis on the page.
+
+Idempotent: skips minds that already have meta.voice. Re-run to fill new minds.
+
+Usage:
+  python -m scripts.generate_mind_voice --dry-run
+  python -m scripts.generate_mind_voice --apply --no-init --sleep 0.3
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+from app.core import config  # noqa: F401 — ensures env is loaded
+from app.core.db import get_conn, _q, _execute, _fetchall, init_db, probe_pgvector
+from app.core.providers import bulk_chat
+
+SYSTEM = (
+    "You ARE the named historical thinker, speaking in the FIRST person to a "
+    "curious person who is about to think WITH you. Voice: distinctive, confident, "
+    "grounded in your real work and era. Never break character."
+)
+
+
+def build_prompt(name: str, domain: str, bio: str, style: str) -> str:
+    return (
+        f"Introduce yourself as {name} ({domain or 'a great thinker'}) in the FIRST "
+        "person — 2 to 3 sentences, 40-65 words. Say how you see your field and the "
+        "one thing you most want a newcomer to grasp. Use 'I'. Make it an invitation "
+        "to think together — NOT a resume, NO birth/death dates, never 'I was a …'. "
+        f"Ground it in:\n{(bio or '')[:380]}\n{(style or '')[:280]}"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--no-init", action="store_true")
+    ap.add_argument("--sleep", type=float, default=0.3)
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args()
+
+    if args.no_init:
+        probe_pgvector()
+    else:
+        init_db()
+
+    with get_conn() as conn:
+        rows = _fetchall(conn, "SELECT id, name, domain, bio_summary, thinking_style, meta_json FROM minds")
+    todo = [r for r in rows if not json.loads(r.get("meta_json") or "{}").get("voice")]
+    print(f"{len(todo)} minds need a voice (of {len(rows)})", file=sys.stderr)
+
+    done = failed = 0
+    for r in todo:
+        if args.limit is not None and done >= args.limit:
+            break
+        try:
+            res, _ = bulk_chat(
+                system=SYSTEM,
+                user=build_prompt(r["name"], r.get("domain"), r.get("bio_summary"), r.get("thinking_style")),
+            )
+            voice = (res.content or "").strip().strip('"').strip()
+            if len(voice) < 30:
+                failed += 1
+                print(f"  FAIL {r['name']!r}: too short", file=sys.stderr)
+                continue
+            if not args.apply:
+                done += 1
+                if done <= 6:
+                    print(f"  [dry] {r['name']}: {voice[:90]}", file=sys.stderr)
+                continue
+            meta = json.loads(r.get("meta_json") or "{}")
+            meta["voice"] = voice
+            with get_conn() as conn:
+                _execute(conn, _q("UPDATE minds SET meta_json = ? WHERE id = ?"),
+                         (json.dumps(meta), r["id"]))
+            done += 1
+            print(f"  OK   {r['name']}: {voice[:70]}", file=sys.stderr)
+        except Exception as exc:
+            failed += 1
+            print(f"  FAIL {r['name']!r}: {exc}", file=sys.stderr)
+        time.sleep(args.sleep)
+
+    print(f"--- done: voiced={done} failed={failed} ---", file=sys.stderr)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -196,6 +196,15 @@ export default async function MindPage({
       <JsonLd data={personLd} />
       <JsonLd data={breadcrumbLd} />
 
+      {/* First-person About — the mind in their own (imagined) voice, up top.
+          Turns "an article about X" into "X, talking to you". */}
+      {mind.voice ? (
+        <section className="seo-section mind-voice-section">
+          <p className="mind-voice-label">In {mind.name}&apos;s own words · imagined</p>
+          <p className="mind-voice-text">{mind.voice}</p>
+        </section>
+      ) : null}
+
       {/* ① The distinctive supply, up front: imagined, persona-grounded
           perspectives (Type 2) Wikipedia structurally can't have — as clickable
           cards, not a buried list. */}

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -29,6 +29,8 @@ export interface MindDetail {
   era?: string;
   domain?: string;
   bio_summary?: string;
+  /** Generated first-person self-intro (imagined). Drives the first-person About. */
+  voice?: string;
   thinking_style?: string;
   typical_phrases?: string[];
   /** Full persona is stripped by /api/minds and /api/minds/{id} (system-prompt

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -495,6 +495,10 @@ body { background-color: var(--bg-home); }
 .mind-topic-card-title { font-size: 16px; font-weight: 600; color: var(--text); line-height: 1.3; }
 .mind-topic-card-cta { font-size: 13px; color: var(--accent); margin-top: 2px; }
 
+/* ── First-person "voice" About ── */
+.mind-voice-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); margin: 0 0 8px; }
+.mind-voice-text { font-size: 18px; line-height: 1.62; color: var(--text); max-width: 660px; margin: 0; }
+
 /* Generated "Key concepts" list on the book hub (Bucket B). */
 .seo-content .key-concepts { list-style: none; padding: 0; margin: 0.6em 0; }
 .seo-content .key-concepts li { margin: 0.5em 0; line-height: 1.55; color: var(--text-secondary); }


### PR DESCRIPTION
The mind in their own (imagined) first-person voice as the About — 'I…' instead of 'X was a…'. Generated per-mind (meta.voice), exposed via the API, rendered at the top. Third-person bio stays demoted for the KG signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)