### PR TITLE
fix(sidebar): collapsed rail showed brand logo + toggle at once

### DIFF
--- a/web/components/shell/Sidebar.tsx
+++ b/web/components/shell/Sidebar.tsx
@@ -88,15 +88,43 @@ export default function Sidebar() {
   return (
     <aside className="app-sidebar" id="app-sidebar" data-collapsed={collapsed}>
       <div className="sidebar-header">
-        <Link href="/" className="sidebar-logo">
+        <Link
+          href="/"
+          className="sidebar-logo"
+          title={collapsed ? "Open sidebar" : "Feynman"}
+          onClick={(e) => {
+            // When collapsed, the brand glyph IS the expand control —
+            // expand in place instead of navigating home.
+            if (collapsed) {
+              e.preventDefault();
+              setCollapsed(false);
+            }
+          }}
+        >
           <BrandMark />
+          <svg
+            className="sidebar-logo-expand"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <line x1="9" y1="3" x2="9" y2="21" />
+          </svg>
           Feynman
         </Link>
         <button
+          id="sidebar-toggle-btn"
           className="sidebar-icon-btn"
-          title="Toggle sidebar"
+          title="Collapse sidebar"
           onClick={() => setCollapsed((c) => !c)}
-          aria-label="Toggle sidebar"
+          aria-label="Collapse sidebar"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2" />

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -197,6 +197,12 @@ body {
 .app-layout.sidebar-collapsed .sidebar-logo-icon { display: block; }
 .app-layout.sidebar-collapsed .sidebar-label { display: none; }
 .app-layout.sidebar-collapsed #sidebar-toggle-btn { display: none; }
+/* Collapsed: the brand glyph doubles as the expand control. The toggle btn
+   is hidden above (so logo + toggle no longer show at once); on hover the
+   glyph swaps to the panel icon to signal "click to open". */
+.sidebar-logo-expand { display: none; }
+.app-layout.sidebar-collapsed .sidebar-logo:hover .sidebar-logo-icon { display: none; }
+.app-layout.sidebar-collapsed .sidebar-logo:hover .sidebar-logo-expand { display: block; }
 .app-layout.sidebar-collapsed .sidebar-header {
   justify-content: center; padding: 14px 0 10px;
 }


### PR DESCRIPTION
## What
When the sidebar is **collapsed**, the narrow rail showed **both** the Feynman brand glyph **and** the panel toggle icon at the top. It should show only one.

## Why
The collapsed styling (`app.css`) was ported expecting the legacy DOM: it hides `#sidebar-toggle-btn` when collapsed and keeps the brand glyph. But the React `Sidebar.tsx` gave the toggle `className="sidebar-icon-btn"` with **no `id`**, so `.sidebar-collapsed #sidebar-toggle-btn { display:none }` never matched → both icons rendered side by side.

Hiding the toggle alone would strand the user collapsed — the brand glyph is a `<Link href="/">` and no float-button is rendered on desktop — so the glyph now doubles as the expand control.

## Changes
- `Sidebar.tsx`: restore `id="sidebar-toggle-btn"` on the toggle so it hides when collapsed; the collapsed brand glyph expands in place (`click → setCollapsed(false)`, no navigation); added the panel icon used for the hover swap; accurate `title`/`aria-label`.
- `app.css`: hover-swap rules — the collapsed glyph reveals the "open sidebar" panel icon on hover so the affordance reads clearly (ChatGPT-style).

## Result
Collapsed rail shows a **single** icon (the brand glyph); hovering it reveals the panel/open icon; clicking expands. Expanded state is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
