### PR TITLE
fix(seo): move "AI insights" link to the right rail (IA consistency)

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -10,7 +10,6 @@ import { coverStyleFromTitle, coverInitials } from "@/lib/books";
 import SamplePassages from "@/components/seo/book/SamplePassages";
 import TableOfContents from "@/components/seo/book/TableOfContents";
 import PopularQuestions from "@/components/seo/book/PopularQuestions";
-import LiveContentLink from "@/components/seo/book/LiveContentLink";
 
 import {
   SITE_URL,
@@ -252,6 +251,19 @@ export default async function BookLandingPage({ params }: PageProps) {
           </ul>
         </div>
       ) : null}
+      {isStub ? null : (
+        <div className="seo-rail-card">
+          <h3>AI insights</h3>
+          <ul>
+            <li>
+              <Link href={`/book/${encodeURIComponent(id)}/insights`}>
+                AI insights about {data.title}
+              </Link>
+            </li>
+          </ul>
+          <p>Accumulated AI commentary, drawn from real reader chat sessions.</p>
+        </div>
+      )}
       {related.books.length ? (
         <div className="seo-rail-card">
           <h3>Related books</h3>
@@ -338,9 +350,6 @@ export default async function BookLandingPage({ params }: PageProps) {
       <SamplePassages passages={passages} />
       <TableOfContents chapters={data.chapters} />
       <PopularQuestions questions={questions} bookId={id} />
-      {/* A bare stub has had no chats, so /insights is an empty state — don't
-          point readers (or crawlers) at it. */}
-      {isStub ? null : <LiveContentLink entityName={data.title} bookId={id} />}
     </EntityLayout>
   );
 }


### PR DESCRIPTION
Moves the "AI insights → /insights" card out of the book content column and into the **right rail**, where the other secondary cross-links live (Great minds / Related books / Topic).

**Why:** per `EntityLayout`'s IA — the main column is this page's own reading content; the right rail is related + secondary links. The card is a cross-link to `/insights`, not the book's own content, and it was rendered headingless mid-content (right under "Popular questions"), which read ambiguously. Now a consistent `.seo-rail-card` with an "AI insights" heading, still gated on non-stub.

`LiveContentLink` is no longer referenced (left in place, unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
