### PR TITLE
fix(share): real speakers + drop blank notice + render markdown on public pages

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2764,7 +2764,7 @@ def list_messages_for_public_session(
         # Single round-trip: gate on approved status by joining the
         # parent session row.
         rows = _fetchall(conn, _q(
-            """SELECT sm.id, sm.role, sm.content, sm.created_at
+            """SELECT sm.id, sm.role, sm.content, sm.meta_json, sm.created_at
                FROM session_messages sm
                JOIN chat_sessions cs ON cs.id = sm.session_id
                WHERE sm.session_id = ?
@@ -2772,7 +2772,18 @@ def list_messages_for_public_session(
                ORDER BY sm.created_at ASC
                LIMIT ?"""
         ), (session_id, limit))
-        return [dict(r) for r in rows]
+        out = []
+        for r in rows:
+            d = dict(r)
+            # Parse per-message meta so the renderer can attribute a 'mind' turn
+            # to the mind that spoke (meta.mindName); without it every speaker
+            # falls back to "Feynman".
+            try:
+                d["meta"] = json.loads(d.pop("meta_json", None) or "{}")
+            except Exception:
+                d["meta"] = {}
+            out.append(d)
+        return out
 
 
 # ─── Shared single answers (per-turn share — share redesign Phase 2) ───

--- a/app/main.py
+++ b/app/main.py
@@ -4383,13 +4383,26 @@ def api_public_discussion(session_id: str) -> JSONResponse:
         raw_msgs = list_messages_for_public_session(session_id)
     except Exception:
         raw_msgs = []
-    messages = [
-        {
-            "role": m.get("role", ""),
-            "content": ugc_module.scrub_pii_for_public_display(m.get("content", "") or ""),
-        }
-        for m in raw_msgs
-    ]
+    messages = []
+    for m in raw_msgs:
+        role = m.get("role") or ""
+        # Drop the "minds joined" system notices (they're empty → blank bubbles).
+        if role == "system-notice":
+            continue
+        content = ugc_module.scrub_pii_for_public_display(m.get("content", "") or "")
+        if not content.strip():
+            continue
+        # Speaker label: a 'mind' turn carries the mind's name in meta; the
+        # default answerer is Feynman; a 'user' turn is the asker (rendered as
+        # "Question" client-side). Without this every reply showed as "Feynman".
+        meta = m.get("meta") or {}
+        if role == "mind":
+            speaker = meta.get("mindName") or "A great mind"
+        elif role == "assistant":
+            speaker = "Feynman"
+        else:
+            speaker = ""
+        messages.append({"role": role, "content": content, "speaker": speaker})
     # Resolve the entity's slug so the discussion's backlink to its book/mind
     # skips the 301 hop (entity_id is a uuid). One lookup, cached with the page;
     # book sessions point at an agent, mind sessions at a mind.

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -2185,3 +2185,38 @@ class TestPublicJsonDatetimeSerialization:
         body = json.loads(resp.body)
         assert body["id"] == "aid"
         assert isinstance(body["approved_at"], str) and body["approved_at"]
+
+
+class TestPublicDiscussionRender:
+    """The /discussions/{id} payload must attribute each turn to its real speaker
+    (a mind's name, not always "Feynman") and drop the empty "minds joined"
+    system-notice (which rendered as a blank bubble)."""
+
+    def test_speaker_attribution_and_system_notice_filtered(self, monkeypatch):
+        import os, uuid, json
+        os.environ.pop("DATABASE_URL", None)
+        from app import main
+        from app.core.db import (
+            init_db, create_chat_session, add_session_message, get_conn, _execute, _q,
+        )
+        init_db()
+        uid = f"user-{uuid.uuid4().hex[:8]}"
+        sid = create_chat_session(title="Q", session_type="chat", user_id=uid)["id"]
+        add_session_message(sid, role="user", content="What are the key ideas?", user_id=uid)
+        add_session_message(sid, role="assistant", content="Feynman's take.", user_id=uid)
+        add_session_message(sid, role="system-notice", content="",
+                            meta={"mindNames": ["Karl Marx"]}, user_id=uid)
+        add_session_message(sid, role="mind", content="A dialectical view.",
+                            meta={"mindName": "Karl Marx"}, user_id=uid)
+        with get_conn() as c:
+            _execute(c, _q("UPDATE chat_sessions SET public_status = 'approved' WHERE id = ?"), (sid,))
+        monkeypatch.setattr(main.ugc_module, "is_enabled", lambda: True)
+        resp = main.api_public_discussion(sid)
+        body = json.loads(resp.body)
+        roles = [m["role"] for m in body["messages"]]
+        assert "system-notice" not in roles, "empty system-notice must be dropped (no blank bubble)"
+        mind_msgs = [m for m in body["messages"] if m["role"] == "mind"]
+        assert mind_msgs and mind_msgs[0]["speaker"] == "Karl Marx", \
+            "a mind turn must be attributed to the mind, not 'Feynman'"
+        asst = [m for m in body["messages"] if m["role"] == "assistant"]
+        assert asst and asst[0]["speaker"] == "Feynman"

--- a/web/app/a/[id]/page.tsx
+++ b/web/app/a/[id]/page.tsx
@@ -12,6 +12,14 @@ import {
   dropNulls,
   type PublicAnswer,
 } from "@/lib/seo-mind";
+import { renderMarkdown } from "@/components/chat/markdown";
+
+// Render the (already PII-scrubbed) answer as markdown. renderMarkdown
+// HTML-escapes all text; PII scrub strips http(s) URLs, so we also neutralize
+// any remaining non-http href so a crafted markdown link can't XSS this page.
+function renderSafe(md: string): string {
+  return renderMarkdown(md).replace(/href="(?!https?:\/\/)[^"]*"/gi, 'href="#"');
+}
 
 // A single approved, PII-scrubbed shared answer (share redesign Phase 2).
 // Data comes from GET /api/public-answers/{id} (gated on
@@ -219,9 +227,10 @@ export default async function SharedAnswerPage({
             )}
           </span>
         </div>
-        {(ans.answer || "").split(/\n{2,}/).map((para, i) => (
-          <p key={i}>{para}</p>
-        ))}
+        <div
+          className="discussion-md"
+          dangerouslySetInnerHTML={{ __html: renderSafe(ans.answer || "") }}
+        />
       </section>
 
       {isMind && ans.mind?.voice ? (

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -9,6 +9,16 @@ import {
   fetchPublicDiscussion,
   metaDescription,
 } from "@/lib/seo-mind";
+import { renderMarkdown } from "@/components/chat/markdown";
+
+// Render the (already PII-scrubbed) message body as markdown. renderMarkdown
+// HTML-escapes all text, so the only injected markup is markdown's own tags.
+// PII scrub already strips http(s) URLs, so we additionally neutralize any
+// remaining non-http href (javascript:/data:/mailto:) — a crafted markdown link
+// must not XSS this PUBLIC page.
+function renderSafe(md: string): string {
+  return renderMarkdown(md).replace(/href="(?!https?:\/\/)[^"]*"/gi, 'href="#"');
+}
 
 // A single approved, PII-scrubbed public discussion. Data comes from
 // GET /api/public-discussions/{id} (mirrors the legacy public_session_page:
@@ -141,9 +151,12 @@ export default async function PublicDiscussionPage({
         {disc.messages.map((m, i) => (
           <div key={i} className={`discussion-msg discussion-${m.role}`}>
             <span className="discussion-role">
-              {m.role === "user" ? "Question" : "Feynman"}
+              {m.role === "user" ? "Question" : m.speaker || "Feynman"}
             </span>
-            <p>{m.content}</p>
+            <div
+              className="discussion-md"
+              dangerouslySetInnerHTML={{ __html: renderSafe(m.content) }}
+            />
           </div>
         ))}
       </section>

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -770,7 +770,8 @@ export interface PublicDiscussion {
   /** Descriptive slug of the linked book/mind (uuid fallback). Avoids the 301. */
   entity_slug?: string;
   approved_at: string;
-  messages: Array<{ role: string; content: string }>;
+  /** speaker: a mind answer's name (mind turns), "Feynman" (assistant), or "" (user). */
+  messages: Array<{ role: string; content: string; speaker?: string }>;
 }
 
 /**

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -602,7 +602,22 @@ body { background-color: var(--bg-home); }
   background: var(--accent-light);
   border: 1px solid var(--border);
 }
-.discussion-msg p { margin: 0; }
+/* A great mind's reply — neutral card + accent stripe, distinct from Feynman's
+   accent fill, so a multi-mind discussion reads as a real panel of voices. */
+.discussion-mind {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+}
+/* Markdown body inside a discussion message (renderSafe output). */
+.discussion-md > :first-child { margin-top: 0; }
+.discussion-md > :last-child { margin-bottom: 0; }
+.discussion-md p { margin: 0 0 0.7em; }
+.discussion-md ul, .discussion-md ol { margin: 0 0 0.7em; padding-left: 1.4em; }
+.discussion-md li { margin: 0.2em 0; }
+.discussion-md h2, .discussion-md h3, .discussion-md h4 { margin: 0.8em 0 0.4em; font-weight: 600; }
+.discussion-md strong { font-weight: 600; }
+.discussion-md code { font-family: ui-monospace, Menlo, monospace; font-size: 0.9em; }
 
 /* ── Shared single answer (/a/[id]) ───────────────────────────────────── */
 .answer-question { margin-bottom: 0.3em; }


### PR DESCRIPTION
Fixes the shared-discussion render quality issues found in the signed-in spot-check (a shared session showed every speaker as **Feynman**, a **blank bubble** for the 'minds joined' notice, and a **raw-text wall** with literal `**`).

- **backend**: `list_messages_for_public_session` returns per-message `meta`; `api_public_discussion` attaches a **`speaker`** (mind name for mind turns, 'Feynman' for assistant) and **drops** the system-notice + empty turns.
- **web**: `/discussions/[id]` shows the real speaker and renders the body as **markdown** (`renderMarkdown` — HTML-escaped; non-http hrefs neutralized to prevent XSS on these public pages). Same markdown fix applied to `/a/[id]`. New `.discussion-mind` (accent-stripe card) + `.discussion-md` prose styles.
- **test**: `TestPublicDiscussionRender` — speaker attribution + system-notice filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)