### PR TITLE
feat(share): per-turn share entry UI — hover Share on each answer (Phase 2)

### DIFF
--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -125,12 +125,24 @@ function stubSession(id: string): Session {
   };
 }
 
-/** Subset of POST /share's response the share button + toast actually read. */
+/** Subset of the /share responses the share button + toast actually read.
+ *  `id` is the public id (session id for a discussion, short id for an answer). */
 interface ShareRecord {
+  id?: string;
   public_status: string;
   public_title?: string | null;
   public_handle?: string | null;
   public_url?: string | null;
+}
+
+/** Pull a human message out of an ApiError (string detail), else the fallback. */
+function apiErrorText(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    const detail = (e.body as { detail?: unknown } | null)?.detail;
+    if (typeof detail === "string" && detail) return detail;
+    if (e.detailMessage) return e.detailMessage;
+  }
+  return fallback;
 }
 
 /** macOS-style share glyph (box + up arrow) — the icon-only affordance that
@@ -214,7 +226,12 @@ export default function ChatView({
   const [publicTitle, setPublicTitle] = useState<string | null>(null);
   const [publicHandle, setPublicHandle] = useState<string | null>(null);
   const [publicUrl, setPublicUrl] = useState<string>("");
-  const [toastUrl, setToastUrl] = useState<string>("");
+  // The publish toast. Carries its own make-private action so it can withdraw
+  // either the whole-session discussion (Phase 1) or one shared answer (Phase 2).
+  const [toast, setToast] = useState<{
+    url: string;
+    withdraw: () => Promise<void>;
+  } | null>(null);
   // Transient inline hint beside the share icon (e.g. the <3-message gate). It
   // auto-clears and never opens a modal — the redesign dropped the form.
   const [shareHint, setShareHint] = useState("");
@@ -224,6 +241,19 @@ export default function ChatView({
     if (shareHintTimer.current) clearTimeout(shareHintTimer.current);
     shareHintTimer.current = setTimeout(() => setShareHint(""), 4000);
   }, []);
+
+  // Make the whole-session discussion private again (Phase 1 "Make private").
+  const withdrawSession = useCallback(async () => {
+    try {
+      await post(`/api/chat-sessions/${encodeURIComponent(sessionId)}/withdraw`);
+    } catch {
+      /* fail silently — user can retry */
+    }
+    setPublicStatus("withdrawn");
+    setPublicUrl("");
+    setToast(null);
+    bumpSessions(); // clear the public ● dot in the sidebar
+  }, [sessionId]);
 
   // One-click publish (share redesign Phase 1). No title/handle form: POST
   // /share with the session's own title and NO handle, so the public page reads
@@ -241,24 +271,50 @@ export default function ChatView({
       if (rec.public_handle !== undefined) setPublicHandle(rec.public_handle ?? null);
       const url = rec.public_url || `/discussions/${sessionId}`;
       setPublicUrl(url);
-      setToastUrl(url);
+      setToast({ url, withdraw: withdrawSession });
       bumpSessions(); // show the public ● dot in the sidebar
     } catch (e) {
-      if (e instanceof ApiError && e.status === 422) {
-        flashShareHint("Chat needs at least 3 messages to share.");
-      } else {
-        const detail =
-          e instanceof ApiError
-            ? (e.body as { detail?: unknown } | null)?.detail
-            : null;
+      flashShareHint(
+        e instanceof ApiError && e.status === 422
+          ? "Chat needs at least 3 messages to share."
+          : apiErrorText(e, "Couldn’t publish — please try again."),
+      );
+    }
+  }, [sessionId, flashShareHint, withdrawSession]);
+
+  // Per-turn publish (share redesign Phase 2): share ONE answer at transcript
+  // index `idx` → /a/{id}, then surface the same PublishToast. No min-message
+  // gate; idempotent server-side. "Make private" withdraws THAT answer only.
+  const doShareMessage = useCallback(
+    async (idx: number) => {
+      try {
+        const rec = await post<ShareRecord>(
+          `/api/chat-sessions/${encodeURIComponent(sessionId)}/messages/${idx}/share`,
+        );
+        const answerId = rec.id || "";
+        setToast({
+          url: rec.public_url || (answerId ? `/a/${answerId}` : ""),
+          withdraw: async () => {
+            if (answerId) {
+              try {
+                await post(`/api/public-answers/${encodeURIComponent(answerId)}/withdraw`);
+              } catch {
+                /* fail silently — user can retry */
+              }
+            }
+            setToast(null);
+          },
+        });
+      } catch (e) {
         flashShareHint(
-          typeof detail === "string" && detail
-            ? detail
-            : "Couldn’t publish — please try again.",
+          e instanceof ApiError && e.status === 422
+            ? "Only an answer can be shared."
+            : apiErrorText(e, "Couldn’t share this answer — please try again."),
         );
       }
-    }
-  }, [sessionId, flashShareHint]);
+    },
+    [sessionId, flashShareHint],
+  );
 
   // Abort guard: bump to invalidate in-flight minds work after a new send.
   const genRef = useRef(0);
