### PR TITLE
fix(egress-watch): don't false-alarm on first cron run + activate CRON_SECRET

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3439,9 +3439,11 @@ def api_cron_egress_watch(request: Request) -> dict[str, Any]:
         return {"status": "error", "reason": str(exc)[:200]}
 
     prev = _json.loads(ops_state_get("egress_watch") or "{}")
+    has_prev = "total_rows" in prev
     prev_rows = int(prev.get("total_rows", 0))
-    # None when pg_stat_statements was reset (counter went backwards) — skip the delta.
-    rows_delta = (total_rows - prev_rows) if total_rows >= prev_rows else None
+    # rows_delta is None on the FIRST run (no baseline yet — don't false-alarm on
+    # the cumulative total) or when pg_stat_statements was reset (counter went back).
+    rows_delta = (total_rows - prev_rows) if (has_prev and total_rows >= prev_rows) else None
     ops_state_set("egress_watch", _json.dumps(
         {"total_rows": total_rows, "total_calls": total_calls, "db_bytes": db_bytes}))
 


### PR DESCRIPTION
Two things:
1. **Cold-start bug**: on the first egress-watch run there's no prior snapshot, so `rows_delta = total cumulative rows` (millions) → a spurious alert. Now the delta is only computed once a baseline exists; the first run just establishes it.
2. **Security**: `CRON_SECRET` is now set in the feynman-pro Vercel env (encrypted, prod+preview). This deploy makes `_verify_cron` enforce it → all `/api/cron/*` endpoints go from **open → authenticated**. Vercel Cron auto-sends the bearer, so the scheduled jobs keep working; manual/unauthorized calls now 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)