### PR TITLE
fix(share): render a shared chat with the real chat transcript (ChatGPT/Claude-style)

### DIFF
--- a/app/core/ugc.py
+++ b/app/core/ugc.py
@@ -86,6 +86,14 @@ _URL_RE = re.compile(
 # Handles like @username and #hashtags often carry identity. Strip.
 _AT_HANDLE_RE = re.compile(r"(?<!\w)@[A-Za-z0-9_]{2,30}\b")
 
+# Markdown links whose target is a dangerous URL scheme. The public renderers
+# run scrubbed text through a markdown→HTML pass, so a crafted
+# ``[x](javascript:…)`` would otherwise become a clickable script link on a
+# PUBLIC page. Strip the scheme (keeping the link text) — XSS hardening.
+_DANGEROUS_LINK_RE = re.compile(
+    r"(?i)(\]\(\s*)(?:javascript|data|vbscript|file)\s*:"
+)
+
 
 def scrub_pii_for_public_display(text: str) -> str:
     """Run the four redactors. Returns the sanitized string. The
@@ -98,6 +106,7 @@ def scrub_pii_for_public_display(text: str) -> str:
     out = _URL_RE.sub("[link redacted]", out)
     out = _PHONE_RE.sub("[phone redacted]", out)
     out = _AT_HANDLE_RE.sub("[handle redacted]", out)
+    out = _DANGEROUS_LINK_RE.sub(r"\1", out)
     return out
 
 

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -2220,3 +2220,26 @@ class TestPublicDiscussionRender:
             "a mind turn must be attributed to the mind, not 'Feynman'"
         asst = [m for m in body["messages"] if m["role"] == "assistant"]
         assert asst and asst[0]["speaker"] == "Feynman"
+
+
+class TestScrubNeutralizesDangerousLinks:
+    """The public pages render scrubbed text through a markdown→HTML pass, so a
+    crafted markdown link with a dangerous scheme must be neutralized to prevent
+    stored XSS on these public pages."""
+
+    def test_javascript_link_scheme_stripped(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("click [here](javascript:alert(1)) now")
+        assert "javascript:" not in out.lower()
+        assert "[here]" in out  # link text preserved, only the scheme removed
+
+    def test_data_and_vbscript_schemes_stripped(self):
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("[a](data:text/html,x) [b](vbscript:msgbox)")
+        assert "data:" not in out.lower() and "vbscript:" not in out.lower()
+
+    def test_plain_prose_colon_not_touched(self):
+        # Only markdown-link targets are neutralized — benign prose is untouched.
+        from app.core import ugc
+        out = ugc.scrub_pii_for_public_display("Note: the data: prefix appears here.")
+        assert "Note: the data: prefix appears here." == out

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -9,16 +9,8 @@ import {
   fetchPublicDiscussion,
   metaDescription,
 } from "@/lib/seo-mind";
-import { renderMarkdown } from "@/components/chat/markdown";
-
-// Render the (already PII-scrubbed) message body as markdown. renderMarkdown
-// HTML-escapes all text, so the only injected markup is markdown's own tags.
-// PII scrub already strips http(s) URLs, so we additionally neutralize any
-// remaining non-http href (javascript:/data:/mailto:) — a crafted markdown link
-// must not XSS this PUBLIC page.
-function renderSafe(md: string): string {
-  return renderMarkdown(md).replace(/href="(?!https?:\/\/)[^"]*"/gi, 'href="#"');
-}
+import MessageList from "@/components/chat/MessageList";
+import type { Message } from "@/lib/chat";
 
 // A single approved, PII-scrubbed public discussion. Data comes from
 // GET /api/public-discussions/{id} (mirrors the legacy public_session_page:
@@ -139,6 +131,22 @@ export default async function PublicDiscussionPage({
     [title, canonical],
   ]);
 
+  // Render the shared transcript with the SAME component the live chat uses, so
+  // a shared conversation looks exactly like it does in-app (Feynman + mind
+  // avatars, names, markdown) — read-only (no composer, no per-message share).
+  const transcript: Message[] = disc.messages.map((m): Message =>
+    m.role === "mind"
+      ? { role: "mind", content: m.content, mindName: m.speaker || "A great mind" }
+      : m.role === "assistant"
+        ? { role: "assistant", content: m.content }
+        : { role: "user", content: m.content },
+  );
+  const knownMindNames = [
+    ...new Set(
+      disc.messages.filter((m) => m.role === "mind").map((m) => m.speaker || ""),
+    ),
+  ].filter(Boolean) as string[];
+
   return (
     <SeoColumn>
       <JsonLd data={forumLd} />
@@ -147,19 +155,9 @@ export default async function PublicDiscussionPage({
       <h1>{title}</h1>
       <p className="seo-meta">Shared by {disc.handle || "Anonymous"}</p>
 
-      <section className="seo-section discussion-thread">
-        {disc.messages.map((m, i) => (
-          <div key={i} className={`discussion-msg discussion-${m.role}`}>
-            <span className="discussion-role">
-              {m.role === "user" ? "Question" : m.speaker || "Feynman"}
-            </span>
-            <div
-              className="discussion-md"
-              dangerouslySetInnerHTML={{ __html: renderSafe(m.content) }}
-            />
-          </div>
-        ))}
-      </section>
+      <div className="shared-transcript">
+        <MessageList messages={transcript} knownMindNames={knownMindNames} />
+      </div>
 
       <p className="seo-cta-row">
         <a className="primary" href={readerHref}>

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -619,6 +619,10 @@ body { background-color: var(--bg-home); }
 .discussion-md strong { font-weight: 600; }
 .discussion-md code { font-family: ui-monospace, Menlo, monospace; font-size: 0.9em; }
 
+/* Public shared transcript (/discussions/[id]) reuses the in-app MessageList so
+   a shared chat looks like the chat; center it to the chat's column width. */
+.shared-transcript { max-width: 780px; margin: 1.5em auto 0; }
+
 /* ── Shared single answer (/a/[id]) ───────────────────────────────────── */
 .answer-question { margin-bottom: 0.3em; }
 .answer-card {


### PR DESCRIPTION
Follow-up to the render fix. The shared `/discussions/{id}` page was a bespoke forum-style layout; ChatGPT/Claude render a shared chat **identically to the in-app chat** (same avatars, bubbles, markdown), read-only. This swaps the custom markup for the app's real **`MessageList`** component, so a shared conversation looks like the conversation — Feynman glyph avatar, mind colored avatars + names, real markdown.

- **web**: `/discussions/[id]` renders `<MessageList>` (read-only) in a centered `.shared-transcript`; maps the public `speaker` → mind name.
- **backend**: `scrub_pii_for_public_display` now neutralizes dangerous markdown-link schemes (`javascript:`/`data:`/`vbscript:`/`file:`) — since the public renderer runs markdown→HTML, this prevents stored XSS on public pages.
- **test**: scheme neutralization (+ the earlier speaker/filter test still guards the payload).

Note: I can't preview visually in-sandbox; CI confirms it builds — please eyeball the rendered page on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)