@@ -987,7 +1043,11 @@ export default function ChatView({
               id="share-session-btn"
               aria-label={isPublic ? "Shared publicly — manage link" : "Share publicly"}
               title={isPublic ? "Shared publicly" : "Share publicly"}
-              onClick={() => (isPublic && publicUrl ? setToastUrl(publicUrl) : doShare())}
+              onClick={() =>
+                isPublic && publicUrl
+                  ? setToast({ url: publicUrl, withdraw: withdrawSession })
+                  : doShare()
+              }
             >
               <ShareIcon />
               {isPublic && (
@@ -1002,7 +1062,13 @@ export default function ChatView({
         )}
 
         <div className="chat-messages" id="chat-messages" ref={scrollRef}>
-          <MessageList messages={messages} knownMindNames={knownMindNames} />
+          <MessageList
+            messages={messages}
+            knownMindNames={knownMindNames}
+            // Per-turn share entry: hover "Share" on each answer. Same gate as
+            // session share (UGC flag on, not a write-book session).
+            onShareMessage={featuresOn && !isWriteBook ? doShareMessage : undefined}
+          />
           {sending && (
             <div className="chat-message assistant">
               <span className="loading-dot">Thinking...</span>
@@ -1077,17 +1143,11 @@ export default function ChatView({
         )
       )}
 
-      {toastUrl && (
+      {toast && (
         <PublishToast
-          url={toastUrl}
-          sessionId={sessionId}
-          onClose={() => setToastUrl("")}
-          onUnshared={() => {
-            setPublicStatus("withdrawn");
-            setPublicUrl("");
-            setToastUrl("");
-            bumpSessions(); // clear the public ● dot in the sidebar
-          }}
+          url={toast.url}
+          onClose={() => setToast(null)}
+          onWithdraw={toast.withdraw}
         />
       )}
     </div>

--- a/web/components/chat/MessageList.module.css
+++ b/web/components/chat/MessageList.module.css
@@ -49,3 +49,37 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Per-turn share entry (share redesign Phase 2) — a hover "Share" action under
+   each assistant/mind answer. Hidden until the message row is hovered or the
+   button is focused (keyboard a11y). Space is reserved (opacity, not display)
+   so revealing it never shifts the transcript. */
+.msgActions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+:global(.chat-message):hover .msgActions,
+.msgActions:focus-within {
+  opacity: 1;
+}
+.shareMsgBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font: 500 12px/1 "Inter", sans-serif;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+.shareMsgBtn:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+  border-color: var(--text-muted);
+}

--- a/web/components/chat/MessageList.tsx
+++ b/web/components/chat/MessageList.tsx
@@ -29,6 +29,45 @@ function FeynmanGlyph() {
   );
 }
 
+/** macOS-style share glyph (box + up arrow), matching the session-share icon. */
+function ShareGlyph() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+      <polyline points="8 6 12 2 16 6" />
+      <line x1="12" y1="2" x2="12" y2="14" />
+    </svg>
+  );
+}
+
+/** Hover "Share" action under an assistant/mind answer (per-turn share entry). */
+function ShareAnswerAction({ onClick }: { onClick: () => void }) {
+  return (
+    <div className={styles.msgActions}>
+      <button
+        type="button"
+        className={styles.shareMsgBtn}
+        onClick={onClick}
+        aria-label="Share this answer"
+        title="Share this answer"
+      >
+        <ShareGlyph />
+        <span>Share</span>
+      </button>
+    </div>
+  );
+}
+
 /**
  * Build assistant body HTML with citation markers replaced by a sentinel we can
  * tokenize into React nodes (so the hover popover is a real component, not an
@@ -129,7 +168,15 @@ const SKILL_LABELS: Record<string, string> = {
   llm_knowledge: "LLM Knowledge",
 };
 
-function AssistantMessage({ msg }: { msg: Message }) {
+function AssistantMessage({
+  msg,
+  index,
+  onShare,
+}: {
+  msg: Message;
+  index: number;
+  onShare?: (index: number) => void;
+}) {
   const refs = msg.opts?.references || [];
   const webSrcs = msg.opts?.webSources || [];
   const usage = msg.opts?.usage;
@@ -226,6 +273,7 @@ function AssistantMessage({ msg }: { msg: Message }) {
             {usage.total_tokens} tokens
           </div>
         )}
+        {onShare && <ShareAnswerAction onClick={() => onShare(index)} />}
       </div>
     </div>
   );
@@ -361,7 +409,15 @@ function renderUserHtml(
   return prefixed ? prefixed + " " + html : html;
 }
 
-function MindMessage({ msg }: { msg: Message }) {
+function MindMessage({
+  msg,
+  index,
+  onShare,
+}: {
+  msg: Message;
+  index: number;
+  onShare?: (index: number) => void;
+}) {
   const name = msg.mindName || "";
   const raw = String(msg.content ?? "");
   const prefixRe = new RegExp(
@@ -393,6 +449,7 @@ function MindMessage({ msg }: { msg: Message }) {
             {usage.total_tokens} tokens
           </div>
         )}
+        {onShare && <ShareAnswerAction onClick={() => onShare(index)} />}
       </div>
     </div>
   );
@@ -430,19 +487,26 @@ function JoinNotice({ names }: { names: string[] }) {
 export default function MessageList({
   messages,
   knownMindNames = [],
+  onShareMessage,
 }: {
   messages: Message[];
   knownMindNames?: string[];
+  /** When provided, each assistant/mind answer shows a hover "Share" action
+   *  that publishes that single turn (index = position in this list, which
+   *  matches the persisted transcript order the backend indexes by). */
+  onShareMessage?: (index: number) => void;
 }) {
   return (
     <>
       {messages.map((msg, i) => {
-        if (msg.role === "mind") return <MindMessage key={i} msg={msg} />;
+        if (msg.role === "mind")
+          return <MindMessage key={i} msg={msg} index={i} onShare={onShareMessage} />;
         if (msg.role === "system-notice")
           return <JoinNotice key={i} names={msg.mindNames || []} />;
         if (msg.role === "error-notice")
           return <ErrorNotice key={i} text={msg.content} />;
-        if (msg.role === "assistant") return <AssistantMessage key={i} msg={msg} />;
+        if (msg.role === "assistant")
+          return <AssistantMessage key={i} msg={msg} index={i} onShare={onShareMessage} />;
         return <UserMessage key={i} msg={msg} knownMindNames={knownMindNames} />;
       })}
     </>

--- a/web/components/chat/ShareModal.tsx
+++ b/web/components/chat/ShareModal.tsx
@@ -8,23 +8,24 @@
  * now holds only the clean popup that surfaces the public link with Copy / Open
  * / Make private — the affordance ChatGPT/Claude show after you share.
  *
- * Reuses the .publish-toast classes. Auto-publish model: POST /share sets
- * public_status 'approved' immediately; the public URL is /discussions/{id}.
+ * Reuses the .publish-toast classes. Auto-publish model: the /share endpoint
+ * sets public_status 'approved' immediately. Used for BOTH whole-session shares
+ * (URL /discussions/{id}) and per-turn answer shares (URL /a/{id}); the
+ * make-private action is caller-provided since the withdraw endpoint differs.
  */
 
 import { useState } from "react";
-import { post } from "@/lib/api";
 
 export function PublishToast({
   url,
-  sessionId,
   onClose,
-  onUnshared,
+  onWithdraw,
 }: {
   url: string;
-  sessionId: string;
   onClose: () => void;
-  onUnshared: () => void;
+  /** Make-private action. The caller owns the endpoint (session vs single
+   *  answer) + any local state updates; the toast only confirms and invokes it. */
+  onWithdraw: () => Promise<void>;
 }) {
   const [copied, setCopied] = useState(false);
 
@@ -41,22 +42,21 @@ export function PublishToast({
   const unshare = async () => {
     if (
       !window.confirm(
-        "Make this conversation private again? The public link will stop working immediately.",
+        "Make this private again? The public link will stop working immediately.",
       )
     )
       return;
     try {
-      await post(`/api/chat-sessions/${encodeURIComponent(sessionId)}/withdraw`);
-      onUnshared();
+      await onWithdraw();
     } catch {
-      /* fail silently — user can retry */
+      /* fail silently — caller handles errors */
     }
   };
 
   return (
     <div className="publish-toast">
       <p className="publish-toast-title">Published</p>
-      <p className="publish-toast-msg">Anyone with this link can read the conversation.</p>
+      <p className="publish-toast-msg">Anyone with this link can read it.</p>
       <div className="publish-toast-link-row">
         <input className="publish-toast-url" readOnly value={url} onFocus={(e) => e.target.select()} />
         <button className="publish-toast-copy" onClick={copy}>


### PR DESCRIPTION
Replaces #90 (auto-closed when its stacked base #86 merged). Hover "Share" on each assistant/mind answer → per-turn endpoint → PublishToast. See #90 for detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)