### PR TITLE
feat(mind): conversion polish — Notable works → rail, chat-cue chips, gate empty dialogues, dialogue bubbles

### DIFF
--- a/web/app/mind/[id]/dialogues/page.tsx
+++ b/web/app/mind/[id]/dialogues/page.tsx
@@ -139,6 +139,7 @@ export default async function MindDialoguesPage({
         <section className="seo-section insights">
           {dialogues.map((d, i) => (
             <article key={i} className="insight-card">
+              <span className="insight-card-who">{mind.name}</span>
               <p>{d.text}</p>
             </article>
           ))}

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   fetchTopics,
   fetchMindLibrary,
   fetchMindThemes,
+  fetchMindDialogues,
   isMindTopicRelevant,
   mindSameAs,
   metaDescription,
@@ -96,12 +97,16 @@ export default async function MindPage({
   if (!mind) notFound();
 
   // Enrichment in parallel; each degrades to empty on failure.
-  const [agents, related, topics, library, themes] = await Promise.all([
+  const [agents, related, topics, library, themes, dialogues] = await Promise.all([
     fetchAgents(),
     fetchRelatedMinds(mind),
     fetchTopics(),
     fetchMindLibrary(params.id),
     fetchMindThemes(params.id),
+    // Gate the "Recent dialogues" link: only advertise it once the page has real
+    // content (matches the sitemap's ≥3-message gate), so the thousands of new
+    // minds don't link to an empty dialogues page.
+    fetchMindDialogues(params.id, 3),
   ]);
 
   const matchingTopics = topics.filter((t) => isMindTopicRelevant(mind, t));
@@ -170,6 +175,22 @@ export default async function MindPage({
             href={`/?mind=${encodeURIComponent(params.id)}&q=${encodeURIComponent(s.q)}`}
             className="mind-starter-chip"
           >
+            <svg
+              className="mind-starter-chip-icon"
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
             {s.label}
           </Link>
         ))}
@@ -182,18 +203,27 @@ export default async function MindPage({
   // the body ("How {mind} approaches key topics"); a rail "Topics" card repeated
   // the same labels on-screen (the bug the /topic review removed), so the
   // body section now carries BOTH the essay link and the topic-hub link instead.
-  const rail = related.length ? (
-    <div className="seo-rail-card">
-      <h3>Related minds</h3>
-      <ul>
-        {related.slice(0, 8).map((rm) => (
-          <li key={rm.id}>
-            <Link href={`/mind/${rm.slug || rm.id}`}>{rm.name}</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
-  ) : null;
+  // Rail = the mind's own Notable works (credibility + book links, promoted from
+  // the page bottom to the top-right) followed by complementary Related minds.
+  const hasWorks = (mind.works || []).filter(Boolean).length > 0;
+  const rail =
+    hasWorks || related.length ? (
+      <>
+        <MindWorks works={mind.works} agents={agents} variant="rail" />
+        {related.length ? (
+          <div className="seo-rail-card">
+            <h3>Related minds</h3>
+            <ul>
+              {related.slice(0, 8).map((rm) => (
+                <li key={rm.id}>
+                  <Link href={`/mind/${rm.slug || rm.id}`}>{rm.name}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </>
+    ) : null;
 
   return (
     <EntityLayout hero={hero} rail={rail}>
@@ -254,7 +284,9 @@ export default async function MindPage({
           </ul>
         </section>
       ) : null}
-      <DialoguesLink mindId={params.id} name={mind.name} />
+      {dialogues.length >= 3 ? (
+        <DialoguesLink mindId={params.id} name={mind.name} />
+      ) : null}
 
       {/* ③ In their voice — signature phrases + core approach (first-person feel). */}
       <MindPhrases phrases={mind.typical_phrases} />
@@ -264,7 +296,6 @@ export default async function MindPage({
       {/* ④ Encyclopedic context — demoted below the distinctive content. */}
       <MindBio bio={mind.bio_summary} />
       <MindThinkingStyle style={mind.thinking_style} />
-      <MindWorks works={mind.works} agents={agents} />
 
       {libraryExtra.length ? (
         <section className="seo-section">

--- a/web/components/seo/mind/MindSections.tsx
+++ b/web/components/seo/mind/MindSections.tsx
@@ -101,25 +101,36 @@ export function MindPersonaExcerpt({
 export function MindWorks({
   works,
   agents,
+  variant = "section",
 }: {
   works?: string[];
   agents: AgentRowLite[];
+  variant?: "section" | "rail";
 }) {
-  const list = (works || []).filter(Boolean).slice(0, 20);
+  const list = (works || []).filter(Boolean).slice(0, variant === "rail" ? 8 : 20);
   if (!list.length) return null;
   const idx = buildWorkLinkIndex(agents);
+  const items = list.map((w, i) => {
+    const bookId = matchWorkToBook(w, idx);
+    return (
+      <li key={i}>
+        {bookId ? <Link href={`/book/${bookId}`}>{w}</Link> : w}
+      </li>
+    );
+  });
+  // Rail variant: a compact credibility card up in the right column (works are a
+  // stronger entity signal than a buried bottom list).
+  if (variant === "rail") {
+    return (
+      <div className="seo-rail-card">
+        <h3>Notable works</h3>
+        <ul>{items}</ul>
+      </div>
+    );
+  }
   return (
     <Section heading="Notable works">
-      <ul className="works">
-        {list.map((w, i) => {
-          const bookId = matchWorkToBook(w, idx);
-          return (
-            <li key={i}>
-              {bookId ? <Link href={`/book/${bookId}`}>{w}</Link> : w}
-            </li>
-          );
-        })}
-      </ul>
+      <ul className="works">{items}</ul>
     </Section>
   );
 }

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -514,6 +514,20 @@ body { background-color: var(--bg-home); }
   text-decoration: none; transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 .mind-starter-chip:hover { border-color: var(--accent); color: var(--accent); background: rgba(128,128,128,0.06); }
+.mind-starter-chip-icon { width: 13px; height: 13px; margin-right: 5px; opacity: 0.55; flex-shrink: 0; }
+.mind-starter-chip:hover .mind-starter-chip-icon { opacity: 1; }
+
+/* ── Live AI dialogues — answer-only snippets, styled as the agent speaking ── */
+.insights { display: flex; flex-direction: column; gap: 14px; margin-top: 4px; }
+.insight-card {
+  padding: 14px 16px; max-width: 680px;
+  background: var(--bg-chat);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent);
+  border-radius: 14px;
+}
+.insight-card-who { display: block; font-size: 12px; font-weight: 600; color: var(--accent); margin-bottom: 5px; }
+.insight-card p { margin: 0; line-height: 1.6; color: var(--text); }
 
 /* ── "Think with X" — Type-2 imagined-perspective cards (the distinctive supply) ── */
 .mind-topic-cards {


### PR DESCRIPTION
Detail-page conversion improvements (from the mind-page review):

1. **Notable works → right rail.** Promoted from the page bottom to a compact rail card (stronger entity/credibility signal + book links visible without scrolling). `MindWorks` gains a `variant="rail"`.
2. **Chat-cue starter chips.** The 'Think with {mind}' chips get a small chat-bubble icon so they read as conversation starters, not topic tags. (They already deep-link into chat via `/?mind=&q=`.)
3. **Gate the empty dialogues link.** 'Recent dialogues' now renders only at ≥3 real messages (matches the sitemap's gate) — so the thousands of new minds don't link to an empty page.
4. **Dialogue bubbles.** Answer-only dialogue snippets get an agent-bubble style (accent rail + mind name) instead of unstyled text.

Verify on preview: a mind with works shows them top-right; chips show the icon; an empty mind has no dialogues link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)