### PR TITLE
fix(share): drop the message-count threshold (any non-empty chat is shareable)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2257,7 +2257,7 @@ def get_chat_session_with_public_status(session_id: str) -> dict[str, Any] | Non
 def request_chat_session_share(
     session_id: str, user_id: str, handle: str | None = None,
     public_title: str | None = None,
-    min_message_count: int = 2, daily_share_limit: int = 10,
+    min_message_count: int = 1, daily_share_limit: int = 10,
 ) -> dict[str, Any] | str | None:
     """User opts in to making this session public.
 

--- a/app/main.py
+++ b/app/main.py
@@ -2533,7 +2533,7 @@ def api_chat_session_share(
     re-sharing updates handle/title but doesn't double-stamp consent.
 
     Two gates run before status flips, surfaced as distinct error codes:
-      * 422 ``too_few_messages`` — session has < 2 messages (no reply yet)
+      * 422 ``too_few_messages`` — session is empty (0 messages)
       * 429 ``rate_limited`` — user shared ≥ 10 sessions in last 24h
       * 404 ``not_found`` / ``rejected`` — session missing, not owned, or
         admin-rejected previously
@@ -2553,7 +2553,7 @@ def api_chat_session_share(
     if result == "too_few_messages":
         raise HTTPException(
             status_code=422,
-            detail="Chat needs at least one reply before it can be shared publicly.",
+            detail="Start the chat before sharing it.",
         )
     if result == "rate_limited":
         raise HTTPException(

--- a/tests/test_seo_pages.py
+++ b/tests/test_seo_pages.py
@@ -1886,23 +1886,15 @@ class TestPhase6AutoPublishShare:
         assert result["public_handle"] == "@me"
         assert result["approved_at"]
 
-    def test_quality_gate_rejects_unanswered_sessions(self):
-        # A lone question (1 message, no reply) can't be shared.
+    def test_share_allows_any_nonempty_session(self):
+        # No message-count threshold (ChatGPT/Claude share any conversation):
+        # a 1-message session shares; only a literally-empty (0-message) session
+        # is rejected as a sanity floor.
         from app.core.db import request_chat_session_share
-        uid, sid = self._mk_session_with_messages(1)
-        result = request_chat_session_share(sid, uid)
-        assert result == "too_few_messages", \
-            "A session with no reply yet must be rejected"
-
-    def test_quality_gate_min_message_count_is_two(self):
-        # Boundary: exactly 2 messages (one Q + one reply) passes; 1 does not.
-        # Lowered from 3 → 2 so any answered chat is shareable (ChatGPT/Claude
-        # share any conversation).
-        from app.core.db import request_chat_session_share
-        uid_pass, sid_pass = self._mk_session_with_messages(2)
-        uid_fail, sid_fail = self._mk_session_with_messages(1)
-        assert isinstance(request_chat_session_share(sid_pass, uid_pass), dict)
-        assert request_chat_session_share(sid_fail, uid_fail) == "too_few_messages"
+        uid_ok, sid_ok = self._mk_session_with_messages(1)
+        uid_empty, sid_empty = self._mk_session_with_messages(0)
+        assert isinstance(request_chat_session_share(sid_ok, uid_ok), dict)
+        assert request_chat_session_share(sid_empty, uid_empty) == "too_few_messages"
 
     def test_rejected_session_cannot_reshare(self):
         # If admin rejected a previous share, the user cannot bypass by

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -276,7 +276,7 @@ export default function ChatView({
     } catch (e) {
       flashShareHint(
         e instanceof ApiError && e.status === 422
-          ? "Send a message and get a reply before sharing."
+          ? "Start the chat before sharing it."
           : apiErrorText(e, "Couldn’t publish — please try again."),
       );
     }
@@ -1028,10 +1028,11 @@ export default function ChatView({
 
   // ── Share eligibility: feature on + ≥3 messages (matches backend gate) ──
   // Write-book sessions are never share-eligible (they aren't discussions).
-  // Share once there's at least one real exchange (a question + a reply = 2
-  // messages), matching ChatGPT/Claude (share any conversation). NOT gated by
-  // the related-books sidebar — purely message count + the feature flag.
-  const shareEligible = !isWriteBook && featuresOn && messages.length >= 2;
+  // No message-count threshold — the share button is available on any chat
+  // that has content (matches ChatGPT/Claude: share any conversation). The only
+  // floor is "non-empty" so it doesn't show on a blank new chat. NOT gated by
+  // the related-books sidebar.
+  const shareEligible = !isWriteBook && featuresOn && messages.length >= 1;
   const isPublic = publicStatus === "approved";
 
   // Show the book-canvas once there's an outline (after /start) or a writing


### PR DESCRIPTION
Removes the share message-count gate entirely (no ≥3, no ≥2). The share button now shows on **any chat with content** — matching ChatGPT/Claude (share any conversation). The backend keeps only a **non-empty floor** (≥1 message) so a literally-blank new chat can't be published; you won’t hit it in normal use.

- frontend `shareEligible = !isWriteBook && featuresOn && messages.length >= 1`
- backend `min_message_count` 2→1 + 422 copy
- test consolidated (1-msg shares, 0-msg rejected); thin-discussion noindex (#100) still guards SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)