### PR TITLE
perf(api): slim agents + minds list payloads (8.6MB -> ~0.5MB)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3557,6 +3557,27 @@ def pro_config() -> dict[str, Any]:
 
 # ─── Agent endpoints ───
 
+# The catalog list only needs a few small meta fields for the library grid, the
+# composer book picker, and a chat's related-books sidebar (see web/lib/books.ts
+# mapAgentsToBooks). The full meta_json blob (insights, overview, per-chunk data,
+# voice, …) averages ~9 KB/row × ~900 rows ≈ 8 MB — 96% of the payload — and is
+# NEVER read from the list (detail pages fetch the single agent for that).
+# Stripping meta to the display fields keeps opening the composer / library / a
+# chat's related-books sidebar from pulling + JSON-parsing 8 MB on the client main
+# thread, which was freezing interactions for seconds.
+_AGENT_LIST_META_FIELDS = (
+    "author", "isbn", "category", "description",
+    "chunk_count", "creator_name", "creator_user_id",
+)
+
+
+def _slim_agent_list_meta(agents: list[dict[str, Any]]) -> None:
+    for agent in agents:
+        meta = agent.get("meta")
+        if isinstance(meta, dict):
+            agent["meta"] = {k: meta[k] for k in _AGENT_LIST_META_FIELDS if k in meta}
+
+
 @app.get("/api/agents")
 def api_list_agents():
     from fastapi.responses import JSONResponse
@@ -3569,6 +3590,7 @@ def api_list_agents():
         _enrich_ai_book_agents(result)
     except Exception as exc:
         log.error("Failed to enrich AI book agents: %s", exc)
+    _slim_agent_list_meta(result)
     return JSONResponse(
         content=result,
         # 5× longer edge cache (was s-maxage=120 = 2 min) — the agents
@@ -4963,6 +4985,13 @@ def api_list_minds(background_tasks: BackgroundTasks):
             background_tasks.add_task(backfill_mind_embeddings)
     for m in minds:
         m.pop("persona", None)
+        # The minds graph/list only render name/era/domain/slug/links (see the web
+        # minds consumers); these heavy detail-only fields add ~580 KB to the
+        # ~940 KB list payload and are never read from it (the mind detail page
+        # fetches the single mind). Drop them so the minds network loads fast.
+        m.pop("thinking_style", None)
+        m.pop("typical_phrases", None)
+        m.pop("works", None)
     return JSONResponse(
         content=minds,
         headers={"Cache-Control": "public, max-age=60, s-maxage=300"},


### PR DESCRIPTION
## Symptom
Clicking many actions freezes for several seconds before responding.

## Root cause (measured on prod)
| endpoint | rows | size | total time |
|---|---|---|---|
| `/api/agents` | 899 | **8.6 MB** | 3.4s warm / 10s cold |
| `/api/minds` | 424 | **937 KB** | 2s warm / 8s cold |

`/api/agents`'s per-book `meta_json` (insights, overview, per-chunk data, voice…) is **8.27 MB — 96% of the payload**. And it's fetched on **interactive** surfaces:
- `RelatedBooks.tsx` — the related-books sidebar **in the chat view**, on every answer that cites books
- `ComposerPickers.tsx` — the composer's book picker
- `Library.tsx` — the library grid

So opening any of those pulls **+ `JSON.parse`s 8.6 MB on the client main thread** → the UI freezes for seconds. `/api/minds` (the minds graph) compounds it with `thinking_style` (316KB) + `typical_phrases` (170KB) + `works` (95KB).

## Fix (backend-only)
The list consumers read only a handful of small fields — `web/lib/books.ts` `mapAgentsToBooks` uses 7 `meta` fields (`author, isbn, category, description, chunk_count, creator_name, creator_user_id`); the minds graph reads only `name/era/domain/slug/links`. Detail pages fetch the **single** agent/mind for the rest.

- `/api/agents`: strip the list's `meta` to those 7 display fields → **~8.6 MB → ~0.5 MB**.
- `/api/minds`: drop `thinking_style` / `typical_phrases` / `works` (extends the existing `persona` pop) → **~937 KB → ~0.35 MB**.

No frontend change — every consumer already used a subset of fields (verified `meta.skills` is typed-only, never read; the `thinking_style`/`typical_phrases` test hits are SEO render-function + detail-page tests, not the list).

## Verification
- pytest (backend gate) + feynman-web build + jsonld.
- Confirm the slimmed sizes on the feynman-pro preview deploy before merge.
- After deploy: opening the composer book picker / a chat with a related-books sidebar / the library / the minds graph should no longer freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
