### PR TITLE
feat(seo): on-demand cache revalidation + /book chip filter

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -174,6 +174,15 @@ export default async function BookLandingPage({ params }: PageProps) {
   if (data.totalWords) metaBits.push(`${data.totalWords.toLocaleString()} words`);
   if (chapterCount) metaBits.push(`${chapterCount} chapter${chapterCount === 1 ? "" : "s"}`);
 
+  // Skip meta-referential questions (thin stubs produce "Given the title…", "The
+  // book promises…", "The description calls it…") so the chips only surface real,
+  // content-grounded asks. Substantial (de-templated) books are unaffected.
+  const chipQs = questions
+    .filter(
+      (q) =>
+        !/^\s*(given|considering|imagine|if you were|drawing on|reflecting on|the (description|book|text|author)\b)/i.test(q),
+    )
+    .slice(0, 3);
   const isAI = data.agent.type === "ai_book";
   const hero = (
     <div className="seo-hero-with-cover">
@@ -190,10 +199,10 @@ export default async function BookLandingPage({ params }: PageProps) {
         {data.author ? <p className="seo-author">by {data.author}</p> : null}
         {metaBits.length ? <p className="seo-meta">{metaBits.join(" · ")}</p> : null}
         <EntityActions actions={actions} shareUrl={canonical} shareTitle={data.title} />
-        {questions.length ? (
+        {chipQs.length ? (
           <div className="mind-starters">
             <span className="mind-starters-label">Ask this book:</span>
-            {questions.slice(0, 3).map((q) => (
+            {chipQs.map((q) => (
               <Link
                 key={q}
                 href={`/?book=${encodeURIComponent(id)}&q=${encodeURIComponent(q)}`}

--- a/web/app/revalidate/route.ts
+++ b/web/app/revalidate/route.ts
@@ -1,0 +1,31 @@
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * On-demand cache busting. Every public SSR read is tagged "ssr" (see
+ * web/lib/api.ts), so POST /revalidate?token=…&tag=ssr invalidates them all and
+ * each SEO page re-fetches fresh data on its next request — content changes
+ * (generated voices, regenerated questions, new minds) go live in seconds
+ * instead of waiting out the 1-day revalidate window. No constant egress cost:
+ * the cache still only refreshes when we explicitly invalidate it.
+ *
+ * Lives at /revalidate (NOT /api/*, which vercel.json rewrites to the FastAPI
+ * backend). Token-gated; a leak's worst case is a one-time cache refresh.
+ */
+export const dynamic = "force-dynamic";
+
+const TOKEN = "fey_rv_9f3a7c2e8b1d4056b7e21ad4c8";
+
+function handle(req: NextRequest): NextResponse {
+  const token =
+    req.nextUrl.searchParams.get("token") || req.headers.get("x-revalidate-token");
+  if (token !== TOKEN) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+  const tag = req.nextUrl.searchParams.get("tag") || "ssr";
+  revalidateTag(tag);
+  return NextResponse.json({ ok: true, revalidated: tag, at: Date.now() });
+}
+
+export const POST = handle;
+export const GET = handle;

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -110,9 +110,13 @@ export async function apiFetch<T = unknown>(
   // caches authenticated/user fetches (a token present); a caller can opt out
   // explicitly via opts.cache or opts.next.
   const isGet = !opts.method || opts.method.toUpperCase() === "GET";
-  const cacheInit: { next?: { revalidate: number } } =
+  // The "ssr" tag lets POST /api/revalidate bust every cached SSR read at once
+  // (after a content batch), so data changes go live in seconds instead of
+  // waiting out the 1-day revalidate window — without shortening it (no constant
+  // egress cost; the cache only refreshes when we explicitly invalidate it).
+  const cacheInit: { next?: { revalidate: number; tags?: string[] } } =
     isServer && isGet && !_authToken && !("cache" in opts) && !("next" in opts)
-      ? { next: { revalidate: SSR_REVALIDATE } }
+      ? { next: { revalidate: SSR_REVALIDATE, tags: ["ssr"] } }
       : {};
 
   let res = await fetch(`${base}${path}`, { ...opts, ...cacheInit, headers: buildHeaders() });


### PR DESCRIPTION
SSR reads tagged 'ssr'; POST /revalidate busts them so content changes go live in seconds (not 1 day) with no constant egress cost. /book chips skip meta-referential stub questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)