### PR TITLE
feat(egress): harden slug-resolution + daily egress-watch email alert

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1049,6 +1049,55 @@ def get_agent_by_slug(slug: str) -> dict[str, Any] | None:
         return _row_to_agent(row) if row else None
 
 
+def resolve_agent_id_by_slug(slug: str) -> str | None:
+    """Slug → id ONLY, for the URL-rewrite middleware. Avoids `SELECT *` reading
+    the full meta_json just to extract the id — that lookup runs on every
+    /book/{slug} + /api/agents/{slug} request (tens of thousands of calls), so
+    SELECT * there was needless Supabase egress."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT id FROM agents WHERE slug = ? AND is_deleted = ?"
+        ), (slug, False if _USE_PG else 0))
+        return row["id"] if row else None
+
+
+def resolve_mind_id_by_slug(slug: str) -> str | None:
+    """Slug → id ONLY, for the URL-rewrite middleware (see resolve_agent_id_by_slug)."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q("SELECT id FROM minds WHERE slug = ?"), (slug,))
+        return row["id"] if row else None
+
+
+# ── ops_state: tiny key/value for cross-run watchdog state (egress-watch cron) ──
+_ops_state_ready = False
+
+
+def _ensure_ops_state(conn) -> None:
+    global _ops_state_ready
+    if _ops_state_ready:
+        return
+    _execute(conn, _q(
+        "CREATE TABLE IF NOT EXISTS ops_state (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT)"
+    ))
+    _ops_state_ready = True
+
+
+def ops_state_get(key: str) -> str | None:
+    with get_conn() as conn:
+        _ensure_ops_state(conn)
+        row = _fetchone(conn, _q("SELECT value FROM ops_state WHERE key = ?"), (key,))
+        return row["value"] if row else None
+
+
+def ops_state_set(key: str, value: str) -> None:
+    with get_conn() as conn:
+        _ensure_ops_state(conn)
+        _execute(conn, _q(
+            "INSERT INTO ops_state (key, value, updated_at) VALUES (?, ?, ?) "
+            "ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at"
+        ), (key, value, _utcnow()))
+
+
 def update_agent_slug(agent_id: str, slug: str) -> None:
     with get_conn() as conn:
         _execute(conn, _q("UPDATE agents SET slug = ? WHERE id = ?"), (slug, agent_id))

