### PR TITLE
feat(share): /a/[id] public render for a shared single answer (Phase 2)

### DIFF
--- a/web/app/a/[id]/page.tsx
+++ b/web/app/a/[id]/page.tsx
@@ -1,0 +1,242 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import SeoColumn from "@/components/seo/SeoColumn";
+import JsonLd from "@/components/seo/JsonLd";
+import {
+  SITE_URL,
+  abs,
+  breadcrumbJsonLd,
+  fetchPublicAnswer,
+  metaDescription,
+  truncate,
+  dropNulls,
+  type PublicAnswer,
+} from "@/lib/seo-mind";
+
+// A single approved, PII-scrubbed shared answer (share redesign Phase 2).
+// Data comes from GET /api/public-answers/{id} (gated on
+// ENABLE_PUBLIC_DISCUSSIONS + public_status='approved'). When the feature is
+// off / the answer is withdrawn / pending, the endpoint 404s and we keep a
+// stable, friendly "not available" page (the URL is a shareable permalink) and
+// noindex it. The unit carries mind/book attribution + a "Chat with {mind}"
+// funnel so a single shared answer still conveys the product (per the spec).
+
+export const revalidate = 600;
+export const dynamicParams = true;
+
+// Empty static params → ISR rather than fully-dynamic. In Next 14 `revalidate`
+// alone leaves an [id] route dynamic (every crawl hits the API); an empty
+// generateStaticParams opts it into the Data/Full-Route cache. See
+// project_seo_isr_caching (the egress fix, #58).
+export function generateStaticParams() {
+  return [];
+}
+
+// UGC quality floor: don't index 1-liner answers (still rendered as permalinks).
+const MIN_INDEXABLE_ANSWER = 120;
+
+/** Mind chat funnel ref: slug preferred, uuid fallback (301s to the slug). */
+function mindRef(mind: NonNullable<PublicAnswer["mind"]>): string {
+  return mind.slug || mind.id || "";
+}
+function bookRef(book: NonNullable<PublicAnswer["book"]>): string {
+  return book.slug || book.agent_id || "";
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const canonical = abs(`/a/${params.id}`);
+  const ans = await fetchPublicAnswer(params.id);
+  if (!ans) {
+    return {
+      title: "Shared answer on Feynman",
+      description: "A shared answer on Feynman.",
+      robots: { index: false, follow: true },
+      alternates: { canonical },
+    };
+  }
+  const who = ans.mind?.name || "Feynman";
+  const title = ans.question ? truncate(ans.question, 70) : `An answer from ${who}`;
+  const desc = metaDescription(ans.answer || `A shared answer from ${who} on Feynman.`);
+  const indexable = (ans.answer || "").trim().length >= MIN_INDEXABLE_ANSWER;
+  return {
+    title: `${title} — Feynman`,
+    description: desc,
+    alternates: { canonical },
+    robots: indexable ? undefined : { index: false, follow: true },
+    openGraph: {
+      type: "article",
+      title,
+      description: desc,
+      url: canonical,
+      siteName: "Feynman",
+    },
+    twitter: { card: "summary", site: "@steve_yeow", title, description: desc },
+  };
+}
+
+export default async function SharedAnswerPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const canonical = abs(`/a/${params.id}`);
+  const ans = await fetchPublicAnswer(params.id);
+
+  // Not available (feature off / withdrawn / pending) — friendly stable page.
+  if (!ans) {
+    const breadcrumbLd = breadcrumbJsonLd([
+      ["Feynman", SITE_URL],
+      ["Shared answer", canonical],
+    ]);
+    return (
+      <SeoColumn>
+        <JsonLd data={breadcrumbLd} />
+        <h1>Shared answer on Feynman</h1>
+        <section className="seo-section">
+          <p>
+            This shared answer isn&rsquo;t available to view right now. Shared
+            answers are user-published with consent and PII-scrubbed before they
+            appear — this one may be private, withdrawn, or pending review.
+          </p>
+          <p>
+            You can still start your own conversation: chat with any book or great
+            mind on Feynman and share an answer from the message menu.
+          </p>
+        </section>
+        <p className="seo-cta-row">
+          <a className="primary" href={`${SITE_URL}/`}>
+            Open Feynman →
+          </a>
+          <Link className="secondary" href="/minds">
+            Meet the minds
+          </Link>
+        </p>
+      </SeoColumn>
+    );
+  }
+
+  const who = ans.mind?.name || "Feynman";
+  const initial = (who.trim().charAt(0) || "F").toUpperCase();
+  const isMind = ans.answer_role === "mind" && !!ans.mind;
+  const mRef = ans.mind ? mindRef(ans.mind) : "";
+  const bRef = ans.book ? bookRef(ans.book) : "";
+
+  // Funnel CTAs. A mind answer → chat with that mind; a Feynman answer → chat
+  // about the cited book, else open Feynman. Secondary → the mind / book page.
+  const chatHref =
+    isMind && mRef
+      ? `/mind/${encodeURIComponent(mRef)}/chat`
+      : bRef
+        ? `/?book=${encodeURIComponent(bRef)}`
+        : `/`;
+  const chatLabel = isMind
+    ? `Chat with ${who} →`
+    : bRef
+      ? "Chat about this book →"
+      : "Start your own conversation →";
+  const moreHref =
+    isMind && mRef
+      ? `/mind/${encodeURIComponent(mRef)}`
+      : bRef
+        ? `/book/${encodeURIComponent(bRef)}`
+        : null;
+  const moreLabel = isMind ? `More from ${who}` : bRef ? "View the book" : null;
+
+  const headline = ans.question ? truncate(ans.question, 110) : `An answer from ${who}`;
+
+  // QAPage when there's a real question; Article otherwise. Author is the mind
+  // (Person) or Feynman (Organization). Text is already PII-scrubbed server-side.
+  const authorLd = isMind
+    ? { "@type": "Person", name: who, url: mRef ? abs(`/mind/${mRef}`) : SITE_URL }
+    : { "@type": "Organization", name: "Feynman", url: SITE_URL };
+  const schemaLd = dropNulls(
+    ans.question
+      ? {
+          "@context": "https://schema.org",
+          "@type": "QAPage",
+          url: canonical,
+          mainEntity: {
+            "@type": "Question",
+            name: truncate(ans.question, 200),
+            text: ans.question,
+            answerCount: 1,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: ans.answer,
+              url: canonical,
+              dateCreated: ans.approved_at || "",
+              author: authorLd,
+            },
+          },
+        }
+      : {
+          "@context": "https://schema.org",
+          "@type": "Article",
+          headline,
+          url: canonical,
+          articleBody: ans.answer,
+          datePublished: ans.approved_at || "",
+          author: authorLd,
+          publisher: { "@type": "Organization", name: "Feynman", url: SITE_URL },
+        },
+  );
+  const breadcrumbLd = breadcrumbJsonLd([
+    ["Feynman", SITE_URL],
+    ["Shared answer", canonical],
+  ]);
+
+  return (
+    <SeoColumn>
+      <JsonLd data={schemaLd} />
+      <JsonLd data={breadcrumbLd} />
+
+      <h1 className="answer-question">{headline}</h1>
+      <p className="seo-meta">
+        Answered by {who}
+        {ans.book ? <> · based on {ans.book.name}</> : null}
+        {ans.handle && ans.handle !== "Anonymous" ? <> · shared by {ans.handle}</> : null}
+      </p>
+
+      <section className="seo-section answer-card">
+        <div className="answer-byline">
+          <span className="answer-avatar" aria-hidden="true">
+            {initial}
+          </span>
+          <span className="answer-author">
+            {isMind && mRef ? (
+              <Link href={`/mind/${encodeURIComponent(mRef)}`}>{who}</Link>
+            ) : (
+              who
+            )}
+          </span>
+        </div>
+        {(ans.answer || "").split(/\n{2,}/).map((para, i) => (
+          <p key={i}>{para}</p>
+        ))}
+      </section>
+
+      {isMind && ans.mind?.voice ? (
+        <p className="answer-voice">“{truncate(ans.mind.voice, 200)}”</p>
+      ) : null}
+
+      <p className="seo-cta-row">
+        <a className="primary" href={chatHref}>
+          {chatLabel}
+        </a>
+        {moreHref ? (
+          <Link className="secondary" href={moreHref}>
+            {moreLabel}
+          </Link>
+        ) : (
+          <Link className="secondary" href="/minds">
+            Meet the minds
+          </Link>
+        )}
+      </p>
+    </SeoColumn>
+  );
+}

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -793,6 +793,50 @@ export async function fetchPublicDiscussion(id: string): Promise<PublicDiscussio
   }
 }
 
