### PR TITLE
fix(egress): cut mind-detail embedding read + similarities cold-start recompute

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1838,9 +1838,22 @@ def create_mind(data: dict[str, Any]) -> str:
     return mind_id
 
 
+# Columns _row_to_mind actually reads. Listed explicitly so the per-request mind
+# detail reads (get_mind / get_mind_by_slug / find_mind_by_name) don't pull the
+# fat ~12KB `embedding` BLOB that _row_to_mind discards anyway — a pure egress
+# win (these run on every mind page render; ~31K calls = a top Supabase-egress
+# source). The embedding is read only by the similarity path
+# (list_minds_with_embeddings).
+_MIND_DETAIL_COLS = (
+    "id, name, slug, era, domain, bio_summary, meta_json, persona, "
+    "thinking_style, typical_phrases, works, avatar_seed, wikidata_url, "
+    "wikipedia_url, version, chat_count, created_at"
+)
+
+
 def get_mind(mind_id: str) -> dict[str, Any] | None:
     with get_conn() as conn:
-        row = _fetchone(conn, _q("SELECT * FROM minds WHERE id = ?"), (mind_id,))
+        row = _fetchone(conn, _q(f"SELECT {_MIND_DETAIL_COLS} FROM minds WHERE id = ?"), (mind_id,))
         if not row:
             return None
         return _row_to_mind(row)
@@ -1849,7 +1862,7 @@ def get_mind(mind_id: str) -> dict[str, Any] | None:
 def find_mind_by_name(name: str) -> dict[str, Any] | None:
     with get_conn() as conn:
         row = _fetchone(conn, _q(
-            "SELECT * FROM minds WHERE LOWER(name) = LOWER(?)"
+            f"SELECT {_MIND_DETAIL_COLS} FROM minds WHERE LOWER(name) = LOWER(?)"
         ), (name,))
         if not row:
             return None
@@ -1859,7 +1872,7 @@ def find_mind_by_name(name: str) -> dict[str, Any] | None:
 def get_mind_by_slug(slug: str) -> dict[str, Any] | None:
     """Resolve a mind by its descriptive URL slug (behind /mind/{slug})."""
     with get_conn() as conn:
-        row = _fetchone(conn, _q("SELECT * FROM minds WHERE slug = ?"), (slug,))
+        row = _fetchone(conn, _q(f"SELECT {_MIND_DETAIL_COLS} FROM minds WHERE slug = ?"), (slug,))
         return _row_to_mind(row) if row else None
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -5087,26 +5087,45 @@ def api_list_minds(background_tasks: BackgroundTasks):
 
 _similarities_cache: dict[str, Any] = {}
 _similarities_cache_ts: float = 0
-_SIMILARITIES_TTL = 3600  # 1 hour
+_SIMILARITIES_TTL = 3600  # 1 hour (warm-instance L1)
+_SIM_OPS_KEY = "mind_similarities_v1"
+_SIM_OPS_TTL = 21600  # 6h — bound how often the ~7.7MB embedding read recomputes
 
 @app.get("/api/minds/similarities")
 def api_mind_similarities():
     from fastapi.responses import JSONResponse
     from .core.minds import compute_mind_similarities, compute_mind_layout
+    from .core.db import ops_state_get, ops_state_set
     global _similarities_cache, _similarities_cache_ts
     now = time.monotonic()
+    hdrs = {"Cache-Control": "public, max-age=3600, s-maxage=3600"}
+    # L1 — warm-instance memory cache.
     if _similarities_cache and (now - _similarities_cache_ts) < _SIMILARITIES_TTL:
-        return JSONResponse(
-            content=_similarities_cache,
-            headers={"Cache-Control": "public, max-age=3600, s-maxage=3600"},
-        )
+        return JSONResponse(content=_similarities_cache, headers=hdrs)
+    # L2 — durable cross-instance cache (ops_state). The recompute below reads
+    # ALL mind embeddings (~7.7MB); on Vercel every cold start / Bearer request
+    # has an empty L1, so without this each one re-read the whole embedding set
+    # (a top Supabase-egress source). Serve the stored result until it ages out.
+    try:
+        raw = ops_state_get(_SIM_OPS_KEY)
+        if raw:
+            stored = json.loads(raw)
+            if (time.time() - stored.get("ts", 0)) < _SIM_OPS_TTL:
+                _similarities_cache = stored["data"]
+                _similarities_cache_ts = now
+                return JSONResponse(content=stored["data"], headers=hdrs)
+    except Exception as exc:
+        log.warning("similarities L2 cache read failed: %s", exc)
+    # Both caches cold → the expensive recompute (reads all embeddings once),
+    # then persist to L2 so other instances skip it for _SIM_OPS_TTL.
     result = {"links": compute_mind_similarities(), "layout": compute_mind_layout()}
     _similarities_cache = result
     _similarities_cache_ts = now
-    return JSONResponse(
-        content=result,
-        headers={"Cache-Control": "public, max-age=3600, s-maxage=3600"},
-    )
+    try:
+        ops_state_set(_SIM_OPS_KEY, json.dumps({"ts": time.time(), "data": result}))
+    except Exception as exc:
+        log.warning("similarities L2 cache write failed: %s", exc)
+    return JSONResponse(content=result, headers=hdrs)
 
 
 @app.get("/api/minds/{mind_id}")


### PR DESCRIPTION
Follow-up to the #110 egress fix. `pg_stat_statements` (since 2026-05-27) shows the big `SELECT *` agents-list spike is gone (the hot `/api/agents` path is lite now), and the remaining DB egress is two fat-row patterns:

1. **`get_mind` / `get_mind_by_slug` / `find_mind_by_name` did `SELECT * FROM minds`** — pulling the ~12KB `embedding` BLOB on every mind-detail render (~31K calls), even though `_row_to_mind` **discards** it. Now project the 17 columns it actually reads → ~17KB→~5KB/row, **zero behavior change**.
2. **`/api/minds/similarities`** recomputes `compute_mind_similarities` + `compute_mind_layout`, each reading **all ~643 embeddings (~7.7MB)**, behind an **in-memory** cache that resets on every Vercel cold start / Bearer request (~609 calls × 7.7MB ≈ **4.7GB**). Added a **durable L2 cache in `ops_state` (6h TTL)** so the embedding read recomputes ~4×/day globally instead of per cold start.

Diagnosed via `pg_stat_statements ORDER BY rows DESC` per the egress-hygiene memory rules. Verify post-deploy: `/api/minds/similarities` still returns links+layout; egress dashboard drops over 24-48h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)