### PR TITLE
fix(seo): restore Sample Passages on slug book pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -178,7 +178,10 @@ async def _llm_referer_middleware(request: Request, call_next):
 # the canonical UUID BEFORE routing, so every endpoint works unchanged. UUID
 # segments skip the lookup (fast path); unknown segments fall through untouched.
 _UUID_SEG = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
-_SLUG_PATH = re.compile(r"^(/api/agents/|/api/minds/|/book/|/mind/)([^/]+)(/.*)?$")
+# /api/public/book/ is the public reader mirror SSR uses for sample passages; it
+# resolves by UUID (get_agent), so without slug rewriting it 404s for every
+# slug-based book page — leaving the "Sample passages" SEO section empty.
+_SLUG_PATH = re.compile(r"^(/api/agents/|/api/minds/|/api/public/book/|/book/|/mind/)([^/]+)(/.*)?$")
 
 
 @app.middleware("http")

--- a/web/lib/seo-book.ts
+++ b/web/lib/seo-book.ts
@@ -487,6 +487,11 @@ interface ReadResponse {
  * We coalesce whichever is present into leading SamplePassage objects.
  * Returns [] on any failure (catalog stubs / no content / API down).
  */
+// Gutenberg / scan boilerplate that makes a useless "sample passage" if it
+// leaks past the front-matter skip below.
+const FRONT_MATTER_RE =
+  /transcriber|project\s+gutenberg|gutenberg-tm|produced\s+by|distributed\s+proofread|all\s+rights\s+reserved|electronic\s+edition/i;
+
 export async function getSamplePassages(
   id: string,
   count = 3,
@@ -517,12 +522,25 @@ export async function getSamplePassages(
   }
 
   if (Array.isArray(res.paragraphs) && res.paragraphs.length) {
-    for (const p of res.paragraphs) {
-      const text = (p || "").trim();
-      if (text.length < 40) continue; // skip headers / stray fragments
-      out.push({ index: out.length, text });
-      if (out.length >= count) break;
-    }
+    const paras = res.paragraphs;
+    // Skip front matter (transcriber's notes, title page, contents) — for a long
+    // book the opening paragraphs are boilerplate that makes a poor, non-
+    // representative sample. Start ~10% in, require real prose length, and drop
+    // Gutenberg boilerplate; fall back to any substantive paragraph if empty.
+    const start = Math.min(
+      Math.floor(paras.length * 0.1),
+      Math.max(paras.length - count, 0),
+    );
+    const pick = (from: number, minLen: number) => {
+      for (let i = from; i < paras.length && out.length < count; i++) {
+        const text = (paras[i] || "").trim();
+        if (text.length < minLen) continue;
+        if (FRONT_MATTER_RE.test(text)) continue;
+        out.push({ index: out.length, text });
+      }
+    };
+    pick(start, 100);
+    if (!out.length) pick(0, 40);
     return out;
   }
 


### PR DESCRIPTION
Root cause: /api/public/book/{id}/read resolves by UUID but the slug→uuid middleware didn't cover that prefix → 404 → empty passages on every slug book page since the slug migration. Add the prefix. Also skip front matter (transcriber's notes) when sampling. Affects the ~57 indexed books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)