### PR TITLE
feat(mind): persistent Chat pill on the long SEO mind page

### DIFF
--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import EntityLayout from "@/components/seo/EntityLayout";
 import EntityActions, { type EntityAction } from "@/components/seo/EntityActions";
 import JsonLd from "@/components/seo/JsonLd";
+import MindStickyCta from "@/components/mind/MindStickyCta";
 import {
   DialoguesLink,
   MindBio,
@@ -196,6 +197,7 @@ export default async function MindPage({
 
   return (
     <EntityLayout hero={hero} rail={rail}>
+      <MindStickyCta name={mind.name} href={chatHref} />
       <JsonLd data={personLd} />
       <JsonLd data={breadcrumbLd} />
 

--- a/web/components/mind/MindStickyCta.tsx
+++ b/web/components/mind/MindStickyCta.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Persistent "Chat with {mind}" affordance for the long SEO mind page. The hero
+ * has the primary Chat button, but it scrolls away — an engaged reader who gets
+ * to the bottom (voice → perspectives → phrases → bio → works) has no way to
+ * start a chat without scrolling back up. This floating accent pill fades in
+ * ONLY after the hero has scrolled out of view (so it's never present at the top
+ * = not obtrusive), and works regardless of which element is the scroll
+ * container (IntersectionObserver on an in-flow sentinel, not window.scrollY).
+ */
+export default function MindStickyCta({ name, href }: { name: string; href: string }) {
+  const sentinel = useRef<HTMLSpanElement>(null);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => setShow(entry.boundingClientRect.top < 0),
+      { threshold: 0 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <>
+      {/* In-flow marker near the top of the content; once it scrolls above the
+          viewport the pill appears. */}
+      <span ref={sentinel} aria-hidden="true" style={{ display: "block", height: 0 }} />
+      <Link
+        href={href}
+        className={`mind-sticky-cta${show ? " visible" : ""}`}
+        aria-hidden={!show}
+        tabIndex={show ? 0 : -1}
+      >
+        Chat with {name}
+        <span className="mind-sticky-cta-arrow" aria-hidden="true">→</span>
+      </Link>
+    </>
+  );
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -303,6 +303,42 @@ body { background-color: var(--bg-home); }
 .seo-action.ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-strong); }
 .seo-action.ghost:hover { color: var(--text); background: rgba(128,128,128,0.08); }
 
+/* Persistent "Chat with {mind}" pill — fades in once the hero CTA scrolls away
+   (MindStickyCta). Floating + bottom-centered so it never sits at the top. */
+.mind-sticky-cta {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(14px);
+  z-index: 150;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 11px 22px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  white-space: nowrap;
+  box-shadow: var(--shadow-lg, 0 8px 28px rgba(0, 0, 0, 0.22));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s ease, transform 0.22s ease, opacity 0.15s ease;
+}
+.mind-sticky-cta.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+.mind-sticky-cta:hover { opacity: 0.92; color: #fff; }
+.mind-sticky-cta-arrow { font-size: 15px; line-height: 1; }
+@media (max-width: 640px) {
+  .mind-sticky-cta { bottom: 16px; padding: 12px 20px; }
+}
+
 /* Feynman share popup (custom — NOT the OS share sheet). */
 .seo-share-wrap { position: relative; display: inline-flex; }
 .seo-share-popup {


### PR DESCRIPTION
The hero `Chat with {mind}` button scrolls away on the long mind page, leaving an engaged reader with no way to start a chat. This adds a floating accent pill that **fades in only after the hero scrolls out of view** (IntersectionObserver on an in-flow sentinel, so it works regardless of which element scrolls), bottom-centered — never present at the top, so it's not obtrusive. Links to the 1:1 chat. Verify on preview: scroll a /mind page; pill fades in past the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)