### PR TITLE
feat(share): "Continue this conversation" (fork) + clean shared-page shell

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2786,6 +2786,43 @@ def list_messages_for_public_session(
         return out
 
 
+def fork_public_discussion(
+    session_id: str, viewer_user_id: str, limit: int = 200,
+) -> dict[str, Any] | None:
+    """Copy an APPROVED public discussion into a NEW session owned by the viewer
+    so they can continue it (ChatGPT-style "Continue this conversation").
+
+    The message CONTENT is PII-scrubbed (the viewer must not receive the
+    sharer's raw PII), but each message's structured meta (mindName,
+    contextBooks/contextMinds, sources) is preserved so the conversation's
+    context carries over. Returns the new session row, or None if the source
+    isn't approved / not found.
+    """
+    from .ugc import scrub_pii_for_public_display
+
+    src = get_chat_session_with_public_status(session_id)
+    if not src or src.get("public_status") != "approved":
+        return None
+    src_msgs = list_messages_for_public_session(session_id, limit=limit)
+    new = create_chat_session(
+        title=src.get("public_title") or src.get("title") or "Shared conversation",
+        session_type=src.get("session_type") or "chat",
+        mind_id=src.get("mind_id"),
+        meta={"forked_from": session_id},
+        user_id=viewer_user_id,
+    )
+    new_id = new["id"]
+    for m in src_msgs:
+        add_session_message(
+            new_id,
+            role=m.get("role") or "assistant",
+            content=scrub_pii_for_public_display(m.get("content") or ""),
+            meta=m.get("meta") or {},
+            user_id=viewer_user_id,
+        )
+    return new
+
+
 # ─── Shared single answers (per-turn share — share redesign Phase 2) ───
 #
 # A "shared answer" is ONE assistant/mind turn published as a standalone

--- a/app/main.py
+++ b/app/main.py
@@ -62,6 +62,7 @@ from .core.db import (
     list_books_for_mind,
     list_messages,
     list_messages_for_public_session,
+    fork_public_discussion,
     list_mind_recent_topics,
     list_minds,
     list_minds_active_for_agent,
@@ -4434,6 +4435,22 @@ def api_public_discussion(session_id: str) -> JSONResponse:
         }),
         headers={"Cache-Control": "public, max-age=600, s-maxage=600"},
     )
+
+
+@app.post("/api/public-discussions/{session_id}/continue")
+def api_continue_discussion(session_id: str, request: Request):
+    """Fork an approved public discussion into a NEW session owned by the
+    signed-in viewer, so they can continue it (ChatGPT-style "Continue this
+    conversation"). 401 if not signed in (the client bounces to /login); 404 if
+    the discussion isn't viewable. Returns the new session id + chat url."""
+    _require_ugc_enabled()
+    uid = _get_user_id(request)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    new = fork_public_discussion(session_id, uid)
+    if not new:
+        raise HTTPException(status_code=404, detail="Discussion not found")
+    return {"session_id": new["id"], "url": f"/chat/{new['id']}"}
 
 
 # ─── Chat sessions endpoints ───

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -2243,3 +2243,47 @@ class TestScrubNeutralizesDangerousLinks:
         from app.core import ugc
         out = ugc.scrub_pii_for_public_display("Note: the data: prefix appears here.")
         assert "Note: the data: prefix appears here." == out