+export interface PublicAnswer {
+  id: string;
+  /** Preceding user turn (PII-scrubbed). May be empty. */
+  question: string;
+  /** The shared answer (PII-scrubbed). */
+  answer: string;
+  /** "assistant" (Feynman) | "mind". */
+  answer_role: string;
+  /** Sharer's display name; "Anonymous" when none. */
+  handle: string;
+  /** The mind that authored a 'mind' answer; null for a Feynman answer. */
+  mind: {
+    name: string;
+    id?: string;
+    slug?: string;
+    avatar_seed?: string;
+    voice?: string;
+  } | null;
+  /** The cited book, when the answer drew on one; otherwise null. */
+  book: { name: string; agent_id?: string; slug?: string } | null;
+  approved_at: string;
+}
+
+/**
+ * One approved, PII-scrubbed shared single answer for /a/{id}
+ * (GET /api/public-answers/{id}). 404 unless the feature flag is on AND the
+ * answer is approved — returns null so the page can render its stable
+ * "not available" permalink state.
+ */
+export async function fetchPublicAnswer(id: string): Promise<PublicAnswer | null> {
+  try {
+    const res = await get<PublicAnswer>(
+      `/api/public-answers/${encodeURIComponent(id)}`,
+      // ISR (see fetchPublicDiscussion): keep /a/[id] cacheable so shareable
+      // permalinks don't render per-request on every crawl.
+      { next: { revalidate: 600 } },
+    );
+    if (!res || !res.id) return null;
+    return res;
+  } catch {
+    return null;
+  }
+}
+
 // ─── Content-density sections: mind library / themes / discussions list ───
 
 export interface LibraryBook {

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -604,6 +604,30 @@ body { background-color: var(--bg-home); }
 }
 .discussion-msg p { margin: 0; }
 
