### PR TITLE
fix(canvas): restore drag-resize + drop Chat/Read underlines

### DIFF
--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -36,6 +36,7 @@ interface BookCanvasProps {
   confirming: boolean;
   error: string | null;
   content?: CanvasContent | null;
+  width?: number | null;
   onConfirm: () => void;
   onCancel: () => void;
   onRetry: () => void;
@@ -49,12 +50,17 @@ export default function BookCanvas({
   confirming,
   error,
   content,
+  width,
   onConfirm,
   onCancel,
   onRetry,
 }: BookCanvasProps) {
   return (
-    <aside className="book-canvas visible" id="book-canvas">
+    <aside
+      className="book-canvas visible"
+      id="book-canvas"
+      style={width != null ? { width } : undefined}
+    >
       <div className="book-canvas-inner" id="book-canvas-content">
         {phase === "outlining" && outline && (
           <OutlineView outline={outline} confirming={confirming} onConfirm={onConfirm} />

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -868,6 +868,33 @@ export default function ChatView({
   // first message the chat is full-width, no canvas).
   const showCanvas = isWriteBook && (!!writeBook.outline || !!writeBook.status);
 
+  // Drag the divider to resize the canvas (port of initCanvasResize). The chat
+  // column flexes to fill the rest, so we only control the canvas width.
+  const [canvasWidth, setCanvasWidth] = useState<number | null>(null);
+  const onResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const canvas = document.getElementById("book-canvas");
+    if (!canvas) return;
+    const startX = e.clientX;
+    const startW = canvas.getBoundingClientRect().width;
+    const handle = e.currentTarget as HTMLElement;
+    handle.classList.add("dragging");
+    document.body.classList.add("canvas-resizing");
+    const onMove = (ev: MouseEvent) => {
+      const dx = ev.clientX - startX;
+      const max = Math.max(420, window.innerWidth - 360);
+      setCanvasWidth(Math.min(max, Math.max(420, startW - dx)));
+    };
+    const onUp = () => {
+      handle.classList.remove("dragging");
+      document.body.classList.remove("canvas-resizing");
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, []);
+
   // Use the production .chat-with-sidebar wrapper so the global
   // `:has(.book-canvas.visible) .chat-main` rule shrinks the chat column when
   // the canvas is open.
@@ -940,8 +967,12 @@ export default function ChatView({
         </div>
       </div>
 
+      {showCanvas && (
+        <div className="book-canvas-resize" onMouseDown={onResizeStart} />
+      )}
       {showCanvas ? (
         <BookCanvas
+          width={canvasWidth}
           phase={writeBook.phase}
           outline={writeBook.outline}
           status={writeBook.status}

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -3284,6 +3284,8 @@ html.dark .lp-chat-card {
 }
 body.canvas-resizing { cursor: col-resize; user-select: none; }
 body.canvas-resizing * { cursor: col-resize !important; }
+/* No width animation while dragging (the 0.35s transition would lag the drag). */
+body.canvas-resizing .book-canvas { transition: none; }
 
 /* Canvas header */
 .canvas-book-header { margin-bottom: 28px; }
@@ -3430,6 +3432,7 @@ html.dark .canvas-secondary-btn:hover { background: rgba(255,255,255,0.06); }
   cursor: pointer; transition: all 0.15s;
   display: inline-flex; align-items: center; justify-content: center; gap: 7px;
   white-space: nowrap;
+  text-decoration: none;
 }
 .canvas-action-btn:hover { transform: translateY(-1px); filter: brightness(0.95); }
 html.dark .canvas-action-btn:hover { filter: brightness(1.15); }


### PR DESCRIPTION
Two write-book canvas migration regressions: the canvas divider lost its drag-to-resize (handle CSS shipped but not the element/logic) and the Chat/Read action buttons showed an anchor underline. Restore the drag + add text-decoration:none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)