### PR TITLE
fix(notify): User-Agent so Resend (behind Cloudflare) doesn't 1010-ban the alert

### DIFF
--- a/app/core/notify.py
+++ b/app/core/notify.py
@@ -35,6 +35,11 @@ def send_alert_email(subject: str, html: str, to: str | None = None) -> bool:
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            # Resend sits behind Cloudflare, which 1010-bans urllib's default UA
+            # ("Python-urllib/x") — the request fails before reaching Resend.
+            # A normal browser UA avoids the block (verified: default UA → CF 1010,
+            # this UA → proper Resend response).
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
         },
         method="POST",
     )


### PR DESCRIPTION
The egress-watch test email failed. Root cause: urllib's default UA (`Python-urllib/x`) is banned by the Cloudflare in front of `api.resend.com` (HTTP 403, CF error 1010) — the POST never reaches Resend. Verified: default UA → CF 1010; browser UA → proper Resend JSON response. This adds a browser UA to the Resend request.

**Still blocked on a manual step (not code):** `feynman.wiki` is not a verified Resend domain (`403 domain not verified`), and the Resend account owner is `stevetianqi@gmail.com` — until a domain is verified, Resend won't deliver to `shuqi.yeow@gmail.com`. After verifying a domain in Resend, set `ALERT_FROM` (+ `ALERT_EMAIL=shuqi.yeow@gmail.com`) in the feynman-pro env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)