### PR TITLE
perf(chat): cache transcripts so switching chats is instant

### DIFF
--- a/web/components/chat/ChatHistory.tsx
+++ b/web/components/chat/ChatHistory.tsx
@@ -16,6 +16,8 @@ import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import {
   listSessions,
+  loadMessages,
+  getCachedMessages,
   deleteSession as apiDeleteSession,
   bumpSessions,
   getCachedSessions,
@@ -113,7 +115,15 @@ export default function ChatHistory() {
           const isPublic = s.publicStatus === "approved";
           return (
             <div className={`history-item-wrap${active ? " active" : ""}`} key={s.id}>
-              <Link href={`/chat/${s.id}`} className="history-item">
+              <Link
+                href={`/chat/${s.id}`}
+                className="history-item"
+                onMouseEnter={() => {
+                  // Prefetch the transcript so the click opens instantly instead
+                  // of waiting 1-3s on the cold origin.
+                  if (!getCachedMessages(s.id)) loadMessages(s.id).catch(() => {});
+                }}
+              >
                 {isWriteBook && <WriteBookIcon />}
                 {s.title}
                 {isPublic && (

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -23,6 +23,8 @@ import { get, post, ApiError } from "@/lib/api";
 import { getAgentCached } from "@/lib/catalog";
 import {
   loadMessages,
+  getCachedMessages,
+  setCachedMessages,
   getSession,
   queueSaveMessage,
   renameSession,
@@ -190,7 +192,9 @@ export default function ChatView({
   // fallback so the chat works even when the row can't be fetched.
   const sessionRef = useRef<Session>(stubSession(sessionId));
 
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<Message[]>(
+    () => getCachedMessages(sessionId) ?? [],
+  );
   // Write-book detection: set once the session row loads (sessionType
   // 'write_book' OR meta.write_book — port of _isWriteBookSession). When true,
   // the composer routes through the ai-books flow + the book-canvas renders
@@ -406,6 +410,9 @@ export default function ChatView({
     // the reply optimistically, and a fast loadMessages() resolving mid-send
     // would otherwise overwrite (clobber) that live transcript.
     if (!hasPending(sessionId)) {
+      // Paint the cached transcript instantly on switch (stale-while-revalidate);
+      // clear if none so the previous chat isn't shown during the load.
+      setMessages(getCachedMessages(sessionId) ?? []);
       loadMessages(sessionId)
         .then((msgs) => {
           if (alive) setMessages(msgs);
@@ -430,6 +437,12 @@ export default function ChatView({
       genRef.current++;
     };
   }, [sessionId]);
+
+  // Keep the transcript cache current as new turns arrive, so switching away and
+  // back shows the latest instantly (stale-while-revalidate).
+  useEffect(() => {
+    if (messages.length) setCachedMessages(sessionId, messages);
+  }, [sessionId, messages]);
 
   // ── Build chat history from current messages (user/assistant turns) ──
   const buildHistory = useCallback(

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -268,12 +268,27 @@ export async function updateSession(
   });
 }
 
+// Per-session transcript cache (stale-while-revalidate). Opening a chat from the
+// history used to re-fetch /api/sessions/{id}/messages from the cold origin every
+// time — a 1-3s blank on every switch. We cache the last-known transcript so
+// switching back to an already-opened (or hover-prefetched) chat paints instantly,
+// then revalidates in the background. ChatView keeps it current as new turns arrive.
+const _messagesCache = new Map<string, Message[]>();
+export function getCachedMessages(id: string): Message[] | null {
+  return _messagesCache.get(id) ?? null;
+}
+export function setCachedMessages(id: string, msgs: Message[]): void {
+  _messagesCache.set(id, msgs);
+}
+
 /** GET /api/sessions/{id}/messages → flattened Message[] (port of switchToSession). */
 export async function loadMessages(id: string): Promise<Message[]> {
   const rows = await get<MessageRow[]>(
     `/api/sessions/${encodeURIComponent(id)}/messages`,
   );
-  return (rows || []).map((m) => ({ role: m.role, content: m.content, ...(m.meta || {}) }));
+  const msgs = (rows || []).map((m) => ({ role: m.role, content: m.content, ...(m.meta || {}) }));
+  _messagesCache.set(id, msgs);
+  return msgs;
 }
 
 /**


### PR DESCRIPTION
## Symptom
Clicking a chat in the sidebar history to switch lags **1-3s** every time.

## Root cause
Opening a chat fires `getSession` + `loadMessages` + `/api/features` in parallel. **`loadMessages` (the transcript) has no cache** (unlike the sessions list), so every open re-fetches `/api/sessions/{id}/messages` from the cold Python origin → 1-3s blank.

## Fix (frontend-only)
A per-session **stale-while-revalidate** transcript cache in `lib/chat.ts`:
- `loadMessages` stores its result in the cache.
- `ChatView` seeds `messages` from the cache + paints it instantly on switch (clears if none, so the previous chat isn't shown during load), then revalidates in the background, and keeps the cache current as new turns arrive.
- `ChatHistory` **prefetches** the transcript on hover, so the click opens instantly even on a first open.

## Result
Switching between opened chats is **instant** (cache hit); first-open after a brief hover is instant too. Background revalidation keeps it fresh.

## Verification
- feynman-web build (typecheck) + pytest + jsonld.
- Auth-gated (private sessions), so it can't be exercised signed-out on preview — **please verify signed-in on prod**: click between chats in the history → instant, no 1-3s blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)