+/* ── Shared single answer (/a/[id]) ───────────────────────────────────── */
+.answer-question { margin-bottom: 0.3em; }
+.answer-card {
+  background: var(--accent-light);
+  border: 1px solid var(--border);
+  border-radius: var(--r-control);
+  padding: 18px 20px;
+}
+.answer-card > p { margin: 0 0 0.8em; }
+.answer-card > p:last-child { margin-bottom: 0; }
+.answer-byline { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.answer-avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent); color: #fff; font-weight: 700; font-size: 15px;
+}
+.answer-author { font-weight: 600; }
+.answer-author a { color: inherit; text-decoration: none; }
+.answer-author a:hover { text-decoration: underline; }
+.answer-voice {
+  color: var(--text-muted); font-style: italic;
+  margin: 1em 0 0; padding-left: 14px; border-left: 2px solid var(--accent);
+}
+
 /* NOTE: .chats-content/.chats-title-row/.chats-new-btn/.chats-list/.chats-list-item/
  * .chats-empty are styled by production app.css — do NOT redefine them here
  * (the earlier glass versions diverged from production). */


### PR DESCRIPTION
## Share redesign — Phase 2, PR 2: `/a/[id]` public render

The page a shared single answer links to. Renders the Q/A card with **mind/book attribution + a "Chat with {mind}" funnel**, so a single shared answer still conveys the product (not a bare message) — mirrors the `/discussions/[id]` render.

### What it does
- Fetches `GET /api/public-answers/{id}` (from #87) via a graceful-degrade helper.
- **Card:** monogram + author byline (mind → links to `/mind/{slug}`; else "Feynman"), the question as the `<h1>`, the answer body, an optional mind **voice** quote.
- **Funnel CTAs:** mind answer → **"Chat with {mind} →"** (`/mind/{slug||id}/chat`) + "More from {mind}"; Feynman answer with a cited book → "Chat about this book →" (`/?book=`) + "View the book"; otherwise → "Start your own conversation →".
- **SEO:** **QAPage** JSON-LD when there's a question (Article when there isn't); thin-answer (<120 chars) **noindex** guard; canonical + OG/Twitter meta.
- **Caching:** ISR `revalidate=600` + **empty `generateStaticParams()`** (the egress fix — keeps `[id]` out of fully-dynamic rendering).
- **Resilience:** feature-off / withdrawn / pending → a stable, friendly **"not available"** permalink (noindex), never a hard 404.

### Files
- `web/app/a/[id]/page.tsx` — the route
- `web/lib/seo-mind.ts` — `PublicAnswer` type + `fetchPublicAnswer`
- `web/styles/liquid.css` — `.answer-card` / byline / monogram / voice styles

### Notes
- **Depends on #87** (backend) being deployed + `ENABLE_PUBLIC_DISCUSSIONS` on to render real data; until then it shows the graceful "not available" state. Merge order: #87 → this.
- Answer renders as **plain text** (paragraph-split), matching the existing `/discussions` render — a markdown renderer is a possible follow-up.
- `/a/*` is served by Next (not in `web/vercel.json` rewrites; uses short ids, not slugs).
- Remaining Phase 2: **dynamic OG image** (`opengraph-image.tsx`) + **per-message share entry UI** in ChatView.
- Couldn't build/preview locally (`web/` has no `node_modules`) — relying on the Vercel **feynman-web** build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
