### PR TITLE
fix(reader): one page at a time + drop try-asking sidebar

### DIFF
--- a/web/components/reader/Reader.module.css
+++ b/web/components/reader/Reader.module.css
@@ -29,13 +29,23 @@
   overflow: hidden;
 }
 
-/* The whole book, laid out in viewport-height CSS columns (one page wide,
-   centered); we translateX to flip between pages. width / column-width /
-   column-gap / padding / --page-h / transform are set inline from measured
-   metrics (see Reader.tsx). */
-.flow {
+/* The single-page CLIP WINDOW — exactly one column wide, centered in the stage.
+   Its overflow:hidden is what makes the reader show ONE page at a time: the
+   flow's other columns spill past this window's edge and are clipped (the stage
+   itself is full-width, so clipping there would leak the next page). Width is
+   set inline = the measured column width. */
+.window {
   height: 100%;
   margin: 0 auto;
+  position: relative;
+  overflow: hidden;
+}
+
+/* The whole book, laid out in viewport-height CSS columns (one page wide); we
+   translateX to flip between pages. width / column-width / column-gap / padding
+   / --page-h / transform are set inline from measured metrics (see Reader.tsx). */
+.flow {
+  height: 100%;
   box-sizing: border-box;
   column-fill: auto;
   transition: transform 0.38s cubic-bezier(0.4, 0, 0.2, 1);

--- a/web/components/reader/Reader.tsx
+++ b/web/components/reader/Reader.tsx
@@ -12,7 +12,6 @@ import {
 import { useRouter } from "next/navigation";
 import {
   getBookContent,
-  getQuestions,
   type BookContent,
   ApiError,
 } from "@/lib/reader";
@@ -36,7 +35,6 @@ export default function Reader({ id }: { id: string }) {
   const router = useRouter();
   const { authEnabled, user } = useAuth();
   const [content, setContent] = useState<BookContent | null>(null);
-  const [questions, setQuestions] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
@@ -98,13 +96,6 @@ export default function Reader({ id }: { id: string }) {
         if (alive) setLoading(false);
       }
     })();
-
-    // Questions are best-effort and never block the read.
-    getQuestions(id)
-      .then((qs) => {
-        if (alive) setQuestions(qs);
-      })
-      .catch(() => {});
 
     return () => {
       alive = false;
@@ -454,6 +445,10 @@ export default function Reader({ id }: { id: string }) {
 
           {paginated && content && (
             <div
+              className={styles.window}
+              style={{ width: metrics.colW || undefined }}
+            >
+            <div
               className={styles.flow}
               ref={flowRef}
               style={
@@ -556,6 +551,7 @@ export default function Reader({ id }: { id: string }) {
                 </footer>
               </article>
             </div>
+            </div>
           )}
 
           {/* Page-flip controls (only with >1 page) */}
@@ -597,24 +593,6 @@ export default function Reader({ id }: { id: string }) {
             </>
           )}
         </main>
-
-        {questions.length > 0 && (
-          <aside className={`chat-sidebar-right visible ${styles.sidebar}`}>
-            <h3 className="sidebar-title">TRY ASKING</h3>
-            <div className={styles.questionList}>
-              {questions.map((q, i) => (
-                <button
-                  key={i}
-                  type="button"
-                  className={styles.questionBtn}
-                  onClick={() => askQuestion(q)}
-                >
-                  {q}
-                </button>
-              ))}
-            </div>
-          </aside>
-        )}
       </div>
 
       <div className={`${styles.toast} ${toast ? styles.toastShow : ""}`} aria-live="polite">


### PR DESCRIPTION
Page-flip leaked the next page (flow's overflow columns clipped at the screen edge, not one page). Add a one-column clip window. Remove the try-asking sidebar (legacy reader never had it). Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)