### PR TITLE
fix(seo): discussion backlink uses entity slug (completes #1)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4260,13 +4260,29 @@ def api_public_discussion(session_id: str) -> JSONResponse:
         }
         for m in raw_msgs
     ]
+    # Resolve the entity's slug so the discussion's backlink to its book/mind
+    # skips the 301 hop (entity_id is a uuid). One lookup, cached with the page;
+    # book sessions point at an agent, mind sessions at a mind.
+    entity_id = session.get("mind_id") or ""
+    entity_slug = ""
+    if entity_id:
+        try:
+            ent = (
+                get_agent(entity_id)
+                if (session.get("session_type") or "") == "book"
+                else get_mind(entity_id)
+            )
+            entity_slug = (ent or {}).get("slug") or ""
+        except Exception:
+            entity_slug = ""
     return JSONResponse(
         content={
             "id": session_id,
             "title": session.get("public_title") or session.get("title") or "",
             "handle": session.get("public_handle") or "Anonymous",
             "session_type": session.get("session_type") or "",
-            "entity_id": session.get("mind_id") or "",
+            "entity_id": entity_id,
+            "entity_slug": entity_slug,
             "approved_at": session.get("approved_at") or session.get("consent_at") or "",
             "messages": messages,
         },

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -98,19 +98,20 @@ export default async function PublicDiscussionPage({
 
   const title = disc.title || "Discussion on Feynman";
   // Cross-link back to the entity (book or mind) this discussion is about.
+  const entityRef = disc.entity_slug || disc.entity_id; // prefer slug, uuid fallback
   const entityHref =
-    disc.entity_id && disc.session_type === "book"
-      ? `/book/${disc.entity_id}`
-      : disc.entity_id
-        ? `/mind/${disc.entity_id}`
+    entityRef && disc.session_type === "book"
+      ? `/book/${entityRef}`
+      : entityRef
+        ? `/mind/${entityRef}`
         : null;
   // "Start your own conversation" → the chat surface (real paths, not dead
   // /#/ hashes): a book → composer preselected; a mind → its 1:1 chat page.
   const readerHref =
-    disc.entity_id && disc.session_type === "book"
-      ? `/?book=${encodeURIComponent(disc.entity_id)}`
-      : disc.entity_id
-        ? `/mind/${encodeURIComponent(disc.entity_id)}/chat`
+    entityRef && disc.session_type === "book"
+      ? `/?book=${encodeURIComponent(entityRef)}`
+      : entityRef
+        ? `/mind/${encodeURIComponent(entityRef)}/chat`
         : `/`;
 
   const forumLd = {

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -767,6 +767,8 @@ export interface PublicDiscussion {
   handle: string;
   session_type: string;
   entity_id: string;
+  /** Descriptive slug of the linked book/mind (uuid fallback). Avoids the 301. */
+  entity_slug?: string;
   approved_at: string;
   messages: Array<{ role: string; content: string }>;
 }


### PR DESCRIPTION
Last cross-entity uuid link: /discussions/{id} backlink. Serializer now resolves entity_slug; page uses slug||uuid. 0 approved discussions exist so forward-looking, but closes the last slug gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)