+
+
+class TestForkPublicDiscussion:
+    """`Continue this conversation` forks an approved discussion into a NEW
+    session owned by the viewer — copying the transcript (PII-scrubbed, meta
+    preserved) so they can keep chatting with the same context."""
+
+    def test_fork_copies_transcript_scrubbed_owned_by_viewer(self):
+        import os, uuid
+        os.environ.pop("DATABASE_URL", None)
+        from app.core.db import (
+            init_db, create_chat_session, add_session_message,
+            fork_public_discussion, list_session_messages, get_conn, _execute, _q,
+        )
+        init_db()
+        sharer = f"sharer-{uuid.uuid4().hex[:8]}"
+        viewer = f"viewer-{uuid.uuid4().hex[:8]}"
+        sid = create_chat_session(
+            title="Q", session_type="mind", mind_id="mind-1", user_id=sharer,
+        )["id"]
+        add_session_message(sid, role="user", content="Email me at a@b.com", user_id=sharer)
+        add_session_message(sid, role="mind", content="A dialectical view.",
+                            meta={"mindName": "Karl Marx"}, user_id=sharer)
+        with get_conn() as c:
+            _execute(c, _q("UPDATE chat_sessions SET public_status = 'approved' WHERE id = ?"), (sid,))
+
+        new = fork_public_discussion(sid, viewer)
+        assert new and new["id"] != sid, "fork creates a NEW session"
+        assert new["user_id"] == viewer, "owned by the viewer, not the sharer"
+        assert new["session_type"] == "mind" and new["mind_id"] == "mind-1", "entity re-seeded"
+
+        msgs = list_session_messages(new["id"], viewer)
+        assert len(msgs) == 2, "full transcript copied"
+        assert "a@b.com" not in msgs[0]["content"] and "[email redacted]" in msgs[0]["content"], \
+            "content PII-scrubbed (viewer must not get the sharer's PII)"
+        assert msgs[1]["meta"].get("mindName") == "Karl Marx", "mind attribution preserved"
+
+    def test_fork_refuses_unapproved(self):
+        import os, uuid
+        os.environ.pop("DATABASE_URL", None)
+        from app.core.db import init_db, create_chat_session, fork_public_discussion
+        init_db()
+        sid = create_chat_session(title="x", user_id="u1")["id"]  # private, not approved
+        assert fork_public_discussion(sid, "viewer") is None

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   metaDescription,
 } from "@/lib/seo-mind";
 import MessageList from "@/components/chat/MessageList";
+import ContinueDiscussionButton from "@/components/chat/ContinueDiscussionButton";
 import type { Message } from "@/lib/chat";
 
 // A single approved, PII-scrubbed public discussion. Data comes from
