### PR TITLE
fix(auth): stop spurious /login bounces + Free/Pro flicker for signed-in users

### DIFF
--- a/web/components/shell/UserMenu.tsx
+++ b/web/components/shell/UserMenu.tsx
@@ -11,7 +11,7 @@ import ThemeToggle from "@/components/theme/ThemeToggle";
  * and just the theme toggle in anonymous mode (auth off, e.g. local dev).
  */
 export default function UserMenu() {
-  const { authEnabled, user, isPro } = useAuth();
+  const { authEnabled, user, isPro, tierKnown } = useAuth();
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
@@ -72,7 +72,7 @@ export default function UserMenu() {
         {user ? (
           <div className="sidebar-label profile-info">
             <span className="profile-name">{name}</span>
-            <span className="profile-tier">{tier}</span>
+            {tierKnown && <span className="profile-tier">{tier}</span>}
           </div>
         ) : (
           <span className="sidebar-label profile-name">{guestLabel}</span>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -129,21 +129,32 @@ export async function apiFetch<T = unknown>(
     }
     let err = new ApiError(res.status, `API ${res.status} on ${path}`, body);
 
-    // Token expired/invalid mid-flight (hosted): refresh the session once and
-    // retry the original request before surfacing the error (port of app.js
-    // api() 1754-1765). Browser-only; retries AT MOST once (no infinite loop).
-    if (
+    // A 401 here is usually recoverable, so try a one-time session refresh + retry
+    // BEFORE surfacing anything — and crucially before bouncing to /login:
+    //  - token_expired / invalid_token: the short-lived Supabase access token aged
+    //    out mid-session.
+    //  - auth_required: a request raced ahead of the token being applied (e.g. at
+    //    startup, or right after the access token expired) so it went out with no
+    //    Authorization header and the auth middleware returned auth_required.
+    // In ALL of these, if a valid Supabase session still exists the refresh handler
+    // mints a fresh token and we retry once. Only a genuinely signed-out user
+    // (refresh yields no token, or the retry is STILL auth_required) is bounced to
+    // /login — so a logged-in user never gets kicked to the login page over a
+    // transient token gap. Browser-only; at most one retry (port + hardening of
+    // app.js api() 1754-1765).
+    const recoverable401 =
       !isServer &&
       res.status === 401 &&
-      (err.code === "token_expired" || err.code === "invalid_token") &&
       opts.auth !== false &&
-      _onTokenRefresh
-    ) {
+      (err.code === "token_expired" ||
+        err.code === "invalid_token" ||
+        err.code === "auth_required");
+    if (recoverable401 && _onTokenRefresh) {
       let newToken: string | null = null;
       try {
         newToken = await _onTokenRefresh();
       } catch {
-        /* refresh failed — fall through to normal error handling */
+        /* refresh failed — fall through to the signed-out handling below */
       }
       if (newToken) {
         _authToken = newToken;
@@ -161,9 +172,17 @@ export async function apiFetch<T = unknown>(
         }
         err = new ApiError(res.status, `API ${res.status} on ${path}`, body);
       }
+      // Refresh couldn't establish a session (or the retry is still auth_required)
+      // → this really is a signed-out state, so surface the login bounce now.
+      if (err.code === "auth_required") {
+        _onAuthRequired?.();
+      }
     }
 
-    // Browser-only interceptors (ports app.js api() 429/401 handling).
+    // Browser-only interceptor (ports app.js api() 429 handling): a daily-limit
+    // 429 opens the upgrade overlay. The 401 auth_required → /login bounce is
+    // handled above (only AFTER a session refresh fails), so a transient token
+    // gap no longer kicks a logged-in user to the login page.
     if (!isServer) {
       if (res.status === 429 && (err.code === "quota_exceeded" || err.code === "upload_limit_reached")) {
         const detail = (body as {
@@ -175,8 +194,6 @@ export async function apiFetch<T = unknown>(
           used: detail?.used,
           tier: detail?.tier,
         });
-      } else if (res.status === 401 && err.code === "auth_required") {
-        _onAuthRequired?.();
       }
     }
     throw err;

--- a/web/lib/auth.tsx
+++ b/web/lib/auth.tsx
@@ -13,6 +13,8 @@ interface AuthContextValue {
   user: User | null;
   /** Subscription tier is pro. */
   isPro: boolean;
+  /** A definitive tier answer has resolved (lets the UI avoid a "Free" flash). */
+  tierKnown: boolean;
   config: ProConfig | null;
   signInWithPassword: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (email: string, password: string) => Promise<{ error: string | null }>;
@@ -33,22 +35,48 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authEnabled, setAuthEnabled] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [isPro, setIsPro] = useState(false);
+  // Whether we have a DEFINITIVE tier answer yet (a successful subscription
+  // fetch, or a signed-out user). The UI hides the Free/Pro badge until this is
+  // true, so a Pro user never flashes "Free" before the tier resolves.
+  const [tierKnown, setTierKnown] = useState(false);
   const [config, setConfig] = useState<ProConfig | null>(null);
   const clientRef = useRef<SupabaseClient | null>(null);
+  // The signed-in identity we last fetched the tier for. onAuthStateChange fires
+  // applySession on every TOKEN_REFRESHED; without this guard each fire re-ran an
+  // authed GET that, if it raced the token, hard-reset a Pro user to Free.
+  const lastTierUserRef = useRef<string | null>(null);
 
   useEffect(() => {
     let unsub: (() => void) | undefined;
 
     const applySession = (session: Session | null) => {
-      setUser(session?.user ?? null);
+      const u = session?.user ?? null;
+      setUser(u);
       setAuthToken(session?.access_token ?? null);
-      if (session?.user) {
-        // Best-effort tier lookup; ignore failures (endpoint requires auth).
-        get<{ tier?: string }>("/api/pro/subscription")
-          .then((s) => setIsPro((s?.tier || "free") === "pro"))
-          .catch(() => setIsPro(false));
+      if (u) {
+        // Fetch the tier only when the identity actually changes — not on every
+        // token refresh.
+        if (lastTierUserRef.current !== u.id) {
+          lastTierUserRef.current = u.id;
+          setTierKnown(false);
+          get<{ tier?: string }>("/api/pro/subscription")
+            .then((s) => {
+              setIsPro((s?.tier || "free") === "pro");
+              setTierKnown(true);
+            })
+            .catch(() => {
+              // Transient failure (e.g. a token that raced the request): do NOT
+              // downgrade a Pro user to Free. Leave the tier unresolved so the
+              // badge stays hidden rather than showing a wrong "Free" — api.ts's
+              // refresh+retry makes this path rare, and a later auth event re-runs
+              // the fetch.
+              lastTierUserRef.current = null;
+            });
+        }
       } else {
+        lastTierUserRef.current = null;
         setIsPro(false);
+        setTierKnown(true);
       }
     };
 
@@ -134,12 +162,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (client) await client.auth.signOut();
     setUser(null);
     setIsPro(false);
+    setTierKnown(true);
+    lastTierUserRef.current = null;
     setAuthToken(null);
   }, []);
 
   return (
     <AuthContext.Provider
-      value={{ ready, authEnabled, user, isPro, config, signInWithPassword, signUp, signInWithOAuth, signOut }}
+      value={{ ready, authEnabled, user, isPro, tierKnown, config, signInWithPassword, signUp, signInWithOAuth, signOut }}
     >
       {children}
     </AuthContext.Provider>


### PR DESCRIPTION
## Symptoms (reported, signed-in Pro user)
- Often bounced to `/login` — including when clicking the new top-right "share whole session" button — but re-entering `feynman.wiki` shows you're already logged in.
- The bottom-left profile often shows **Free** even though the account is **Pro**; after clicking into a Pro feature it flips back to **Pro**.

## Root cause (one mechanism, two symptoms)
Auth is fully client-side (Supabase session in `localStorage`; SSR always renders signed-out). There's a window — at startup before `AuthProvider` finishes `getSession`, and any time the 1-hour access token has aged out but the refresh token is still valid — where an authed request goes out with **no / expired Bearer token** and the server returns **401**. The old handling was too harsh:

1. **`/login` bounce:** a 401 with `code: "auth_required"` called `_onAuthRequired()` → `router.push("/login")` **with no refresh attempt** (the refresh+retry only covered `token_expired`/`invalid_token`). So Share — or any authed call that raced the token — kicked a logged-in user to `/login`, even though their session was valid.
2. **Free/Pro flicker:** `/api/pro/subscription` is one such authed call. On failure `applySession` did `setIsPro(false)`, hard-downgrading a Pro user to "Free" until a later successful fetch flipped it back — and `onAuthStateChange` re-ran that destructive fetch on **every** token refresh.

## Fix
- **`lib/api.ts`** — a recoverable 401 (`token_expired | invalid_token | auth_required`) now does a one-time **session refresh + retry before surfacing anything**. Only a genuinely signed-out user (refresh yields no token, or the retry is still `auth_required`) is bounced to `/login`. A logged-in user is never kicked over a transient token gap.
- **`lib/auth.tsx`** — fetch the tier only when the signed-in **identity changes** (not on every token refresh); **never** downgrade Pro→Free on a transient fetch failure (leave it unresolved + retry on the next auth event); add `tierKnown`.
- **`UserMenu.tsx`** — render the Free/Pro chip only once `tierKnown`, so a Pro user never flashes "Free".

## Verification
- CI: feynman-web build (typecheck) + pytest + jsonld.
- The race is timing- and Pro-session-dependent, so it can't be reproduced headlessly/signed-out. **Please verify signed-in on prod:** click Share repeatedly + navigate around — no more `/login` bounces; the profile shows **Pro** steadily (no "Free" flash).
- **Core-auth change.** If anything regresses on normal sign-in/out, revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
