### PR TITLE
feat(share): one-click publish, drop the title/handle modal (Phase 1)

### DIFF
--- a/web/components/chat/ChatView.module.css
+++ b/web/components/chat/ChatView.module.css
@@ -8,22 +8,44 @@
   min-height: 0;
 }
 
-/* Right-aligned share affordance row above the transcript. */
+/* Share affordance, top-right of the transcript. The global
+   .chat-session-actions already positions this (absolute, top/right, flex,
+   gap) — we only keep the inline hint + icon vertically centered. */
 .shareActions {
-  display: flex;
-  justify-content: flex-end;
-  padding: 12px 32px 0;
+  align-items: center;
 }
 
+/* Icon-only share button — keeps the circular composer-icon-btn shape;
+   position:relative anchors the public-status dot. */
 .shareBtn {
-  width: auto;
-  padding: 6px 12px;
-  gap: 6px;
-  font-size: 13px;
+  position: relative;
+  flex-shrink: 0;
 }
 
+/* Accent dot badge in the button corner when the conversation is public. The
+   ring blends it into the chat surface so it reads as a status pip. */
 .shareDot {
-  color: var(--accent);
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--bg-chat);
+}
+
+/* Transient inline hint shown to the left of the icon (e.g. the <3-message
+   gate). Small frosted pill, auto-dismissed by ChatView. */
+.shareHint {
+  font: 500 12px/1.3 "Inter", sans-serif;
+  color: var(--text-muted);
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  white-space: nowrap;
+  box-shadow: var(--depth-1);
 }
 
 .toastClose {

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { get } from "@/lib/api";
+import { get, post, ApiError } from "@/lib/api";
 import {
   loadMessages,
   getSession,
@@ -50,7 +50,7 @@ import MindConsent from "./MindConsent";
 import RelatedBooks from "./RelatedBooks";
 import BookCanvas from "./BookCanvas";
 import { useWriteBook } from "./useWriteBook";
-import { ShareModal, PublishToast } from "./ShareModal";
+import { PublishToast } from "./ShareModal";
 import {
   bookToContext,
   type SelectedBook,
@@ -125,6 +125,36 @@ function stubSession(id: string): Session {
   };
 }
 
+/** Subset of POST /share's response the share button + toast actually read. */
+interface ShareRecord {
+  public_status: string;
+  public_title?: string | null;
+  public_handle?: string | null;
+  public_url?: string | null;
+}
+
+/** macOS-style share glyph (box + up arrow) — the icon-only affordance that
+ *  replaced the old "Share publicly" text button in the redesign. */
+function ShareIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+      <polyline points="8 6 12 2 16 6" />
+      <line x1="12" y1="2" x2="12" y2="14" />
+    </svg>
+  );
+}
+
 export default function ChatView({
   sessionId,
   initialMinds,
@@ -180,12 +210,55 @@ export default function ChatView({
 
   // Share state
   const [featuresOn, setFeaturesOn] = useState(false);
-  const [shareOpen, setShareOpen] = useState(false);
   const [publicStatus, setPublicStatus] = useState("private");
   const [publicTitle, setPublicTitle] = useState<string | null>(null);
   const [publicHandle, setPublicHandle] = useState<string | null>(null);
   const [publicUrl, setPublicUrl] = useState<string>("");
   const [toastUrl, setToastUrl] = useState<string>("");
+  // Transient inline hint beside the share icon (e.g. the <3-message gate). It
+  // auto-clears and never opens a modal — the redesign dropped the form.
+  const [shareHint, setShareHint] = useState("");
+  const shareHintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flashShareHint = useCallback((msg: string) => {
+    setShareHint(msg);
+    if (shareHintTimer.current) clearTimeout(shareHintTimer.current);
+    shareHintTimer.current = setTimeout(() => setShareHint(""), 4000);
+  }, []);
+
+  // One-click publish (share redesign Phase 1). No title/handle form: POST
+  // /share with the session's own title and NO handle, so the public page reads
+  // "Anonymous" (ChatGPT-style), then surface the clean PublishToast. The
+  // backend's <3-message gate (422, string detail — no code) becomes a small
+  // inline hint instead of a modal.
+  const doShare = useCallback(async () => {
+    try {
+      const rec = await post<ShareRecord>(
+        `/api/chat-sessions/${encodeURIComponent(sessionId)}/share`,
+        { title: sessionRef.current?.title || undefined },
+      );
+      setPublicStatus(rec.public_status);
+      if (rec.public_title !== undefined) setPublicTitle(rec.public_title ?? null);
+      if (rec.public_handle !== undefined) setPublicHandle(rec.public_handle ?? null);
+      const url = rec.public_url || `/discussions/${sessionId}`;
+      setPublicUrl(url);
+      setToastUrl(url);
+      bumpSessions(); // show the public ● dot in the sidebar
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 422) {
+        flashShareHint("Chat needs at least 3 messages to share.");
+      } else {
+        const detail =
+          e instanceof ApiError
+            ? (e.body as { detail?: unknown } | null)?.detail
+            : null;
+        flashShareHint(
+          typeof detail === "string" && detail
+            ? detail
+            : "Couldn’t publish — please try again.",
+        );
+      }
+    }
+  }, [sessionId, flashShareHint]);
 
   // Abort guard: bump to invalidate in-flight minds work after a new send.
   const genRef = useRef(0);
@@ -903,18 +976,27 @@ export default function ChatView({
       <div className="chat-main">
         {shareEligible && (
           <div className={`chat-session-actions ${styles.shareActions}`} id="chat-session-actions">
+            {shareHint && (
+              <span className={styles.shareHint} role="status">
+                {shareHint}
+              </span>
+            )}
             <button
               type="button"
               className={`composer-icon-btn ${styles.shareBtn}`}
               id="share-session-btn"
-              onClick={() => (isPublic && publicUrl ? setToastUrl(publicUrl) : setShareOpen(true))}
+              aria-label={isPublic ? "Shared publicly — manage link" : "Share publicly"}
+              title={isPublic ? "Shared publicly" : "Share publicly"}
+              onClick={() => (isPublic && publicUrl ? setToastUrl(publicUrl) : doShare())}
             >
+              <ShareIcon />
               {isPublic && (
-                <span id="share-status-indicator" className={styles.shareDot} title="Public">
-                  ●
-                </span>
+                <span
+                  id="share-status-indicator"
+                  className={styles.shareDot}
+                  aria-hidden="true"
+                />
               )}
-              <span className="share-btn-label">{isPublic ? "Manage share" : "Share publicly"}</span>
             </button>
           </div>
         )}
@@ -993,23 +1075,6 @@ export default function ChatView({
             excludeAgentIds={[...books.values()].map((b) => b.agentId)}
           />
         )
-      )}
-
-      {shareOpen && (
-        <ShareModal
-          session={{ ...sessionRef.current, publicStatus, publicTitle, publicHandle }}
-          onClose={() => setShareOpen(false)}
-          onShared={(rec) => {
-            setPublicStatus(rec.public_status);
-            if (rec.public_title !== undefined) setPublicTitle(rec.public_title ?? null);
-            if (rec.public_handle !== undefined) setPublicHandle(rec.public_handle ?? null);
-            const url = rec.public_url || `/discussions/${sessionId}`;
-            setPublicUrl(url);
-            setShareOpen(false);
-            setToastUrl(url);
-            bumpSessions(); // show the public ● dot in the sidebar
-          }}
-        />
       )}
 
       {toastUrl && (

--- a/web/components/chat/ShareModal.tsx
+++ b/web/components/chat/ShareModal.tsx
@@ -1,124 +1,19 @@
 "use client";
 
 /**
- * Share-publicly modal + success toast. Port of the Phase 6 user-share UI in
- * app.js (~7798-7919). Auto-publish model: POST /share sets public_status
- * 'approved' immediately; the public URL is /discussions/{id}.
+ * Publish-success toast for the share flow.
  *
- * Reuses .share-modal(.hidden) + .share-modal-card + .publish-toast classes.
- * Eligibility (feature flag + min message count) is decided by ChatView; this
- * component only renders when asked and reports the published record back up.
+ * The old title/handle modal was removed in the share redesign (Phase 1) in
+ * favor of one-click publish wired directly in ChatView (`doShare`). This file
+ * now holds only the clean popup that surfaces the public link with Copy / Open
+ * / Make private — the affordance ChatGPT/Claude show after you share.
+ *
+ * Reuses the .publish-toast classes. Auto-publish model: POST /share sets
+ * public_status 'approved' immediately; the public URL is /discussions/{id}.
  */
 
-import { useEffect, useState } from "react";
-import { post, ApiError } from "@/lib/api";
-import type { Session } from "@/lib/chat";
-
-interface ShareRecord {
-  public_status: string;
-  public_title?: string | null;
-  public_handle?: string | null;
-  public_url?: string | null;
-}
-
-export function ShareModal({
-  session,
-  onClose,
-  onShared,
-}: {
-  session: Session;
-  onClose: () => void;
-  onShared: (rec: ShareRecord) => void;
-}) {
-  const [title, setTitle] = useState(
-    (session.publicTitle || session.title || "").slice(0, 200),
-  );
-  const [handle, setHandle] = useState(session.publicHandle || "");
-  const [error, setError] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-
-  // Esc closes (mirrors the legacy global keydown handler).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
-  const submit = async () => {
-    setSubmitting(true);
-    setError("");
-    try {
-      const rec = await post<ShareRecord>(
-        `/api/chat-sessions/${encodeURIComponent(session.id)}/share`,
-        {
-          title: title.trim() || undefined,
-          handle: handle.trim() || undefined,
-        },
-      );
-      onShared(rec);
-    } catch (e) {
-      const detail =
-        e instanceof ApiError &&
-        typeof (e.body as { detail?: string })?.detail === "string"
-          ? (e.body as { detail: string }).detail
-          : "Could not publish.";
-      setError(detail);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="share-modal">
-      <div className="share-modal-backdrop" onClick={onClose} />
-      <div className="share-modal-card" role="dialog" aria-modal="true">
-        <div className="share-modal-header">
-          <h2>Share publicly</h2>
-          <button className="share-modal-close" aria-label="Close" onClick={onClose}>
-            ×
-          </button>
-        </div>
-        <div className="share-modal-body">
-          <p className="share-modal-intro">
-            Publish this conversation to a public page anyone can read. You can make
-            it private again at any time.
-          </p>
-          <label className="share-field">
-            <span className="share-field-label">Title</span>
-            <input
-              className="share-field-input"
-              value={title}
-              maxLength={200}
-              placeholder="Conversation title"
-              onChange={(e) => setTitle(e.target.value)}
-            />
-          </label>
-          <label className="share-field">
-            <span className="share-field-label">Your handle (optional)</span>
-            <input
-              className="share-field-input"
-              value={handle}
-              placeholder="e.g. feynman_fan"
-              onChange={(e) => setHandle(e.target.value)}
-            />
-            <span className="share-field-hint">Shown as the author of the public page.</span>
-          </label>
-          {error && <div className="share-modal-error">{error}</div>}
-        </div>
-        <div className="share-modal-footer">
-          <button className="share-modal-cancel" onClick={onClose} disabled={submitting}>
-            Cancel
-          </button>
-          <button className="share-modal-submit" onClick={submit} disabled={submitting}>
-            {submitting ? "Publishing…" : "Publish"}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { useState } from "react";
+import { post } from "@/lib/api";
 
 export function PublishToast({
   url,


### PR DESCRIPTION
## Share redesign — Phase 1 (clean entry, frontend only)

Replaces the title/handle share **modal** with a one-click publish flow, matching how ChatGPT/Claude share a conversation.

### What changed
- **Icon-only share button** (macOS box+arrow glyph) replaces the "Share publicly" / "Manage share" text button. A public conversation shows an accent **corner-dot** status pip.
- **One-click `doShare()`** — `POST /api/chat-sessions/{id}/share` with the session's own title and **no handle**, so the public page reads "Anonymous" (ChatGPT-style). On success it opens the clean **`PublishToast`** (copy link / open / make private).
- The backend **<3-message gate (422)** now shows a small **inline pill hint** ("Chat needs at least 3 messages to share.") instead of opening a modal. (The backend sends this as a 422 with a *string* detail, so the client keys on `status === 422`.)
- Removed `shareOpen` state + the `<ShareModal>` render; **kept `PublishToast`**.
- `ShareModal.tsx` now exports only `PublishToast` (the form component was deleted).

### Scope / notes
- **Frontend only** — reuses the existing `POST /api/chat-sessions/{id}/share` auto-publish endpoint (no backend change).
- The share action is **auth + UGC-flag gated**, so it only appears for signed-in users with the flag on → verify on **prod, signed in**.
- Couldn't build/preview locally (`web/` has no `node_modules`) — relying on the Vercel **feynman-web** build for compile validation.
- Per-turn ("share a single answer") is **Phase 2** — separate PRs to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
