### PR TITLE
feat(share): auto-continue after login + drop dead discussion CSS

### DIFF
--- a/web/components/auth/LoginForm.tsx
+++ b/web/components/auth/LoginForm.tsx
@@ -72,7 +72,13 @@ export default function LoginForm() {
       setAgreed(false);
       return;
     }
-    router.push("/");
+    // Honor a same-site ?next= return path (e.g. "Continue this conversation"
+    // bounces here when signed out). Guard against open redirects.
+    const next =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("next")
+        : null;
+    router.push(next && next.startsWith("/") && !next.startsWith("//") ? next : "/");
   }
 
   return (

--- a/web/components/chat/ContinueDiscussionButton.tsx
+++ b/web/components/chat/ContinueDiscussionButton.tsx
@@ -4,19 +4,22 @@
  * "Continue this conversation" — the ChatGPT-style fork CTA on a public shared
  * discussion (/discussions/[id]). POSTs to /continue, which copies the shared
  * transcript into a NEW session owned by the signed-in viewer, then routes them
- * into the live chat to keep going. Signed-out → bounce to /login.
+ * into the live chat to keep going.
+ *
+ * Signed-out flow: 401 → bounce to /login with a ?next= back here carrying
+ * ?continue=1, so after login we land back and auto-continue once.
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { post, ApiError } from "@/lib/api";
 
 export default function ContinueDiscussionButton({ id }: { id: string }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
+  const autofired = useRef(false);
 
-  const onClick = async () => {
-    if (busy) return;
+  const go = async (fromAutofire: boolean) => {
     setBusy(true);
     try {
       const res = await post<{ session_id: string; url?: string }>(
@@ -24,21 +27,32 @@ export default function ContinueDiscussionButton({ id }: { id: string }) {
       );
       router.push(res.url || `/chat/${res.session_id}`);
     } catch (e) {
-      // Signed out → go authenticate, then they can continue. Other errors →
-      // re-enable so they can retry.
-      if (e instanceof ApiError && e.status === 401) {
-        router.push("/login");
+      // Signed out → log in, then return here and auto-continue. Don't loop if
+      // the auto-continue itself 401s.
+      if (e instanceof ApiError && e.status === 401 && !fromAutofire) {
+        const back = `/discussions/${encodeURIComponent(id)}?continue=1`;
+        router.push(`/login?next=${encodeURIComponent(back)}`);
       } else {
         setBusy(false);
       }
     }
   };
 
+  // Returning from login with ?continue=1 → auto-continue once.
+  useEffect(() => {
+    if (autofired.current || typeof window === "undefined") return;
+    if (new URLSearchParams(window.location.search).get("continue") === "1") {
+      autofired.current = true;
+      void go(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <button
       type="button"
       className="shared-continue-btn"
-      onClick={onClick}
+      onClick={() => !busy && go(false)}
       disabled={busy}
     >
       {busy ? "Starting…" : "Continue this conversation →"}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -590,26 +590,9 @@ body { background-color: var(--bg-home); }
     var(--depth-3);
 }
 
-/* ── Public discussion thread (/discussions/[id]) ─────────────────────── */
-.discussion-thread { display: flex; flex-direction: column; gap: 16px; }
-.discussion-msg { padding: 12px 16px; border-radius: var(--r-control); }
-.discussion-msg .discussion-role {
-  display: block; font-size: 12px; font-weight: 600;
-  color: var(--text-muted); margin-bottom: 4px;
-}
-.discussion-user { background: var(--bg-chat); }
-.discussion-assistant {
-  background: var(--accent-light);
-  border: 1px solid var(--border);
-}
-/* A great mind's reply — neutral card + accent stripe, distinct from Feynman's
-   accent fill, so a multi-mind discussion reads as a real panel of voices. */
-.discussion-mind {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--accent);
-}
-/* Markdown body inside a discussion message (renderSafe output). */
+/* Markdown body inside a shared answer (/a/[id] renderSafe output). The old
+   .discussion-thread/.discussion-msg/.discussion-mind rules were removed once
+   /discussions/[id] switched to the real in-app MessageList. */
 .discussion-md > :first-child { margin-top: 0; }
 .discussion-md > :last-child { margin-bottom: 0; }
 .discussion-md p { margin: 0 0 0.7em; }


### PR DESCRIPTION
Two share follow-ups.

- **Auto-continue after login**: signed-out "Continue this conversation" now bounces to `/login?next=/discussions/{id}?continue=1`; `LoginForm` honors a same-site `?next=` (guarded against open redirects), and `ContinueDiscussionButton` auto-fires the continue once on return. Signed-in path unchanged.
- **Dead CSS cleanup**: removed the leftover `.discussion-thread/.discussion-msg/.discussion-mind` rules (superseded when `/discussions/[id]` switched to the real `MessageList`); kept `.discussion-md` (still used by `/a/[id]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)