@@ -107,15 +108,6 @@ export default async function PublicDiscussionPage({
       : entityRef
         ? `/mind/${entityRef}`
         : null;
-  // "Start your own conversation" → the chat surface (real paths, not dead
-  // /#/ hashes): a book → composer preselected; a mind → its 1:1 chat page.
-  const readerHref =
-    entityRef && disc.session_type === "book"
-      ? `/?book=${encodeURIComponent(entityRef)}`
-      : entityRef
-        ? `/mind/${encodeURIComponent(entityRef)}/chat`
-        : `/`;
-
   const forumLd = {
     "@context": "https://schema.org",
     "@type": "DiscussionForumPosting",
@@ -152,27 +144,29 @@ export default async function PublicDiscussionPage({
       <JsonLd data={forumLd} />
       <JsonLd data={breadcrumbLd} />
 
-      <h1>{title}</h1>
-      <p className="seo-meta">Shared by {disc.handle || "Anonymous"}</p>
+      {/* h1 kept for SEO but visually hidden — the chat itself has no big title;
+          the question is the first turn of the transcript below. */}
+      <h1 className="sr-only">{title}</h1>
+      <div className="shared-banner">
+        <span className="shared-banner-label">Shared conversation on Feynman</span>
+        <span className="shared-banner-by">Shared by {disc.handle || "Anonymous"}</span>
+      </div>
 
       <div className="shared-transcript">
         <MessageList messages={transcript} knownMindNames={knownMindNames} />
       </div>
 
-      <p className="seo-cta-row">
-        <a className="primary" href={readerHref}>
-          Start your own conversation →
-        </a>
-        {entityHref ? (
-          <Link className="secondary" href={entityHref}>
-            More discussions
-          </Link>
-        ) : (
-          <Link className="secondary" href="/library">
-            Browse the library
-          </Link>
-        )}
-      </p>
+      <div className="shared-cta">
+        <ContinueDiscussionButton id={params.id} />
+        <Link
+          className="shared-cta-alt"
+          href={entityHref || "/library"}
+        >
+          {entityHref
+            ? `More from this ${disc.session_type === "book" ? "book" : "mind"}`
+            : "Browse the library"}
+        </Link>
+      </div>
     </SeoColumn>
   );
 }

--- a/web/components/chat/ContinueDiscussionButton.tsx
+++ b/web/components/chat/ContinueDiscussionButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * "Continue this conversation" — the ChatGPT-style fork CTA on a public shared
+ * discussion (/discussions/[id]). POSTs to /continue, which copies the shared
+ * transcript into a NEW session owned by the signed-in viewer, then routes them
+ * into the live chat to keep going. Signed-out → bounce to /login.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { post, ApiError } from "@/lib/api";
+
+export default function ContinueDiscussionButton({ id }: { id: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const onClick = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await post<{ session_id: string; url?: string }>(
+        `/api/public-discussions/${encodeURIComponent(id)}/continue`,
+      );
+      router.push(res.url || `/chat/${res.session_id}`);
+    } catch (e) {
+      // Signed out → go authenticate, then they can continue. Other errors →
+      // re-enable so they can retry.
+      if (e instanceof ApiError && e.status === 401) {
+        router.push("/login");
+      } else {
+        setBusy(false);
+      }
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="shared-continue-btn"
+      onClick={onClick}
+      disabled={busy}
+    >
+      {busy ? "Starting…" : "Continue this conversation →"}
+    </button>
+  );
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -621,7 +621,39 @@ body { background-color: var(--bg-home); }
 
 /* Public shared transcript (/discussions/[id]) reuses the in-app MessageList so
    a shared chat looks like the chat; center it to the chat's column width. */
-.shared-transcript { max-width: 780px; margin: 1.5em auto 0; }
+.shared-transcript { max-width: 780px; margin: 0.5em auto 0; }
+
+/* Screen-reader-only (SEO h1 kept, visually hidden — the chat has no big title). */
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
+
+/* Slim "shared conversation" banner — like Claude/ChatGPT's share header. */
+.shared-banner {
+  max-width: 780px; margin: 0 auto; padding: 9px 14px;
+  display: flex; justify-content: space-between; align-items: center; gap: 12px;
+  font-size: 13px; color: var(--text-muted);
+  background: var(--bg-elev); border: 1px solid var(--border);
+  border-radius: var(--r-control);
+}
+.shared-banner-by { white-space: nowrap; }
+
+/* Footer CTA: a single clean "Continue this conversation" (ChatGPT-style fork)
+   + a subtle secondary link. */
+.shared-cta {
+  max-width: 780px; margin: 8px auto 0; padding: 16px 0 8px;
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+}
+.shared-continue-btn {
+  background: var(--accent); color: #fff; border: 0; cursor: pointer;
+  padding: 11px 22px; border-radius: var(--r-pill, 999px);
+  font: 600 15px/1 "Inter", sans-serif; transition: filter 0.15s;
+}
+.shared-continue-btn:hover { filter: brightness(1.06); }
+.shared-continue-btn:disabled { opacity: 0.6; cursor: default; }
+.shared-cta-alt { font-size: 13px; color: var(--text-muted); text-decoration: none; }
+.shared-cta-alt:hover { color: var(--text); text-decoration: underline; }
 
 /* ── Shared single answer (/a/[id]) ───────────────────────────────────── */
 .answer-question { margin-bottom: 0.3em; }


### PR DESCRIPTION
Makes a shared chat **look and behave like the in-app chat**, with the ChatGPT-style **Continue this conversation** you preferred over Claude's start-fresh.

### Continue (fork)
- `POST /api/public-discussions/{id}/continue` → `fork_public_discussion` copies the shared transcript into a **new session owned by the signed-in viewer** (PII-scrubbed content, per-message meta like mindName/contextBooks preserved so context carries over), then the client routes to `/chat/{id}` to keep chatting. Signed-out → `/login`.
- New `ContinueDiscussionButton` client component.

### Shell cleanup (the "too ugly / truncated" fixes)
- Dropped the big SEO serif `<h1>` (kept `sr-only` for crawlers) and the two-button SEO footer.
- Added a slim **"Shared conversation · Shared by X"** banner (Claude/ChatGPT-style) + a single **"Continue this conversation →"** CTA.
- The full question is now the first transcript turn — no more truncated auto-title.

### Tests
`TestForkPublicDiscussion` — fork copies the transcript, scrubs PII, owns it to the viewer, re-seeds type/mind_id, and refuses unapproved.

Note: signed-in continue is the clean path (verified logic + pytest); signed-out bounces to `/login` (auto-return after login is a follow-up). Can't preview visually in-sandbox — please eyeball on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)