### PR TITLE
fix(egress): stop /api/agents SELECT * reading full 8.3MB meta_json from Supabase per call

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1054,15 +1054,35 @@ def update_agent_slug(agent_id: str, slug: str) -> None:
         _execute(conn, _q("UPDATE agents SET slug = ? WHERE id = ?"), (slug, agent_id))
 
 
-def list_agents(limit: int | None = None) -> list[dict[str, Any]]:
+def list_agents(limit: int | None = None, lite: bool = False) -> list[dict[str, Any]]:
     """List all non-deleted agents.
 
-    `limit` is a defensive cap to prevent unbounded reads from blowing through
-    egress quotas when the table grows. Default None preserves existing
-    behavior; callers that touch this on every request (sitemap, llms-full,
-    cron loops, public endpoints) should always pass an explicit limit.
+    `limit` caps the row COUNT. `lite=True` (Postgres only) caps the row WIDTH:
+    it projects meta_json down to the few display fields the catalog list needs
+    (web/lib/books.ts mapAgentsToBooks) INSTEAD of `SELECT *`. The full meta_json
+    (insights, overview, per-chunk data, voice) averages ~9 KB/row, so `SELECT *`
+    over ~900 rows reads ~8.3 MB from the DB PER CALL — and /api/agents is hit
+    thousands of times, which made this `SELECT *` the DOMINANT Supabase EGRESS
+    source (confirmed via pg_stat_statements: ~8k calls × 7.25M rows ≈ tens of
+    GB). The lite projection drops each read to ~160 KB (≈50× less). SQLite/local
+    dev keeps SELECT * — egress only matters on the hosted Postgres.
     """
-    sql = "SELECT * FROM agents WHERE is_deleted = ? ORDER BY created_at DESC"
+    if lite and _USE_PG:
+        sql = (
+            "SELECT id, name, slug, type, source, status, user_id, is_deleted, created_at, "
+            "jsonb_build_object("
+            "'author',(meta_json::jsonb)->'author',"
+            "'isbn',(meta_json::jsonb)->'isbn',"
+            "'category',(meta_json::jsonb)->'category',"
+            "'description',(meta_json::jsonb)->'description',"
+            "'chunk_count',(meta_json::jsonb)->'chunk_count',"
+            "'creator_name',(meta_json::jsonb)->'creator_name',"
+            "'creator_user_id',(meta_json::jsonb)->'creator_user_id'"
+            ")::text AS meta_json "
+            "FROM agents WHERE is_deleted = ? ORDER BY created_at DESC"
+        )
+    else:
+        sql = "SELECT * FROM agents WHERE is_deleted = ? ORDER BY created_at DESC"
     params: tuple[Any, ...] = (False if _USE_PG else 0,)
     if limit is not None:
         sql += " LIMIT ?"

--- a/app/main.py
+++ b/app/main.py
@@ -848,7 +848,7 @@ def sitemap_xml():
     # AND wrap the whole response in a TTL cache.
     try:
         ready_agents = [
-            a for a in list_agents(limit=5000)
+            a for a in list_agents(limit=5000, lite=True)
             if a.get("status") == "ready"
         ]
         ready_ids = [a["id"] for a in ready_agents]
@@ -1206,7 +1206,7 @@ The project draws inspiration from Richard Feynman's approach to learning:
     # and used to pull the entire catalog through Supabase's pooler on every
     # request. Limits are large enough to cover the catalog, but bounded.
     try:
-        for agent in list_agents(limit=5000):
+        for agent in list_agents(limit=5000, lite=True):
             if agent.get("status") != "ready":
                 continue
             name = agent.get("name", "Untitled")
@@ -3422,7 +3422,7 @@ def api_cron_indexnow(request: Request) -> dict[str, Any]:
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=26)).isoformat()
     urls: list[str] = []
     # Recent ready agents → /book/{id}
-    for a in list_agents(limit=2000):
+    for a in list_agents(limit=2000, lite=True):
         if a.get("status") != "ready":
             continue
         if (a.get("created_at") or "") < cutoff:
@@ -3585,7 +3585,7 @@ def api_list_agents():
     # past any realistic user-perceivable size. Without a cap, this endpoint
     # is hit on every page load and pulls the full agents table over the
     # Supabase pooler.
-    result = list_agents(limit=5000)
+    result = list_agents(limit=5000, lite=True)
     try:
         _enrich_ai_book_agents(result)
     except Exception as exc:


### PR DESCRIPTION
## The proof
`pg_stat_statements` on prod:
```
SELECT * FROM agents WHERE is_deleted=$1 ORDER BY created_at DESC LIMIT $2
  → ~8,000 calls, 7.25M rows
```
`/api/agents` does **`SELECT *`**, reading the full **8.27 MB `meta_json`** (insights/overview/chunks/voice) from Supabase **every call**. ~8k calls × 8.3 MB ≈ tens of GB = the **754% egress overage** (37.7/5 GB).

## Why prior fixes missed it
- The ISR fix (#57/#58) cached anonymous SEO crawls — never touched this query.
- **#106 trimmed the response in Python *after* the DB read** → cut client/Vercel egress, **not** the Supabase read. The `SELECT *` still pulled 8.3 MB/call.

## Fix
`list_agents(lite=True)` projects `meta_json` to the 7 fields `mapAgentsToBooks` needs, **in SQL** (`jsonb_build_object`): **8270 kB → 163 kB per call (~51×)** — verified against prod (returns correct author/category/chunk_count). Applied to the request/crawler hot paths (`/api/agents`, `llms-full`, sitemap ×2). Scripts + detail pages keep full meta (`lite` defaults False, so they're untouched).

## Verify
- pytest (SQLite path = SELECT *, unchanged) + builds.
- Post-deploy: `/api/agents` still returns author/category; **watch Supabase egress drop** over the next day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)