### PR TITLE
feat(share): per-turn share backend — shared_answers store + endpoints (Phase 2)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -329,6 +330,34 @@ def init_db() -> None:
                 )
             """)
             _execute(conn, "CREATE INDEX IF NOT EXISTS idx_session_messages_session ON session_messages(session_id)")
+
+            # Shared single answers (per-turn share — share redesign Phase 2).
+            # A snapshot of ONE assistant/mind turn published at /a/{id}. Stored
+            # in its own table (not on session_messages) so a shared answer is an
+            # immutable public artifact: NO foreign key to chat_sessions, so it
+            # survives later edits/deletes of the source session. Same UGC gating
+            # + PII scrub + ENABLE_PUBLIC_DISCUSSIONS flag as session discussions.
+            _execute(conn, """
+                CREATE TABLE IF NOT EXISTS shared_answers (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    message_index INTEGER NOT NULL,
+                    user_id TEXT NOT NULL,
+                    question TEXT NOT NULL DEFAULT '',
+                    answer TEXT NOT NULL DEFAULT '',
+                    answer_role TEXT NOT NULL DEFAULT 'assistant',
+                    mind_id TEXT,
+                    mind_name TEXT,
+                    sources_json TEXT,
+                    public_status TEXT NOT NULL DEFAULT 'private',
+                    public_handle TEXT,
+                    consent_at TEXT,
+                    approved_at TEXT,
+                    created_at TEXT NOT NULL,
+                    UNIQUE (session_id, message_index)
+                )
+            """)
+            _execute(conn, "CREATE INDEX IF NOT EXISTS idx_shared_answers_user ON shared_answers(user_id)")
 
             # AI-generated books
             _execute(conn, """
@@ -798,6 +827,31 @@ def init_db() -> None:
                 )
             """)
             _execute(conn, "CREATE INDEX IF NOT EXISTS idx_session_messages_session ON session_messages(session_id)")
+
+            # Shared single answers (per-turn share — share redesign Phase 2).
+            # Mirrors the PG branch above; see that comment for the artifact /
+            # privacy rationale.
+            _execute(conn, """
+                CREATE TABLE IF NOT EXISTS shared_answers (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    message_index INTEGER NOT NULL,
+                    user_id TEXT NOT NULL,
+                    question TEXT NOT NULL DEFAULT '',
+                    answer TEXT NOT NULL DEFAULT '',
+                    answer_role TEXT NOT NULL DEFAULT 'assistant',
+                    mind_id TEXT,
+                    mind_name TEXT,
+                    sources_json TEXT,
+                    public_status TEXT NOT NULL DEFAULT 'private',
+                    public_handle TEXT,
+                    consent_at TEXT,
+                    approved_at TEXT,
+                    created_at TEXT NOT NULL,
+                    UNIQUE (session_id, message_index)
+                )
+            """)
+            _execute(conn, "CREATE INDEX IF NOT EXISTS idx_shared_answers_user ON shared_answers(user_id)")
 
             # AI-generated books
             _execute(conn, """
