### PR TITLE
feat(share): dynamic OG image for shared answers /a/[id] (Phase 2)

### DIFF
--- a/web/app/a/[id]/opengraph-image.tsx
+++ b/web/app/a/[id]/opengraph-image.tsx
@@ -1,0 +1,83 @@
+import { ImageResponse } from "next/og";
+import { fetchPublicAnswer, truncate } from "@/lib/seo-mind";
+
+// Dynamic social card for a shared answer (share redesign Phase 2). Next
+// auto-wires this as the page's og:image + twitter:image. Generated on demand
+// (ISR-cached with the route) — mind name + answer snippet + brand, so a shared
+// answer looks good when pasted into X / Slack / iMessage.
+//
+// Note: relies on @vercel/og's default font (no custom font fetch → no extra
+// network failure mode). If the data fetch 404s (feature off / withdrawn) we
+// still emit a branded fallback card rather than erroring.
+
+export const alt = "A shared answer on Feynman";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: { id: string } }) {
+  const ans = await fetchPublicAnswer(params.id);
+  const who = ans?.mind?.name || "Feynman";
+  const snippet = truncate(
+    (ans?.answer || ans?.question || "A shared answer on Feynman").replace(/\s+/g, " "),
+    220,
+  );
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px 80px",
+          background:
+            "linear-gradient(135deg, #0b1020 0%, #11162a 60%, #0b1020 100%)",
+          color: "#f5f5f7",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            fontSize: 34,
+            fontWeight: 700,
+            letterSpacing: -0.5,
+            color: "#6aa8ff",
+          }}
+        >
+          Feynman
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 52,
+            lineHeight: 1.25,
+            fontWeight: 600,
+            letterSpacing: -1,
+            maxWidth: 1040,
+          }}
+        >
+          {snippet}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontSize: 30,
+            color: "#9aa4b8",
+          }}
+        >
+          <span style={{ display: "flex" }}>— {who}</span>
+          <span style={{ display: "flex" }}>feynman.wiki</span>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/web/app/a/[id]/page.tsx
+++ b/web/app/a/[id]/page.tsx
@@ -74,7 +74,12 @@ export async function generateMetadata({
       url: canonical,
       siteName: "Feynman",
     },
-    twitter: { card: "summary", site: "@steve_yeow", title, description: desc },
+    twitter: {
+      card: "summary_large_image",
+      site: "@steve_yeow",
+      title,
+      description: desc,
+    },
   };
 }
 


### PR DESCRIPTION
## Share redesign — Phase 2, PR 3: dynamic OG image for `/a/[id]`

A `next/og` `ImageResponse` social card so a shared answer looks good when pasted into X / Slack / iMessage. Next auto-wires it as the page's `og:image` + `twitter:image`.

### What it does
- `web/app/a/[id]/opengraph-image.tsx` — 1200×630 card: **Feynman** wordmark + the **answer snippet** (≤220 chars) + **— {mind name}** attribution + `feynman.wiki`, on the brand gradient.
- Reuses `fetchPublicAnswer` for the data; **graceful branded fallback** when the answer 404s (feature off / withdrawn) instead of erroring.
- Bumps the page's Twitter card to **`summary_large_image`** now that a real image exists.

### Notes
- **Stacked on #88** — the OG route must live in the same `/a/[id]` folder as the render page. Merge order: #88 → this.
- Relies on `@vercel/og`'s **default font** (no network font fetch → one fewer runtime failure mode). If the image ever 500s in prod, adding an explicit font is the fix — but the OG route failing only affects the social thumbnail, not the page.
- Runtime-only artifact (generated on request) — CI validates it **compiles/builds**; the actual rendered image is verified on prod (with `ENABLE_PUBLIC_DISCUSSIONS` on).

### Phase 2 status
This is the last of the "render side." The remaining piece is the **per-message share entry UI** in ChatView (the hover "Share" action that calls the per-turn endpoint) — it touches `ChatView.tsx` so it should land after #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
