### PR TITLE
fix(seo): internal cross-links use slug + passage/chip polish

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1919,7 +1919,7 @@ def list_minds_for_agent(agent_id: str, limit: int = 12) -> list[dict[str, Any]]
     PageRank from book pages → mind pages."""
     with get_conn() as conn:
         rows = _fetchall(conn, _q(
-            """SELECT m.id, m.name, m.era, m.domain
+            """SELECT m.id, m.name, m.slug, m.era, m.domain
                FROM mind_works mw
                JOIN minds m ON m.id = mw.mind_id
                WHERE mw.agent_id = ?
@@ -2058,7 +2058,7 @@ def list_books_for_mind(mind_id: str, limit: int = 12) -> list[dict[str, Any]]:
     on a public landing page."""
     with get_conn() as conn:
         rows = _fetchall(conn, _q(
-            """SELECT a.id, a.name, a.type, a.meta
+            """SELECT a.id, a.name, a.slug, a.type, a.meta
                FROM mind_works mw
                JOIN agents a ON a.id = mw.agent_id
                WHERE mw.mind_id = ? AND a.status = 'ready'
@@ -2075,6 +2075,7 @@ def list_books_for_mind(mind_id: str, limit: int = 12) -> list[dict[str, Any]]:
             out.append({
                 "id": r["id"],
                 "name": r["name"],
+                "slug": (r.get("slug") if isinstance(r, dict) else r["slug"]) or "",
                 "type": r["type"],
                 "author": meta.get("author", ""),
             })
@@ -2763,6 +2764,7 @@ def list_related_books(
         out.append({
             "id": agent["id"],
             "name": agent.get("name", ""),
+            "slug": agent.get("slug") or "",
             "type": agent.get("type", ""),
             "author": meta.get("author", ""),
         })

--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -185,10 +185,18 @@ export default async function BookLandingPage({ params }: PageProps) {
   const hasRealContent = Number(data.meta.chunk_count || 0) >= 5;
   const chipQs = hasRealContent
     ? questions
-        .filter(
-          (q) =>
-            !/^\s*(given|considering|imagine|if you were|drawing on|reflecting on|the (description|book|text|author)\b)/i.test(q),
-        )
+        .filter((q) => {
+          // Drop meta-referential openers…
+          if (
+            /^\s*(given|considering|imagine|if you were|drawing on|reflecting on|the (description|book|text|author)\b)/i.test(q)
+          )
+            return false;
+          // …and questions ABOUT the book's packaging rather than its ideas
+          // ("What does the title's emphasis…", "the description calls it…").
+          if (/\bthe (title|description)\b|\bthe book['’]s (title|premise|promise|status)\b/i.test(q))
+            return false;
+          return true;
+        })
         .slice(0, 3)
     : [];
   const isAI = data.agent.type === "ai_book";
@@ -233,7 +241,7 @@ export default async function BookLandingPage({ params }: PageProps) {
           <ul>
             {related.minds.map((m) => (
               <li key={m.id}>
-                <Link href={`/mind/${m.id}`}>{m.name}</Link>
+                <Link href={`/mind/${m.slug || m.id}`}>{m.name}</Link>
                 {m.activity && m.activity.count > 0 ? (
                   <span className="activity-badge" title="Active in real reader conversations about this book">
                     {" "}● {m.activity.count} {m.activity.count === 1 ? "chat" : "chats"}
@@ -250,7 +258,7 @@ export default async function BookLandingPage({ params }: PageProps) {
           <ul>
             {related.books.map((b) => (
               <li key={b.id}>
-                <Link href={`/book/${b.id}`}>{b.name}</Link>
+                <Link href={`/book/${b.slug || b.id}`}>{b.name}</Link>
               </li>
             ))}
           </ul>

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -184,7 +184,7 @@ export default async function MindPage({
       <ul>
         {related.slice(0, 8).map((rm) => (
           <li key={rm.id}>
-            <Link href={`/mind/${rm.id}`}>{rm.name}</Link>
+            <Link href={`/mind/${rm.slug || rm.id}`}>{rm.name}</Link>
           </li>
         ))}
       </ul>
@@ -267,7 +267,7 @@ export default async function MindPage({
           <ul className="related-books">
             {libraryExtra.map((b) => (
               <li key={b.id}>
-                <Link href={`/book/${b.id}`}>{b.name}</Link>
+                <Link href={`/book/${b.slug || b.id}`}>{b.name}</Link>
               </li>
             ))}
           </ul>

--- a/web/app/topic/[slug]/page.tsx
+++ b/web/app/topic/[slug]/page.tsx
@@ -91,10 +91,10 @@ export default async function TopicPage({
   // CollectionPage → ItemList: books first, then minds.
   const items: Array<{ name: string; url: string }> = [];
   for (const b of books) {
-    if (b.id && b.name) items.push({ name: b.name, url: abs(`/book/${b.id}`) });
+    if (b.id && b.name) items.push({ name: b.name, url: abs(`/book/${b.slug || b.id}`) });
   }
   for (const m of topicMinds) {
-    if (m.id && m.name) items.push({ name: m.name, url: abs(`/mind/${m.id}`) });
+    if (m.id && m.name) items.push({ name: m.name, url: abs(`/mind/${m.slug || m.id}`) });
   }
 
   const desc = `Chat with the best ${topic} books and great minds on Feynman. ${books.length} curated ${books.length === 1 ? "book" : "books"}, ${topicMinds.length} ${topicMinds.length === 1 ? "thinker" : "thinkers"}.`;
@@ -159,7 +159,7 @@ export default async function TopicPage({
               const author = bookAuthor(b);
               return (
                 <li key={b.id}>
-                  <Link href={`/book/${b.id}`}>{b.name}</Link>
+                  <Link href={`/book/${b.slug || b.id}`}>{b.name}</Link>
                   {author ? ` — ${author}` : ""}
                 </li>
               );
@@ -174,11 +174,11 @@ export default async function TopicPage({
           <ul className="related-minds">
             {topicMinds.map((m) => (
               <li key={m.id}>
-                <Link href={`/mind/${m.id}`}>{m.name}</Link>
+                <Link href={`/mind/${m.slug || m.id}`}>{m.name}</Link>
                 {m.era ? ` — ${m.era}` : ""}
                 {" · "}
                 <Link
-                  href={`/mind/${m.id}/on/${params.slug}`}
+                  href={`/mind/${m.slug || m.id}/on/${params.slug}`}
                   className="seo-inline-link"
                 >
                   How {m.name} might approach {topic} →

--- a/web/lib/seo-book.ts
+++ b/web/lib/seo-book.ts
@@ -492,6 +492,20 @@ interface ReadResponse {
 const FRONT_MATTER_RE =
   /transcriber|project\s+gutenberg|gutenberg-tm|produced\s+by|distributed\s+proofread|all\s+rights\s+reserved|electronic\s+edition/i;
 
+// Chunk/line splitting often cuts mid-sentence, so a sampled paragraph can open
+// on a lowercase fragment ("…electrised that is foul. EXPERIMENT VI…"). Drop the
+// leading partial sentence so the passage starts at a real boundary; if there's
+// no clean break (or it would leave too little), keep the original.
+function trimToSentenceStart(text: string): string {
+  if (/^["“'([A-Z0-9]/.test(text)) return text; // already starts a sentence/quote/number
+  const m = text.match(/[.?!]\s+(["“'(]?[A-Z])/);
+  if (m && m.index !== undefined) {
+    const rest = text.slice(m.index + m[0].length - m[1].length).trim();
+    if (rest.length >= 60) return rest;
+  }
+  return text;
+}
+
 export async function getSamplePassages(
   id: string,
   count = 3,
@@ -533,10 +547,10 @@ export async function getSamplePassages(
     );
     const pick = (from: number, minLen: number) => {
       for (let i = from; i < paras.length && out.length < count; i++) {
-        const text = (paras[i] || "").trim();
-        if (text.length < minLen) continue;
-        if (FRONT_MATTER_RE.test(text)) continue;
-        out.push({ index: out.length, text });
+        const raw = (paras[i] || "").trim();
+        if (raw.length < minLen) continue;
+        if (FRONT_MATTER_RE.test(raw)) continue;
+        out.push({ index: out.length, text: trimToSentenceStart(raw) });
       }
     };
     pick(start, 100);
@@ -654,12 +668,14 @@ export async function getBookQa(id: string, question: string): Promise<BookQa | 
 export interface RelatedBook {
   id: string;
   name: string;
+  slug?: string;
   author?: string;
   type?: string;
 }
 export interface RelatedMind {
   id: string;
   name: string;
+  slug?: string;
   era?: string;
   domain?: string;
   activity?: { count: number; last_seen?: string };

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -26,6 +26,7 @@ export const SITE_URL =
 export interface MindDetail {
   id: string;
   name: string;
+  slug?: string;
   era?: string;
   domain?: string;
   bio_summary?: string;
@@ -51,6 +52,7 @@ export interface MindDetail {
 export interface AgentRowLite {
   id: string;
   name: string;
+  slug?: string;
   type?: string;
   status?: string;
   source?: string;
@@ -793,6 +795,7 @@ export async function fetchPublicDiscussion(id: string): Promise<PublicDiscussio
 export interface LibraryBook {
   id: string;
   name: string;
+  slug?: string;
   type?: string;
   author?: string;
 }


### PR DESCRIPTION
#1 internal related/topic/library links now emit slug (no 301 hop), threading slug through the slim serializers. #4 passages start at a sentence boundary; chips drop 'about the packaging' questions. Deferred: discussions UGC entity backlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)