@@ -2719,6 +2773,148 @@ def list_messages_for_public_session(
                LIMIT ?"""
         ), (session_id, limit))
         return [dict(r) for r in rows]
+
+
+# ─── Shared single answers (per-turn share — share redesign Phase 2) ───
+#
+# A "shared answer" is ONE assistant/mind turn published as a standalone
+# public page at /a/{id}. Mirrors the session-level discussion share
+# (request_chat_session_share et al.) but the unit is a single turn and the
+# content is SNAPSHOT at publish time, so the row is self-contained and
+# survives later edits/deletes of the source session. Reads gate on
+# public_status='approved'; callers PII-scrub before display.
+
+def _new_short_id(nbytes: int = 8) -> str:
+    """URL-safe short id for /a/{id} (~11 chars). secrets → unguessable."""
+    return secrets.token_urlsafe(nbytes)
+
+
+def _get_shared_answer_by_turn(
+    session_id: str, message_index: int,
+) -> dict[str, Any] | None:
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT * FROM shared_answers WHERE session_id = ? AND message_index = ?"
+        ), (session_id, message_index))
+        return dict(row) if row else None
+
+
+def get_shared_answer(answer_id: str) -> dict[str, Any] | None:
+    """Fetch a shared answer by id regardless of status (owner/admin view)."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT * FROM shared_answers WHERE id = ?"
+        ), (answer_id,))
+        return dict(row) if row else None
+
+
+def get_public_answer(answer_id: str) -> dict[str, Any] | None:
+    """SAFETY-CRITICAL read: returns the row ONLY if public_status='approved'.
+    The /a/{id} render + /api/public-answers/{id} both gate on this. Caller
+    still PII-scrubs question + answer before display."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT * FROM shared_answers WHERE id = ? AND public_status = 'approved'"
+        ), (answer_id,))
+        return dict(row) if row else None
+
+
+def request_answer_share(
+    session_id: str, message_index: int, user_id: str,
+    handle: str | None = None,
+) -> dict[str, Any] | str | None:
+    """Publish the single answer at ``message_index`` for the owning user.
+
+    Auto-publish, mirroring request_chat_session_share but per-turn: there is
+    NO minimum-message gate (a single answer IS the unit) and the snapshot is
+    immutable. Idempotent per (session_id, message_index): re-sharing the same
+    turn returns the existing row (re-publishing it if previously withdrawn).
+
+    Returns:
+      * dict — the shared_answer row on success
+      * str  — "not_found" (session missing / not owned / index out of range),
+               "not_an_answer" (the indexed turn isn't an assistant/mind reply),
+               "rejected" (admin-removed; cannot be re-shared)
+      * None — unknown failure
+    """
+    sess = get_chat_session_with_public_status(session_id)
+    if not sess or sess.get("user_id") != user_id:
+        return "not_found"
+
+    # Idempotency: reuse the existing row for this turn if present.
+    existing = _get_shared_answer_by_turn(session_id, message_index)
+    if existing:
+        if existing.get("public_status") == "rejected":
+            return "rejected"
+        if existing.get("public_status") != "approved":
+            now = _utcnow()
+            with get_conn() as conn:
+                _execute(conn, _q(
+                    """UPDATE shared_answers
+                       SET public_status = 'approved', approved_at = ?
+                       WHERE id = ? AND user_id = ?"""
+                ), (now, existing["id"], user_id))
+            return get_shared_answer(existing["id"])
+        return existing
+
+    # Snapshot the turn. Owner-scoped read (list_session_messages filters by
+    # user_id) so we never snapshot another user's transcript.
+    msgs = list_session_messages(session_id, user_id)
+    if message_index < 0 or message_index >= len(msgs):
+        return "not_found"
+    ans = msgs[message_index]
+    role = ans.get("role") or ""
+    if role not in ("assistant", "mind"):
+        return "not_an_answer"
+    meta = ans.get("meta") or {}
+    # Per-turn attribution: a 'mind' reply carries the mind's name in meta;
+    # an 'assistant' reply is Feynman (no mind) and may carry book sources.
+    mind_name = meta.get("mindName") if role == "mind" else None
+    sources = meta.get("sources")
+    # Nearest preceding user turn = the question.
+    question = ""
+    for j in range(message_index - 1, -1, -1):
+        if (msgs[j].get("role") or "") == "user":
+            question = msgs[j].get("content") or ""
+            break
+    # Resolve the mind id (messages store only the display name).
+    mind_id = None
+    if mind_name:
+        m = find_mind_by_name(mind_name)
+        if m:
+            mind_id = m.get("id")
+
+    now = _utcnow()
+    answer_id = _new_short_id()
+    with get_conn() as conn:
+        _execute(conn, _q(
+            """INSERT INTO shared_answers
+                 (id, session_id, message_index, user_id, question, answer,
+                  answer_role, mind_id, mind_name, sources_json,
+                  public_status, public_handle, consent_at, approved_at, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'approved', ?, ?, ?, ?)"""
+        ), (
+            answer_id, session_id, message_index, user_id,
+            question, ans.get("content") or "", role, mind_id, mind_name,
+            json.dumps(sources) if sources else None,
+            handle or None, now, now, now,
+        ))
+    return get_shared_answer(answer_id)
+
+
+def withdraw_answer_share(
+    answer_id: str, user_id: str,
+) -> dict[str, Any] | None:
+    """Owner withdraws a shared answer — flips status to 'withdrawn' so it
+    stops rendering. Returns the updated row, or None if not found / not owned."""
+    row = get_shared_answer(answer_id)
+    if not row or row.get("user_id") != user_id:
+        return None
+    with get_conn() as conn:
+        _execute(conn, _q(
+            "UPDATE shared_answers SET public_status = 'withdrawn' WHERE id = ? AND user_id = ?"
+        ), (answer_id, user_id))
+    return get_shared_answer(answer_id)
 
 
 def count_pending_public_sessions() -> int:

--- a/app/main.py
+++ b/app/main.py
@@ -75,6 +75,10 @@ from .core.db import (
     reject_chat_session_public,
     request_chat_session_share,
     withdraw_chat_session_share,
+    request_answer_share,
+    withdraw_answer_share,
+    get_public_answer,
+    get_shared_answer,
     list_session_messages,
     list_user_interest_profile,
     list_votes,
@@ -2604,6 +2608,125 @@ def api_chat_session_public_status(session_id: str, request: Request):
         "consent_at": sess.get("consent_at"),
         "approved_at": sess.get("approved_at"),
     }
+
+
+# ─── Per-turn share (share redesign Phase 2) ───
+# Publish a SINGLE assistant/mind answer as a standalone public page at
+# /a/{id}. Same auth + UGC-flag gating + PII scrub as session discussions;
+# the unit is one turn (no minimum-message gate), snapshot at publish time.
+
+class ShareAnswerRequest(BaseModel):
+    handle: str | None = Field(default=None, max_length=40)
+
+
+@app.post("/api/chat-sessions/{session_id}/messages/{message_index}/share")
+def api_answer_share(
+    session_id: str, message_index: int, request: Request,
+    payload: ShareAnswerRequest | None = None,
+):
+    """Publish the single answer at ``message_index`` as a public /a/{id} page.
+
+    Auto-publish, idempotent per (session, message_index). NO minimum-message
+    gate — one answer is the unit. The request body is optional (a bare
+    one-click share sends none). Error codes:
+      * 422 ``not_an_answer`` — the indexed turn isn't an assistant/mind reply
+      * 404 — session missing / not owned / index out of range / admin-rejected
+    """
+    _require_ugc_enabled()
+    uid = _get_user_id(request)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    handle, err = ugc_module.validate_public_handle(
+        (payload.handle if payload else None) or "")
+    if err:
+        raise HTTPException(status_code=422, detail=err)
+    result = request_answer_share(session_id, message_index, uid, handle=handle or None)
+    if result == "not_an_answer":
+        raise HTTPException(status_code=422, detail="Only an assistant answer can be shared.")
+    if not result or isinstance(result, str):
+        # not_found / rejected / unknown — 404 to avoid leaking which.
+        raise HTTPException(status_code=404, detail="Answer not eligible for sharing")
+    return {
+        "id": result["id"],
+        "public_status": result["public_status"],
+        "public_handle": result.get("public_handle"),
+        "public_url": f"{_SITE_URL}/a/{result['id']}",
+        "consent_at": result.get("consent_at"),
+        "approved_at": result.get("approved_at"),
+    }
+
+
+@app.post("/api/public-answers/{answer_id}/withdraw")
+def api_answer_withdraw(answer_id: str, request: Request):
+    """Owner withdraws a shared answer — status → 'withdrawn'. Idempotent."""
+    _require_ugc_enabled()
+    uid = _get_user_id(request)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    result = withdraw_answer_share(answer_id, uid)
+    if not result:
+        raise HTTPException(status_code=404, detail="Answer not found")
+    return {"id": result["id"], "public_status": result["public_status"]}
+
+
+@app.get("/api/public-answers/{answer_id}")
+def api_public_answer(answer_id: str) -> JSONResponse:
+    """One approved shared answer as JSON (drives the /a/{id} render). 404
+    unless the feature flag is on AND public_status='approved'. Question +
+    answer pass through the same PII scrub as discussions; carries the mind /
+    book attribution that makes a single shared answer self-explanatory."""
+    _require_ugc_enabled()
+    row = get_public_answer(answer_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Answer not found")
+    # Attribution: a 'mind' answer resolves to that mind; an 'assistant' answer
+    # is Feynman (mind=None) and may carry a cited book.
+    mind = None
+    if row.get("mind_id"):
+        try:
+            m = get_mind(row["mind_id"])
+        except Exception:
+            m = None
+        if m:
+            mind = {
+                "name": m.get("name") or row.get("mind_name") or "",
+                "slug": m.get("slug") or "",
+                "avatar_seed": m.get("avatar_seed") or "",
+                "voice": m.get("voice") or "",
+            }
+    if mind is None and row.get("mind_name"):
+        # Named in the snapshot but no longer resolvable — still attribute it.
+        mind = {"name": row["mind_name"], "slug": "", "avatar_seed": "", "voice": ""}
+    # Book attribution from the snapshotted sources (first cited book).
+    book = None
+    try:
+        srcs = json.loads(row.get("sources_json") or "[]")
+    except Exception:
+        srcs = []
+    if srcs:
+        first = srcs[0] or {}
+        agent_id = first.get("agent_id") or ""
+        slug = ""
+        if agent_id:
+            try:
+                ag = get_agent(agent_id)
+                slug = (ag or {}).get("slug") or ""
+            except Exception:
+                slug = ""
+        book = {"name": first.get("agent_name") or "", "agent_id": agent_id, "slug": slug}
+    return JSONResponse(
+        content={
+            "id": row["id"],
+            "question": ugc_module.scrub_pii_for_public_display(row.get("question") or ""),
+            "answer": ugc_module.scrub_pii_for_public_display(row.get("answer") or ""),
+            "answer_role": row.get("answer_role") or "assistant",
+            "handle": row.get("public_handle") or "Anonymous",
+            "mind": mind,
+            "book": book,
+            "approved_at": row.get("approved_at") or row.get("consent_at") or "",
+        },
+        headers={"Cache-Control": "public, max-age=600, s-maxage=600"},
+    )
 
 
 class AdminApproveRequest(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -2690,13 +2690,16 @@ def api_public_answer(answer_id: str) -> JSONResponse:
         if m:
             mind = {
                 "name": m.get("name") or row.get("mind_name") or "",
+                # id alongside slug so the render's "Chat with {mind}" link can
+                # fall back to slug||id (uuid 301s to the slug path).
+                "id": m.get("id") or "",
                 "slug": m.get("slug") or "",
                 "avatar_seed": m.get("avatar_seed") or "",
                 "voice": m.get("voice") or "",
             }
     if mind is None and row.get("mind_name"):
         # Named in the snapshot but no longer resolvable — still attribute it.
-        mind = {"name": row["mind_name"], "slug": "", "avatar_seed": "", "voice": ""}
+        mind = {"name": row["mind_name"], "id": "", "slug": "", "avatar_seed": "", "voice": ""}
     # Book attribution from the snapshotted sources (first cited book).
     book = None
     try:

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1967,3 +1967,171 @@ class TestPhase6AutoPublishShare:
         assert match[0]["public_status"] == "approved", \
             "_row_to_session must surface public_status (SPA UI depends on this)"
         assert match[0]["public_handle"] == "@me"
+
+
+class TestPhase2AnswerShare:
+    """Per-turn share (share redesign Phase 2): publishing a SINGLE answer.
+
+    Mirrors TestPhase6AutoPublishShare but the unit is one turn. Guards the
+    snapshot, attribution, approved-gating, withdraw, and idempotency contracts
+    the /a/{id} public render depends on.
+    """
+
+    def _mk_session(self):
+        """Build a session whose transcript is:
+            0 user       "What is entropy? mail me at a@b.com"
+            1 assistant  "<answer w/ a link>"  meta.sources=[{agent_id, agent_name}]
+            2 user       "And you, Ada?"
+            3 mind        "<mind answer>"      meta.mindName="Ada Lovelace"
+        Returns (user_id, session_id)."""
+        import os, uuid
+        os.environ.pop("DATABASE_URL", None)
+        from app.core.db import (
+            init_db, create_chat_session, add_session_message,
+        )
+        init_db()
+        uid = f"user-{uuid.uuid4().hex[:8]}"
+        sid = create_chat_session(title="Entropy chat", session_type="chat", user_id=uid)["id"]
+        add_session_message(sid, role="user",
+                            content="What is entropy? mail me at a@b.com", user_id=uid)
+        add_session_message(sid, role="assistant",
+                            content="Entropy measures disorder. See https://example.com/x",
+                            meta={"sources": [{"agent_id": "agent-1",
+                                               "agent_name": "Thermodynamics 101"}]},
+                            user_id=uid)
+        add_session_message(sid, role="user", content="And you, Ada?", user_id=uid)
+        add_session_message(sid, role="mind",
+                            content="From a computational view, entropy is information.",
+                            meta={"mindName": "Ada Lovelace"}, user_id=uid)
+        return uid, sid
+
+    def test_share_snapshots_question_and_answer(self):
+        from app.core.db import request_answer_share
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        assert isinstance(rec, dict), f"expected dict, got {rec!r}"
+        assert rec["public_status"] == "approved"
+        assert rec["answer"].startswith("Entropy measures disorder")
+        assert rec["question"] == "What is entropy? mail me at a@b.com"
+        assert rec["answer_role"] == "assistant"
+        assert rec["approved_at"]
+        assert 0 < len(rec["id"]) < 36, "public id must be short (not a uuid)"
+
+    def test_share_mind_answer_resolves_attribution(self):
+        from app.core.db import request_answer_share, create_mind
+        uid, sid = self._mk_session()
+        mind_id = create_mind({"name": "Ada Lovelace", "persona": "analytical engine pioneer"})
+        rec = request_answer_share(sid, 3, uid)
+        assert isinstance(rec, dict)
+        assert rec["answer_role"] == "mind"
+        assert rec["mind_name"] == "Ada Lovelace"
+        assert rec["mind_id"] == mind_id, "mind must be resolved by name to its id"
+
+    def test_mind_answer_without_db_mind_still_attributes_name(self):
+        # The mind named in the message isn't in the minds table — we still
+        # snapshot the name (mind_id stays NULL); the API attributes by name.
+        from app.core.db import request_answer_share
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 3, uid)
+        assert isinstance(rec, dict)
+        assert rec["mind_name"] == "Ada Lovelace"
+        assert not rec["mind_id"]
+
+    def test_user_turn_cannot_be_shared(self):
+        from app.core.db import request_answer_share
+        uid, sid = self._mk_session()
+        assert request_answer_share(sid, 0, uid) == "not_an_answer"
+
+    def test_out_of_range_index_is_not_found(self):
+        from app.core.db import request_answer_share
+        uid, sid = self._mk_session()
+        assert request_answer_share(sid, 99, uid) == "not_found"
+
+    def test_wrong_owner_is_not_found(self):
+        from app.core.db import request_answer_share
+        _, sid = self._mk_session()
+        assert request_answer_share(sid, 1, "someone-else") == "not_found"
+
+    def test_no_min_message_gate(self):
+        # A 2-message session can share its answer — the per-turn unit has NO
+        # 3-message gate (unlike whole-session share).
+        import os, uuid
+        os.environ.pop("DATABASE_URL", None)
+        from app.core.db import (
+            init_db, create_chat_session, add_session_message, request_answer_share,
+        )
+        init_db()
+        uid = f"user-{uuid.uuid4().hex[:8]}"
+        sid = create_chat_session(title="x", session_type="chat", user_id=uid)["id"]
+        add_session_message(sid, role="user", content="hi", user_id=uid)
+        add_session_message(sid, role="assistant", content="hello there", user_id=uid)
+        rec = request_answer_share(sid, 1, uid)
+        assert isinstance(rec, dict), "single answer must be shareable (no min-message gate)"
+        assert rec["answer"] == "hello there"
+
+    def test_idempotent_per_turn(self):
+        from app.core.db import request_answer_share
+        uid, sid = self._mk_session()
+        a = request_answer_share(sid, 1, uid)
+        b = request_answer_share(sid, 1, uid)
+        assert isinstance(a, dict) and isinstance(b, dict)
+        assert a["id"] == b["id"], "re-sharing the same turn must return the same row"
+
+    def test_public_read_gates_on_approved(self):
+        from app.core.db import request_answer_share, get_public_answer, get_shared_answer
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        assert get_public_answer(rec["id"]) is not None
+        assert get_shared_answer(rec["id"]) is not None
+
+    def test_withdraw_stops_public_render(self):
+        from app.core.db import (
+            request_answer_share, withdraw_answer_share, get_public_answer, get_shared_answer,
+        )
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        out = withdraw_answer_share(rec["id"], uid)
+        assert out and out["public_status"] == "withdrawn"
+        assert get_public_answer(rec["id"]) is None, "withdrawn answers must not render publicly"
+        assert get_shared_answer(rec["id"]) is not None, "row still exists for the owner"
+
+    def test_withdraw_wrong_owner_refused(self):
+        from app.core.db import request_answer_share, withdraw_answer_share, get_public_answer
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        assert withdraw_answer_share(rec["id"], "intruder") is None
+        assert get_public_answer(rec["id"]) is not None, "a failed withdraw must not unpublish"
+
+    def test_reshare_withdrawn_republishes_same_id(self):
+        from app.core.db import (
+            request_answer_share, withdraw_answer_share, get_public_answer,
+        )
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        withdraw_answer_share(rec["id"], uid)
+        again = request_answer_share(sid, 1, uid)
+        assert isinstance(again, dict)
+        assert again["id"] == rec["id"]
+        assert again["public_status"] == "approved"
+        assert get_public_answer(rec["id"]) is not None
+
+    def test_sources_snapshotted_for_book_attribution(self):
+        import json as _json
+        from app.core.db import request_answer_share
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        srcs = _json.loads(rec.get("sources_json") or "[]")
+        assert srcs and srcs[0]["agent_name"] == "Thermodynamics 101"
+
+    def test_snapshot_is_raw_so_render_scrub_can_redact(self):
+        # The snapshot stores RAW text; PII is redacted at render time by the
+        # endpoint via ugc.scrub_pii_for_public_display (so scrub rules can
+        # improve without a re-publish). Verify both halves of that contract.
+        from app.core.db import request_answer_share
+        from app.core import ugc
+        uid, sid = self._mk_session()
+        rec = request_answer_share(sid, 1, uid)
+        assert "https://example.com/x" in rec["answer"]
+        assert "a@b.com" in rec["question"]
+        assert "[link redacted]" in ugc.scrub_pii_for_public_display(rec["answer"])
+        assert "[email redacted]" in ugc.scrub_pii_for_public_display(rec["question"])

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1977,13 +1977,14 @@ class TestPhase2AnswerShare:
     the /a/{id} public render depends on.
     """
 
-    def _mk_session(self):
+    def _mk_session(self, mind_name="Ada Lovelace"):
         """Build a session whose transcript is:
             0 user       "What is entropy? mail me at a@b.com"
             1 assistant  "<answer w/ a link>"  meta.sources=[{agent_id, agent_name}]
-            2 user       "And you, Ada?"
-            3 mind        "<mind answer>"      meta.mindName="Ada Lovelace"
-        Returns (user_id, session_id)."""
+            2 user       "And you?"
+            3 mind        "<mind answer>"      meta.mindName=<mind_name>
+        Returns (user_id, session_id). Tests own the DB across the session (one
+        SQLite file), so pass a UNIQUE mind_name when asserting on mind presence."""
         import os, uuid
         os.environ.pop("DATABASE_URL", None)
         from app.core.db import (
@@ -1999,10 +2000,10 @@ class TestPhase2AnswerShare:
                             meta={"sources": [{"agent_id": "agent-1",
                                                "agent_name": "Thermodynamics 101"}]},
                             user_id=uid)
-        add_session_message(sid, role="user", content="And you, Ada?", user_id=uid)
+        add_session_message(sid, role="user", content="And you?", user_id=uid)
         add_session_message(sid, role="mind",
                             content="From a computational view, entropy is information.",
-                            meta={"mindName": "Ada Lovelace"}, user_id=uid)
+                            meta={"mindName": mind_name}, user_id=uid)
         return uid, sid
 
     def test_share_snapshots_question_and_answer(self):
@@ -2018,23 +2019,27 @@ class TestPhase2AnswerShare:
         assert 0 < len(rec["id"]) < 36, "public id must be short (not a uuid)"
 
     def test_share_mind_answer_resolves_attribution(self):
+        import uuid
         from app.core.db import request_answer_share, create_mind
-        uid, sid = self._mk_session()
-        mind_id = create_mind({"name": "Ada Lovelace", "persona": "analytical engine pioneer"})
+        name = f"Ada Lovelace {uuid.uuid4().hex[:8]}"  # unique → no cross-test bleed
+        mind_id = create_mind({"name": name, "persona": "analytical engine pioneer"})
+        uid, sid = self._mk_session(mind_name=name)
         rec = request_answer_share(sid, 3, uid)
         assert isinstance(rec, dict)
         assert rec["answer_role"] == "mind"
-        assert rec["mind_name"] == "Ada Lovelace"
+        assert rec["mind_name"] == name
         assert rec["mind_id"] == mind_id, "mind must be resolved by name to its id"
 
     def test_mind_answer_without_db_mind_still_attributes_name(self):
         # The mind named in the message isn't in the minds table — we still
         # snapshot the name (mind_id stays NULL); the API attributes by name.
+        import uuid
         from app.core.db import request_answer_share
-        uid, sid = self._mk_session()
+        name = f"Nonexistent Mind {uuid.uuid4().hex[:8]}"  # never inserted
+        uid, sid = self._mk_session(mind_name=name)
         rec = request_answer_share(sid, 3, uid)
         assert isinstance(rec, dict)
-        assert rec["mind_name"] == "Ada Lovelace"
+        assert rec["mind_name"] == name
         assert not rec["mind_id"]
 
     def test_user_turn_cannot_be_shared(self):


### PR DESCRIPTION
## Share redesign — Phase 2, PR 1: per-turn share backend

Backend foundation for sharing a **single answer** as a standalone public page at `/a/{id}` — the per-turn unit requested, alongside Phase 1's one-click session share (#86).

### Design
- **Snapshot, not live reference.** A shared answer is an immutable public artifact: question + answer + attribution are snapshotted into a new `shared_answers` table at publish time. **No FK** to `chat_sessions`, so it survives later edits/deletes of the source chat (like a published tweet). PII is scrubbed at *render* time so the scrub rules can improve without a re-publish.
- **Per-turn attribution** (the point of the per-turn unit — a bare message wouldn't convey the product):
  - a **mind** answer (`role:"mind"`, `meta.mindName`) resolves to that mind → name + slug + avatar + voice → powers the "Chat with {mind}" CTA.
  - an **assistant** answer is **Feynman**, and snapshots cited **book** sources for "based on {book}".
- **Idempotent** per `(session_id, message_index)`; **no minimum-message gate** (one answer is the unit). Auto-publish + withdraw, mirroring session discussions.

### Endpoints (auth + `ENABLE_PUBLIC_DISCUSSIONS`-gated)
- `POST /api/chat-sessions/{id}/messages/{idx}/share` → `{ id, public_url:/a/{id}, public_status, ... }`
- `GET /api/public-answers/{id}` → `{ question, answer, answer_role, mind, book, handle, approved_at }` (PII-scrubbed, `approved`-only)
- `POST /api/public-answers/{id}/withdraw`

### Tests
`TestPhase2AnswerShare` (DB-level, mirroring `TestPhase6AutoPublishShare`): snapshot, mind + book attribution, user-turn rejection, out-of-range / wrong-owner, no-min-gate, idempotency, approved-gating, withdraw (incl. wrong-owner refusal), re-publish-withdrawn, PII render contract.

### Notes / follow-ups
- `/a/{id}` **render route** (Next `web/app/a/[id]/page.tsx` + QAPage JSON-LD), **dynamic OG image**, and **per-message share UI** in ChatView are the next Phase 2 PRs.
- `/a/{id}` is served by Next (short ids, not slugs → **not** added to `_SLUG_PATH`).
- No per-answer rate limit yet (auth + flag-gated; flag is OFF in prod) — flagged as a follow-up.
- Couldn't run pytest locally (sandbox lacks backend deps); `py_compile` clean — relying on CI pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