--- a/app/core/notify.py
+++ b/app/core/notify.py
@@ -1,0 +1,54 @@
+"""Lightweight operational alerting via Resend (stdlib-only, no new deps).
+
+Sends to ALERT_EMAIL (default shuqi.yeow@gmail.com). The `from` address must be a
+Resend-verified sender — set ALERT_FROM to a verified one (default assumes the
+feynman.wiki domain is verified). Never raises: a failed alert must not break the
+caller (it's a watchdog, not a critical path)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TO = "shuqi.yeow@gmail.com"
+_DEFAULT_FROM = "Feynman Alerts <alerts@feynman.wiki>"
+
+
+def send_alert_email(subject: str, html: str, to: str | None = None) -> bool:
+    """POST an email via Resend. Returns True on 2xx, False otherwise (logged)."""
+    api_key = os.getenv("RESEND_API_KEY")
+    if not api_key:
+        log.warning("send_alert_email: RESEND_API_KEY not set — skipping")
+        return False
+    to_addr = to or os.getenv("ALERT_EMAIL", _DEFAULT_TO)
+    from_addr = os.getenv("ALERT_FROM", _DEFAULT_FROM)
+    payload = json.dumps(
+        {"from": from_addr, "to": [to_addr], "subject": subject, "html": html}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.resend.com/emails",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            ok = 200 <= resp.status < 300
+            if not ok:
+                log.error("send_alert_email: Resend returned %s", resp.status)
+            return ok
+    except Exception as exc:  # noqa: BLE001 — watchdog must never raise
+        body = ""
+        try:
+            body = exc.read().decode("utf-8")[:300]  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        log.error("send_alert_email: Resend send failed: %s %s", exc, body)
+        return False

--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,8 @@ from .core.db import (
     get_chat_session,
     get_mind,
     get_mind_by_slug,
+    resolve_agent_id_by_slug,
+    resolve_mind_id_by_slug,
     init_db,
     list_agents,
     list_chat_sessions,
@@ -199,10 +201,13 @@ async def _resolve_slug_path(request: Request, call_next):
             if seg and not _UUID_SEG.match(seg):
                 from starlette.concurrency import run_in_threadpool
                 is_mind = prefix in ("/api/minds/", "/mind/")
-                row = await run_in_threadpool(
-                    get_mind_by_slug if is_mind else get_agent_by_slug, seg)
-                if row:
-                    new_path = f"{prefix}{row['id']}{rest}"
+                # Resolve slug → id ONLY (not the full row): this runs on every
+                # slug request, and SELECT * here used to read the full meta_json
+                # just to grab the id — needless Supabase egress.
+                resolver = resolve_mind_id_by_slug if is_mind else resolve_agent_id_by_slug
+                resolved_id = await run_in_threadpool(resolver, seg)
+                if resolved_id:
+                    new_path = f"{prefix}{resolved_id}{rest}"
                     request.scope["path"] = new_path
                     request.scope["raw_path"] = new_path.encode("utf-8")
     except Exception:
@@ -3386,6 +3391,86 @@ _DISCOVER_CRON_ENABLED = os.getenv("ENABLE_DISCOVER_CRON", "true").strip().lower
     "0", "false", "no", "off",
 )
 _DISCOVER_CRON_MAX_INDEX = int(os.getenv("DISCOVER_CRON_MAX_INDEX", "5"))
+
+
+@app.get("/api/cron/egress-watch")
+def api_cron_egress_watch(request: Request) -> dict[str, Any]:
+    """Daily Supabase egress + DB-size watchdog. Snapshots pg_stat_statements
+    total rows returned (an egress proxy) and the database size; emails an alert
+    (Resend → ALERT_EMAIL, default shuqi.yeow@gmail.com) when the per-run rows
+    delta or DB size crosses a threshold. Postgres-only (the metric source);
+    no-op on SQLite. `?test=1` forces a test email to verify the wiring.
+
+    This exists because a `SELECT *` on /api/agents silently leaked tens of GB of
+    egress (754% over the free tier) and was only caught manually days later —
+    this catches that class of regression within a day.
+    """
+    _verify_cron(request)
+    import json as _json
+    from .core.notify import send_alert_email
+    if request.query_params.get("test"):
+        ok = send_alert_email(
+            "Feynman egress-watch — test alert",
+            "<p>Test of the egress-watch alert pipeline. If you received this, "
+            "Resend alerts are wired correctly.</p>",
+        )
+        return {"status": "test_sent" if ok else "test_failed"}
+
+    from .core.db import (
+        get_conn, _fetchone, _fetchall, _q, ops_state_get, ops_state_set, _USE_PG,
+    )
+    if not _USE_PG:
+        return {"status": "skip", "reason": "not postgres"}
+
+    _DB_LIMIT = 500 * 1024 * 1024  # Supabase free tier
+    _ROWS_DELTA_ALERT = int(os.getenv("EGRESS_WATCH_ROWS_DELTA", "3000000"))
+    try:
+        with get_conn() as conn:
+            db_bytes = int(_fetchone(conn, _q(
+                "SELECT pg_database_size(current_database()) AS b"), ())["b"])
+            tot = _fetchone(conn, _q(
+                "SELECT coalesce(sum(rows),0) AS r, coalesce(sum(calls),0) AS c "
+                "FROM pg_stat_statements"), ())
+            total_rows, total_calls = int(tot["r"]), int(tot["c"])
+            top = _fetchall(conn, _q(
+                "SELECT calls, rows, left(regexp_replace(query, '\\s+', ' ', 'g'), 140) AS q "
+                "FROM pg_stat_statements ORDER BY rows DESC LIMIT 6"), ())
+    except Exception as exc:  # pg_stat_statements may be unavailable — never break
+        return {"status": "error", "reason": str(exc)[:200]}
+
+    prev = _json.loads(ops_state_get("egress_watch") or "{}")
+    prev_rows = int(prev.get("total_rows", 0))
+    # None when pg_stat_statements was reset (counter went backwards) — skip the delta.
+    rows_delta = (total_rows - prev_rows) if total_rows >= prev_rows else None
+    ops_state_set("egress_watch", _json.dumps(
+        {"total_rows": total_rows, "total_calls": total_calls, "db_bytes": db_bytes}))
+
+    db_pct = round(100 * db_bytes / _DB_LIMIT, 1)
+    alerts: list[str] = []
+    if db_pct >= 90:
+        alerts.append(f"Database size at {db_pct}% of the 500MB free limit")
+    if rows_delta is not None and rows_delta >= _ROWS_DELTA_ALERT:
+        alerts.append(
+            f"{rows_delta:,} DB rows read since last check "
+            f"(threshold {_ROWS_DELTA_ALERT:,}) — possible egress spike")
+
+    if alerts:
+        rows_html = "".join(
+            f"<li><code>calls={r['calls']:,} rows={r['rows']:,}</code> — {r['q']}</li>"
+            for r in top)
+        html = (
+            "<h3>⚠️ Feynman egress-watch</h3><ul>"
+            + "".join(f"<li>{a}</li>" for a in alerts)
+            + "</ul>"
+            f"<p>DB size: {db_bytes // 1024 // 1024} MB / 500 MB ({db_pct}%). "
+            f"Cumulative: {total_rows:,} rows over {total_calls:,} calls.</p>"
+            f"<p>Top queries by rows (egress proxy):</p><ul>{rows_html}</ul>"
+            "<p>Usual cause: a SELECT * on a fat table (agents/minds meta_json, "
+            "chunks) on a hot/request path — project the columns in SQL.</p>"
+        )
+        send_alert_email(f"Feynman egress-watch: {alerts[0]}", html)
+        return {"status": "alerted", "alerts": alerts, "db_pct": db_pct, "rows_delta": rows_delta}
+    return {"status": "ok", "db_pct": db_pct, "rows_delta": rows_delta}
 
 
 @app.get("/api/cron/discover")

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,7 @@
     { "path": "/api/cron/seed-minds", "schedule": "0 0 * * 1" },
     { "path": "/api/cron/discover", "schedule": "0 6 * * 3" },
     { "path": "/api/cron/embed-minds", "schedule": "0 0 * * *" },
-    { "path": "/api/cron/indexnow", "schedule": "0 4 * * *" }
+    { "path": "/api/cron/indexnow", "schedule": "0 4 * * *" },
+    { "path": "/api/cron/egress-watch", "schedule": "0 8 * * *" }
   ]
 }


### PR DESCRIPTION
Continues the egress work after #110.

## 1. Hardening (continue fixing)
The slug→id URL-rewrite middleware called `get_agent_by_slug`/`get_mind_by_slug` = **`SELECT *`** (full meta_json) just to read the `id`, on **every** `/book/{slug}` + `/api/{slug}` request (~32k calls). New `resolve_agent_id_by_slug`/`resolve_mind_id_by_slug` do **`SELECT id`** only.

## 2. Guardrail — so a blowout can't go unnoticed again
`/api/cron/egress-watch` (daily Vercel cron) snapshots `pg_stat_statements` total rows (egress proxy) + DB size into a new `ops_state` kv, and **emails an alert via Resend** (`app/core/notify.send_alert_email` → `ALERT_EMAIL`, default **shuqi.yeow@gmail.com**) when the per-run rows-delta > 3M **or** DB > 90%. This is the monitoring that would have caught the 754% egress blowout **within a day** instead of days. `?test=1` forces a test email.

## Verified
- Against prod (psycopg2): the cron's read queries + `ops_state` upsert work; slug resolvers return correct ids; AST + vercel.json valid.
- After deploy I'll hit `?test=1` to confirm the email actually arrives (sender `ALERT_FROM` must be a Resend-verified domain — will flag if not).

Note: I deferred slimming the minds-list DB read — `_row_to_mind` hard-reads the fat columns so it's riskier, and it's only ~100MB (not the overage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)