### PR TITLE
fix(seo): slug for the two missed mind-page link sources

### DIFF
--- a/web/components/seo/mind/MindSections.tsx
+++ b/web/components/seo/mind/MindSections.tsx
@@ -132,7 +132,7 @@ export function RelatedMinds({ minds }: { minds: MindDetail[] }) {
       <ul className="related-minds">
         {list.map((m) => (
           <li key={m.id}>
-            <Link href={`/mind/${m.id}`}>{m.name}</Link>
+            <Link href={`/mind/${m.slug || m.id}`}>{m.name}</Link>
             {m.era ? ` — ${m.era}` : ""}
           </li>
         ))}

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -626,7 +626,8 @@ export function buildWorkLinkIndex(
 ): Map<string, string> {
   const idx = new Map<string, string>();
   for (const a of agents) {
-    if (a.id && a.name) idx.set(a.name.toLowerCase(), a.id);
+    // Store the slug (uuid fallback) so work→book links skip the 301 hop.
+    if (a.id && a.name) idx.set(a.name.toLowerCase(), a.slug || a.id);
   }
   return idx;
 }


### PR DESCRIPTION
Follow-up to #75: 'Notable works' (buildWorkLinkIndex) + RelatedMinds component were still emitting uuids. Now slug || id. Full audit confirms only self-refs + deferred discussions remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)