### PR TITLE
fix(share): show the share button on any answered chat (gate 3->2)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2257,7 +2257,7 @@ def get_chat_session_with_public_status(session_id: str) -> dict[str, Any] | Non
 def request_chat_session_share(
     session_id: str, user_id: str, handle: str | None = None,
     public_title: str | None = None,
-    min_message_count: int = 3, daily_share_limit: int = 10,
+    min_message_count: int = 2, daily_share_limit: int = 10,
 ) -> dict[str, Any] | str | None:
     """User opts in to making this session public.
 

--- a/app/main.py
+++ b/app/main.py
@@ -2533,7 +2533,7 @@ def api_chat_session_share(
     re-sharing updates handle/title but doesn't double-stamp consent.
 
     Two gates run before status flips, surfaced as distinct error codes:
-      * 422 ``too_few_messages`` — session has < 3 messages
+      * 422 ``too_few_messages`` — session has < 2 messages (no reply yet)
       * 429 ``rate_limited`` — user shared ≥ 10 sessions in last 24h
       * 404 ``not_found`` / ``rejected`` — session missing, not owned, or
         admin-rejected previously
@@ -2553,7 +2553,7 @@ def api_chat_session_share(
     if result == "too_few_messages":
         raise HTTPException(
             status_code=422,
-            detail="Chat needs at least 3 messages before it can be shared publicly.",
+            detail="Chat needs at least one reply before it can be shared publicly.",
         )
     if result == "rate_limited":
         raise HTTPException(

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1886,18 +1886,21 @@ class TestPhase6AutoPublishShare:
         assert result["public_handle"] == "@me"
         assert result["approved_at"]
 
-    def test_quality_gate_rejects_thin_sessions(self):
+    def test_quality_gate_rejects_unanswered_sessions(self):
+        # A lone question (1 message, no reply) can't be shared.
         from app.core.db import request_chat_session_share
         uid, sid = self._mk_session_with_messages(1)
         result = request_chat_session_share(sid, uid)
         assert result == "too_few_messages", \
-            "Sessions with <3 messages must be rejected to avoid thin pages"
+            "A session with no reply yet must be rejected"
 
-    def test_quality_gate_min_message_count_is_three(self):
-        # Boundary: exactly 3 messages passes; 2 does not.
+    def test_quality_gate_min_message_count_is_two(self):
+        # Boundary: exactly 2 messages (one Q + one reply) passes; 1 does not.
+        # Lowered from 3 → 2 so any answered chat is shareable (ChatGPT/Claude
+        # share any conversation).
         from app.core.db import request_chat_session_share
-        uid_pass, sid_pass = self._mk_session_with_messages(3)
-        uid_fail, sid_fail = self._mk_session_with_messages(2)
+        uid_pass, sid_pass = self._mk_session_with_messages(2)
+        uid_fail, sid_fail = self._mk_session_with_messages(1)
         assert isinstance(request_chat_session_share(sid_pass, uid_pass), dict)
         assert request_chat_session_share(sid_fail, uid_fail) == "too_few_messages"
 

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -42,10 +42,16 @@ export async function generateMetadata({
   const desc = metaDescription(
     `A public discussion shared by ${disc.handle} on Feynman.`,
   );
+  // Thin-content guard: now that any answered chat (≥2 messages) is shareable,
+  // don't index very short discussions — still renders + is shareable, just not
+  // crawled (protects the GSC index from thin pages).
+  const totalChars = disc.messages.reduce((n, m) => n + (m.content || "").length, 0);
+  const thin = totalChars < 400;
   return {
     title: `${title} — Feynman`,
     description: desc,
     alternates: { canonical },
+    robots: thin ? { index: false, follow: true } : undefined,
     openGraph: {
       type: "article",
       title,

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -276,7 +276,7 @@ export default function ChatView({
     } catch (e) {
       flashShareHint(
         e instanceof ApiError && e.status === 422
-          ? "Chat needs at least 3 messages to share."
+          ? "Send a message and get a reply before sharing."
           : apiErrorText(e, "Couldn’t publish — please try again."),
       );
     }
@@ -1028,7 +1028,10 @@ export default function ChatView({
 
   // ── Share eligibility: feature on + ≥3 messages (matches backend gate) ──
   // Write-book sessions are never share-eligible (they aren't discussions).
-  const shareEligible = !isWriteBook && featuresOn && messages.length >= 3;
+  // Share once there's at least one real exchange (a question + a reply = 2
+  // messages), matching ChatGPT/Claude (share any conversation). NOT gated by
+  // the related-books sidebar — purely message count + the feature flag.
+  const shareEligible = !isWriteBook && featuresOn && messages.length >= 2;
   const isPublic = publicStatus === "approved";
 
   // Show the book-canvas once there's an outline (after /start) or a writing


### PR DESCRIPTION
The session-share button vanished on short chats. Diagnosed from the code: it was **purely the `messages.length >= 3` gate**, not the RELATED BOOKS sidebar (the button lives in `.chat-main`, the left column — the sidebar can't hide it). Most book Q&As are 1 question + 1 answer = 2 messages, so the button never showed → looked like "RELATED BOOKS → no share."

- **Lower the gate to ≥2** (one real exchange), matching ChatGPT/Claude (share any conversation): frontend `shareEligible`, backend `min_message_count` 3→2, hint/422 copy, boundary test.
- **SEO guard**: noindex very short discussions (<400 chars) so lowering the gate doesn’t add thin pages to the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)