### PR TITLE
seo(entity): lead mind/book title + meta with the chat hook, not a static bio

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -48,11 +48,12 @@ function bookDescription(
   subtitle: string,
   author: string,
 ): string {
-  let raw: string;
-  if (subtitle) raw = subtitle;
-  else if (author) raw = `by ${author} — Read and chat with this book on Feynman`;
-  else raw = "Read and chat with this book on Feynman";
-  return clampDescription(raw);
+  const by = author ? ` by ${author}` : "";
+  // Lead with the interactive hook so the SERP snippet differentiates from a
+  // static book summary; append the subtitle for context (clampDescription trims,
+  // keeping the hook up front where it survives SERP truncation).
+  const lead = `Read & chat with this book${by} on Feynman — ask it anything and get answers grounded in its actual text.`;
+  return clampDescription(subtitle ? `${lead} ${subtitle}` : lead);
 }
 
 export async function generateMetadata({
@@ -79,7 +80,7 @@ export async function generateMetadata({
   const ogImage = `${SITE_URL}/book/${encodeURIComponent(params.id)}/og.png`;
   const desc = bookDescription(data.subtitle, data.author);
   return {
-    title: `${data.title} — Feynman`,
+    title: `Read & chat with ${data.title} — Feynman`,
     description: desc,
     alternates: { canonical },
     ...(isStub ? { robots: { index: false, follow: true } } : {}),

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -42,10 +42,13 @@ export function generateStaticParams() {
 }
 
 function descFor(mind: MindDetail): string {
-  const base =
-    mind.bio_summary ||
-    `${mind.name} — ${mind.domain || ""} thinker on Feynman`.trim();
-  return metaDescription(base);
+  const domain = mind.domain ? ` about ${mind.domain}` : "";
+  // Lead with the interactive hook — what a static encyclopedia can't offer — so
+  // the SERP snippet differentiates from Wikipedia instead of reading like another
+  // third-person bio. The bio is appended for context/keywords; metaDescription
+  // trims, keeping the hook up front (where it survives SERP truncation).
+  const lead = `Chat with ${mind.name} on Feynman — ask${domain}, answered in their own words. An interactive great mind, not a static encyclopedia entry.`;
+  return metaDescription(mind.bio_summary ? `${lead} ${mind.bio_summary}` : lead);
 }
 
 export async function generateMetadata({
@@ -61,7 +64,7 @@ export async function generateMetadata({
   const ogImage = abs(`/mind/${params.id}/og.png`);
   const desc = descFor(mind);
   return {
-    title: `${mind.name} — Feynman Great Minds`,
+    title: `Chat with ${mind.name} — Feynman`,
     description: desc,
     alternates: { canonical },
     openGraph: {


### PR DESCRIPTION
## Why
GSC shows the **mind pages** are getting the impressions — but their SERP snippet is the problem:
- Mind title: `{name} — Feynman Great Minds` (generic) · mind meta: a **third-person bio identical to Wikipedia**. The differentiation (you can *chat* with them) is invisible exactly where the user decides to click.
- Book meta had the hook, but the **title** didn't — and a book *with a subtitle* dropped the hook entirely (meta = just the subtitle).

The on-page experience is already differentiated (chat CTA + first-person voice above the fold); this fixes only the **SERP-facing layer**.

## Change (metadata only)
- **Mind** `title` → `Chat with {name} — Feynman`; `description` leads with `Chat with {name} … answered in their own words. An interactive great mind, not a static encyclopedia entry.` (bio appended for context/keywords; trimmed).
- **Book** `title` → `Read & chat with {title} — Feynman`; `description` always leads with the read-&-chat hook (subtitle appended).

## Verify
- feynman-web build + pytest + jsonld.
- Will curl the preview deploy's `<title>`/`<meta>` to confirm the hook-first output for a mind + a book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)