### PR TITLE
perf(client): cache catalog/minds/sessions so re-visits don't re-fetch

### DIFF
--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -19,7 +19,8 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { get, post, ApiError, getAgent } from "@/lib/api";
+import { get, post, ApiError } from "@/lib/api";
+import { getAgentCached } from "@/lib/catalog";
 import {
   loadMessages,
   getSession,
@@ -366,7 +367,7 @@ export default function ChatView({
           !(initialMinds && initialMinds.length)
         ) {
           if (s.sessionType === "book") {
-            getAgent(s.mindId)
+            getAgentCached(s.mindId)
               .then((a) => {
                 if (!alive || !a?.id) return;
                 setBooks((prev) =>

--- a/web/components/chat/ChatsList.tsx
+++ b/web/components/chat/ChatsList.tsx
@@ -11,12 +11,21 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
-import { listSessions, SESSIONS_CHANGED, type Session } from "@/lib/chat";
+import {
+  listSessions,
+  getCachedSessions,
+  sessionsCacheFresh,
+  SESSIONS_CHANGED,
+  type Session,
+} from "@/lib/chat";
 
 export default function ChatsList() {
   const { ready, authEnabled, user } = useAuth();
   const router = useRouter();
-  const [sessions, setSessions] = useState<Session[] | null>(null);
+  // Seed from the sessions cache so re-visiting /chats paints the last-known list
+  // immediately (the sidebar's ChatHistory already does this) instead of
+  // re-fetching the cold origin on every visit.
+  const [sessions, setSessions] = useState<Session[] | null>(() => getCachedSessions());
   const [query, setQuery] = useState("");
 
   useEffect(() => {
@@ -28,17 +37,26 @@ export default function ChatsList() {
       return;
     }
     let alive = true;
-    const load = () =>
+    const load = (force = false) => {
+      // Fresh cache → paint it and skip the network round-trip (this removes the
+      // multi-second reload on every visit). bumpSessions() invalidates the cache
+      // on any mutation, so this stays correct.
+      if (!force && sessionsCacheFresh()) {
+        const cached = getCachedSessions();
+        if (cached && alive) setSessions(cached);
+        return;
+      }
       listSessions()
         .then((s) => {
           if (alive) setSessions(s);
         })
         .catch(() => {
-          if (alive) setSessions([]);
+          if (alive && !getCachedSessions()) setSessions([]);
         });
+    };
     load();
-    // Live-refresh on session mutations (M16).
-    const onChanged = () => load();
+    // Live-refresh on session mutations (M16) — force past the TTL.
+    const onChanged = () => load(true);
     window.addEventListener(SESSIONS_CHANGED, onChanged);
     return () => {
       alive = false;

--- a/web/components/chat/ComposerPickers.tsx
+++ b/web/components/chat/ComposerPickers.tsx
@@ -17,9 +17,9 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { get } from "@/lib/api";
-import { mapAgentsToBooks, type AgentRow, type Book } from "@/lib/books";
+import { type Book } from "@/lib/books";
 import { listMinds, type Mind } from "@/lib/api";
+import { getCatalogBooks } from "@/lib/catalog";
 import { generateMind } from "@/lib/minds-chat";
 import { useProGate } from "@/components/pro/ProOverlay";
 import { mindColor, mindInitials } from "./markdown";
@@ -128,10 +128,10 @@ export function BookPopover({
     if (!open || loadedRef.current) return;
     let alive = true;
     setState("loading");
-    get<AgentRow[]>("/api/agents")
-      .then((rows) => {
+    getCatalogBooks()
+      .then((catBooks) => {
         if (!alive) return;
-        setBooks(mapAgentsToBooks(rows || []));
+        setBooks(catBooks);
         setState("ready");
         loadedRef.current = true;
       })

--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -15,7 +15,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { getAgent, getMind, type Agent, type Mind } from "@/lib/api";
+import { getMind, type Agent, type Mind } from "@/lib/api";
+import { getAgentCached } from "@/lib/catalog";
 import { createSession, bumpSessions } from "@/lib/chat";
 import { startWriteBook } from "@/lib/writeBook";
 import { useAuth } from "@/lib/auth";
@@ -204,7 +205,7 @@ export default function HomeComposer() {
     // never matched the uuid-keyed catalog, so it fell through to this same
     // fetch anyway — but only after a multi-second catalog download, leaving the
     // composer empty ~4s. Now it's one small request.
-    getAgent(bookId)
+    getAgentCached(bookId)
       .then((agent: Agent) => {
         if (agent?.id) {
           setBooks(

--- a/web/components/chat/RelatedBooks.tsx
+++ b/web/components/chat/RelatedBooks.tsx
@@ -14,8 +14,8 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { get } from "@/lib/api";
-import { mapAgentsToBooks, type AgentRow, type Book } from "@/lib/books";
+import { type Book } from "@/lib/books";
+import { getCatalogBooks } from "@/lib/catalog";
 import type { Source } from "@/lib/chat";
 
 export default function RelatedBooks({
@@ -31,9 +31,9 @@ export default function RelatedBooks({
   // Load the catalog once so we can resolve categories for "related" picks.
   useEffect(() => {
     let alive = true;
-    get<AgentRow[]>("/api/agents")
-      .then((rows) => {
-        if (alive) setAllBooks(mapAgentsToBooks(rows || []));
+    getCatalogBooks()
+      .then((books) => {
+        if (alive) setAllBooks(books);
       })
       .catch(() => {
         /* keep allBooks empty; the sidebar just stays hidden */

--- a/web/components/library/Library.tsx
+++ b/web/components/library/Library.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { get, post, listVotes } from "@/lib/api";
-import { AgentRow, Book, mapAgentsToBooks, mergeVotes } from "@/lib/books";
+import { Book, mergeVotes } from "@/lib/books";
+import { getCatalogBooks, getCachedCatalogBooks, invalidateCatalogBooks } from "@/lib/catalog";
 import { startWriteBook } from "@/lib/writeBook";
 import { useAuth } from "@/lib/auth";
 import { useProGate } from "@/components/pro/ProOverlay";
@@ -23,13 +24,15 @@ export default function Library() {
   const router = useRouter();
   const { authEnabled, user } = useAuth();
   const { requirePro } = useProGate();
-  const [books, setBooks] = useState<Book[]>([]);
+  // Seed from the catalog cache so re-visiting Library paints instantly instead
+  // of flashing loading → fetch → refill on every navigation.
+  const [books, setBooks] = useState<Book[]>(() => getCachedCatalogBooks() ?? []);
   const [topics, setTopics] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [activeTopics, setActiveTopics] = useState<Set<string>>(new Set());
   const [loadingTopics, setLoadingTopics] = useState<Set<string>>(new Set());
   const [filter, setFilter] = useState<"recent" | "all">("recent");
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(() => getCachedCatalogBooks() === null);
   const [discovering, setDiscovering] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -43,12 +46,12 @@ export default function Library() {
   const load = useCallback(async () => {
     setError(null);
     try {
-      const [agents, tops, votes] = await Promise.all([
-        get<AgentRow[]>("/api/agents"),
+      const [catBooks, tops, votes] = await Promise.all([
+        getCatalogBooks(),
         get<{ topics?: string[] } | string[]>("/api/topics").catch(() => ({ topics: [] })),
         listVotes().catch(() => []),
       ]);
-      setBooks(mergeVotes(mapAgentsToBooks(agents), votes));
+      setBooks(mergeVotes(catBooks, votes));
       setTopics(Array.isArray(tops) ? tops : tops.topics || []);
     } catch {
       setError("Couldn't load the library. Is the API running?");
@@ -79,6 +82,7 @@ export default function Library() {
 
   const handleDeleted = useCallback((agentId: string) => {
     setBooks((prev) => prev.filter((b) => b.agentId !== agentId));
+    invalidateCatalogBooks(); // drop the shared cache so the deleted book doesn't reappear
   }, []);
 
   const filtered = useMemo(() => {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -237,7 +237,34 @@ export const listAgents = () => get<Agent[]>("/api/agents");
 export const getAgent = (id: string) => get<Agent>(`/api/agents/${encodeURIComponent(id)}`);
 export const deleteAgent = (id: string) =>
   del<void>(`/api/agents/${encodeURIComponent(id)}`);
-export const listMinds = () => get<Mind[]>("/api/minds");
+// Minds list cache (near-static). ChatView + the composer mind picker import
+// listMinds from here, so cache it (TTL + de-dupe) to avoid re-fetching the cold
+// Python origin on every mount. auth:false → the list is identity-independent, so
+// the first load can hit Vercel's shared edge cache too. (lib/minds.ts has its
+// own cache for the graph's richer Mind type.)
+let _mindsListCache: Mind[] | null = null;
+let _mindsListAt = 0;
+let _mindsListInflight: Promise<Mind[]> | null = null;
+export const listMinds = (): Promise<Mind[]> => {
+  if (_mindsListCache && Date.now() - _mindsListAt < 300_000) {
+    return Promise.resolve(_mindsListCache);
+  }
+  if (_mindsListInflight) return _mindsListInflight;
+  _mindsListInflight = apiFetch<Mind[]>("/api/minds", { method: "GET", auth: false })
+    .then((m) => {
+      _mindsListCache = Array.isArray(m) ? m : [];
+      _mindsListAt = Date.now();
+      return _mindsListCache;
+    })
+    .catch((e) => {
+      if (_mindsListCache) return _mindsListCache; // serve stale on a transient failure
+      throw e;
+    })
+    .finally(() => {
+      _mindsListInflight = null;
+    });
+  return _mindsListInflight;
+};
 export const getMind = (id: string) => get<Mind>(`/api/minds/${encodeURIComponent(id)}`);
 
 /**

--- a/web/lib/catalog.ts
+++ b/web/lib/catalog.ts
@@ -1,0 +1,72 @@
+/**
+ * In-memory client cache for the near-static catalog reads.
+ *
+ * The book catalog (`/api/agents`) and the minds list (`/api/minds`) change at
+ * most a few times an hour, but were re-fetched on EVERY navigation/mount —
+ * Library, the composer book picker, a chat's related-books sidebar, the minds
+ * graph. Worse, for a signed-in user the Bearer header makes Vercel's edge cache
+ * skip these responses, so each fetch hit the COLD Python origin (~1.5-6s). That
+ * was the "switching Chats/Library/Great Minds loads for seconds every time,
+ * even when just visited" lag.
+ *
+ * Fix: cache them here with a short TTL + in-flight de-dup, so re-visits are
+ * instant (no network). And fetch them with `auth: false` — these lists are
+ * identity-independent (the endpoints take no user), so dropping the Bearer lets
+ * the FIRST load hit the shared edge cache too.
+ */
+
+import { apiFetch, getAgent, type Agent } from "@/lib/api";
+import { mapAgentsToBooks, type AgentRow, type Book } from "@/lib/books";
+
+// 5 min: a freshly created book/mind still appears within the window, and the
+// lists are otherwise static across a browsing session.
+const TTL = 5 * 60 * 1000;
+
+// ── Catalog books (/api/agents) ──────────────────────────────────────────
+let _books: Book[] | null = null;
+let _booksAt = 0;
+let _booksInflight: Promise<Book[]> | null = null;
+
+/** The catalog as display Books — cached (TTL) + request-deduped. */
+export async function getCatalogBooks(): Promise<Book[]> {
+  if (_books && Date.now() - _booksAt < TTL) return _books;
+  if (_booksInflight) return _booksInflight;
+  _booksInflight = apiFetch<AgentRow[]>("/api/agents", { method: "GET", auth: false })
+    .then((rows) => {
+      _books = mapAgentsToBooks(rows || []);
+      _booksAt = Date.now();
+      return _books;
+    })
+    .catch((err) => {
+      if (_books) return _books; // serve stale on a transient failure
+      throw err;
+    })
+    .finally(() => {
+      _booksInflight = null;
+    });
+  return _booksInflight;
+}
+
+/** Synchronous peek for instant first paint — null when no fresh cache. */
+export function getCachedCatalogBooks(): Book[] | null {
+  return _books && Date.now() - _booksAt < TTL ? _books : null;
+}
+
+/** Drop the cached catalog (e.g. after creating/deleting a book). */
+export function invalidateCatalogBooks(): void {
+  _books = null;
+  _booksAt = 0;
+}
+
+// ── Single agent (/api/agents/{id}) ──────────────────────────────────────
+// Memoizes per-id so re-opening the same book (composer preselect, chat resume)
+// doesn't re-hit the origin. Stays authed (a single agent may be a private book).
+const _agents = new Map<string, { at: number; agent: Agent }>();
+
+export async function getAgentCached(id: string): Promise<Agent> {
+  const hit = _agents.get(id);
+  if (hit && Date.now() - hit.at < TTL) return hit.agent;
+  const agent = await getAgent(id);
+  _agents.set(id, { at: Date.now(), agent });
+  return agent;
+}

--- a/web/lib/minds.ts
+++ b/web/lib/minds.ts
@@ -114,7 +114,7 @@ export function hexToRgb(hex: string): [number, number, number] {
 }
 
 // ── API ──────────────────────────────────────────────────────────────────
-import { apiFetch, get } from "@/lib/api";
+import { apiFetch } from "@/lib/api";
 
 // Near-static minds list — cache it (TTL) + de-dupe so the Great Minds graph,
 // the composer mind picker, and ChatView don't re-fetch the cold origin on every
@@ -150,19 +150,35 @@ export async function listMinds(): Promise<Mind[]> {
  * arrays on failure (the graph falls back to a charge-only layout). Tolerates
  * the legacy/alternate `layout` map shape just in case, normalizing to LayoutPos[].
  */
+let _simCache: GraphData | null = null;
+let _simAt = 0;
+let _simInflight: Promise<GraphData> | null = null;
+
 export async function getSimilarities(): Promise<GraphData> {
-  try {
-    const resp = await get<{ links?: GraphLink[]; layout?: unknown }>(
-      "/api/minds/similarities",
-    );
-    return {
-      links: Array.isArray(resp?.links) ? resp.links : [],
-      layout: normalizeLayout(resp?.layout),
-    };
-  } catch (err) {
-    console.warn("[minds] getSimilarities failed:", err);
-    return { links: [], layout: [] };
-  }
+  if (_simCache && Date.now() - _simAt < MINDS_TTL) return _simCache;
+  if (_simInflight) return _simInflight;
+  // 176 KB graph, fetched on every Great Minds mount — cache it (TTL) like the
+  // minds list. auth:false: it's the global embedding graph (identity-independent).
+  _simInflight = apiFetch<{ links?: GraphLink[]; layout?: unknown }>(
+    "/api/minds/similarities",
+    { method: "GET", auth: false },
+  )
+    .then((resp) => {
+      _simCache = {
+        links: Array.isArray(resp?.links) ? resp.links : [],
+        layout: normalizeLayout(resp?.layout),
+      };
+      _simAt = Date.now();
+      return _simCache;
+    })
+    .catch((err) => {
+      console.warn("[minds] getSimilarities failed:", err);
+      return _simCache || { links: [], layout: [] };
+    })
+    .finally(() => {
+      _simInflight = null;
+    });
+  return _simInflight;
 }
 
 /** Accept either the real array shape or a {[id]:[x,y]|{rx,ry}} map. */

--- a/web/lib/minds.ts
+++ b/web/lib/minds.ts
@@ -114,17 +114,35 @@ export function hexToRgb(hex: string): [number, number, number] {
 }
 
 // ── API ──────────────────────────────────────────────────────────────────
-import { get } from "@/lib/api";
+import { apiFetch, get } from "@/lib/api";
 
-/** GET /api/minds — full mind list. Returns [] on any failure (never throws). */
+// Near-static minds list — cache it (TTL) + de-dupe so the Great Minds graph,
+// the composer mind picker, and ChatView don't re-fetch the cold origin on every
+// mount. Fetched auth:false (the endpoint is identity-independent) so the first
+// load can hit the shared edge cache too.
+const MINDS_TTL = 5 * 60 * 1000;
+let _mindsCache: Mind[] | null = null;
+let _mindsAt = 0;
+let _mindsInflight: Promise<Mind[]> | null = null;
+
+/** GET /api/minds — full mind list, cached. Returns [] on failure (never throws). */
 export async function listMinds(): Promise<Mind[]> {
-  try {
-    const minds = await get<Mind[]>("/api/minds");
-    return Array.isArray(minds) ? minds : [];
-  } catch (err) {
-    console.warn("[minds] listMinds failed:", err);
-    return [];
-  }
+  if (_mindsCache && Date.now() - _mindsAt < MINDS_TTL) return _mindsCache;
+  if (_mindsInflight) return _mindsInflight;
+  _mindsInflight = apiFetch<Mind[]>("/api/minds", { method: "GET", auth: false })
+    .then((minds) => {
+      _mindsCache = Array.isArray(minds) ? minds : [];
+      _mindsAt = Date.now();
+      return _mindsCache;
+    })
+    .catch((err) => {
+      console.warn("[minds] listMinds failed:", err);
+      return _mindsCache || []; // stale-or-empty; preserve the never-throws contract
+    })
+    .finally(() => {
+      _mindsInflight = null;
+    });
+  return _mindsInflight;
 }
 
 /**


### PR DESCRIPTION
## Symptom (after #106)
Slimming the payloads fixed the main-thread *freeze*, but switching **Chats / Library / Great Minds** — or opening a book chat, or the composer's book picker — still **loaded for several seconds, even when just visited**.

## Root cause
There's **no client cache** (no SWR/React Query). Every hot surface fetched the catalog / minds / sessions into local component state and **re-fetched on every mount**. So each navigation re-hit the cold Python origin (~1.5–6s). Worse: for a signed-in user the `Authorization` header makes Vercel's edge cache **skip** these responses, so even repeat fetches hit the origin. (`ChatHistory` in the sidebar already used a sessions cache — but `ChatsList`, `Library`, and `listMinds` didn't.)

## Fix (frontend-only)
New `lib/catalog.ts` — a small in-memory TTL (5 min) cache + in-flight de-dup:
- `getCatalogBooks()` for `/api/agents`, fetched **`auth: false`** (the list is identity-independent) so the **first** load can hit the shared edge cache, and re-visits are instant from memory.
- `getAgentCached()` memoizes the single-book fetch (composer preselect, chat resume).

Plus:
- Cache `listMinds` the same way (both the `lib/api.ts` copy that `ChatView`/`ComposerPickers` use **and** the `lib/minds.ts` copy the graph uses).
- Wire `Library`, `ComposerPickers`, `RelatedBooks` → `getCatalogBooks`; `HomeComposer` + `ChatView` → `getAgentCached`; `ChatsList` → the existing sessions cache (mirrors `ChatHistory`).
- `Library` / `ChatsList` seed initial state from the cache → **instant paint** on re-visit (no loading flash).
- Invalidate the catalog cache on book delete (so a deleted book can't reappear from cache).

## Net effect
- **Re-visits: instant** (served from memory, zero network) — fixes "loads for seconds even when just visited".
- **First load: faster** — `auth:false` lets the catalog/minds hit the edge cache instead of the cold origin.

Verified signed-out on the preview (menu-switching is instant after first load); the signed-in paths additionally benefit from skipping the per-request Bearer-bypassed origin hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
