### PR TITLE
feat(minds): /api/cron/voice-minds — auto-backfill first-person voice

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1967,6 +1967,52 @@ def update_mind_links(mind_id: str, wikidata_url: str | None = None, wikipedia_u
         ), (wikidata_url or None, wikipedia_url or None, mind_id))
 
 
+def list_minds_missing_voice(limit: int = 50) -> list[dict[str, Any]]:
+    """Minds with no first-person meta_json.voice yet (drives /api/cron/voice-minds).
+    On PG, filters in SQL so only the missing rows egress; reads just the columns the
+    voice prompt needs (NOT embedding/persona)."""
+    with get_conn() as conn:
+        if _USE_PG:
+            rows = _fetchall(conn, _q(
+                "SELECT id, name, domain, bio_summary, thinking_style FROM minds "
+                "WHERE meta_json IS NULL OR meta_json = '' "
+                "OR COALESCE(NULLIF(meta_json, '')::jsonb ->> 'voice', '') = '' "
+                "LIMIT ?"
+            ), (limit,))
+            return [dict(r) for r in rows]
+        # SQLite (local dev): no jsonb operator → read + filter in Python.
+        rows = _fetchall(conn, _q(
+            "SELECT id, name, domain, bio_summary, thinking_style, meta_json FROM minds"
+        ))
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        try:
+            v = (json.loads(r.get("meta_json") or "{}").get("voice") or "").strip()
+        except Exception:
+            v = ""
+        if not v:
+            out.append(dict(r))
+            if len(out) >= limit:
+                break
+    return out
+
+
+def update_mind_voice(mind_id: str, voice: str) -> None:
+    """Merge a generated first-person voice into minds.meta_json.voice, preserving
+    any other meta fields."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q("SELECT meta_json FROM minds WHERE id = ?"), (mind_id,))
+        meta: dict[str, Any] = {}
+        if row and row.get("meta_json"):
+            try:
+                meta = json.loads(row["meta_json"])
+            except Exception:
+                meta = {}
+        meta["voice"] = voice
+        _execute(conn, _q("UPDATE minds SET meta_json = ? WHERE id = ?"),
+                 (json.dumps(meta), mind_id))
+
+
 def get_mind_meta(mind_id: str) -> dict[str, Any]:
     """A mind's PRIVATE meta dict — pre-stored SEO content (Type-2 essays under
     `essays`). Deliberately NOT surfaced by `_row_to_mind` / the public mind API,

--- a/app/core/minds.py
+++ b/app/core/minds.py
@@ -22,8 +22,10 @@ from .db import (
     list_mind_memories,
     list_minds,
     list_minds_missing_embeddings,
+    list_minds_missing_voice,
     list_minds_with_embeddings,
     update_mind_embedding,
+    update_mind_voice,
     upsert_compiled_memory,
 )
 from .providers import ProviderError, bulk_chat, chat_with_fallback, pick_provider
@@ -202,6 +204,51 @@ def backfill_mind_embeddings(batch_size: int = 10) -> int:
             log.warning("Backfill embed failed for %s: %s", mind["name"], exc)
     log.info("Backfilled embeddings for %d/%d minds (%d remaining)", count, len(missing), len(missing) - count)
     return count
+
+
+_VOICE_SYSTEM = (
+    "You ARE the named historical thinker, speaking in the FIRST person to a "
+    "curious person who is about to think WITH you. Voice: distinctive, confident, "
+    "grounded in your real work and era. Never break character."
+)
+
+
+def _voice_prompt(name: str, domain: str, bio: str, style: str) -> str:
+    return (
+        f"Introduce yourself as {name} ({domain or 'a great thinker'}) in the FIRST "
+        "person — 2 to 3 sentences, 40-65 words. Say how you see your field and the "
+        "one thing you most want a newcomer to grasp. Use 'I'. Make it an invitation "
+        "to think together — NOT a resume, NO birth/death dates, never 'I was a …'. "
+        "Do NOT open with a greeting (no 'Ah', 'Hello', 'Greetings', 'Welcome', "
+        "'Hi', 'Hail') — open directly with your name or an idea. "
+        f"Ground it in:\n{(bio or '')[:380]}\n{(style or '')[:280]}"
+    )
+
+
+def backfill_mind_voices(batch_size: int = 6) -> tuple[int, int]:
+    """Generate the first-person meta_json.voice for minds that lack it, up to
+    batch_size per call. Uses bulk_chat (the CHAT provider → DeepSeek fallback, so it
+    works even where the Gemini embedding API is geoblocked). Returns
+    (voiced, remaining); call repeatedly until remaining == 0 — mirrors
+    backfill_mind_embeddings, drives /api/cron/voice-minds."""
+    missing = list_minds_missing_voice(limit=200)
+    count = 0
+    for r in missing[:batch_size]:
+        try:
+            res, _ = bulk_chat(
+                system=_VOICE_SYSTEM,
+                user=_voice_prompt(
+                    r["name"], r.get("domain"), r.get("bio_summary"), r.get("thinking_style")
+                ),
+            )
+            voice = (res.content or "").strip().strip('"').strip()
+            if len(voice) < 30:
+                continue
+            update_mind_voice(r["id"], voice)
+            count += 1
+        except Exception as exc:
+            log.warning("Voice backfill failed for %s: %s", r.get("name"), exc)
+    return count, max(0, len(missing) - count)
 
 
 def compute_mind_layout() -> list[dict[str, Any]]:

--- a/app/main.py
+++ b/app/main.py
@@ -3561,6 +3561,23 @@ def api_cron_embed_minds(request: Request) -> dict[str, Any]:
         return {"status": "error", "detail": str(exc)}
 
 
+@app.get("/api/cron/voice-minds")
+def api_cron_voice_minds(request: Request) -> dict[str, Any]:
+    """Cron-triggered first-person voice backfill for minds missing meta_json.voice
+    (the Feynman-native About hero). Bounded per call (chat-LLM latency) to stay
+    within the Vercel function timeout; runs daily so new minds self-fill. Voice goes
+    through the CHAT provider (DeepSeek fallback), so unlike embeddings it isn't
+    blocked when Gemini is geoblocked."""
+    _verify_cron(request)
+    from .core.minds import backfill_mind_voices
+    try:
+        voiced, remaining = backfill_mind_voices(batch_size=6)
+        return {"status": "ok", "voiced": voiced, "remaining": remaining}
+    except Exception as exc:
+        log.error("Voice-minds cron failed: %s", exc)
+        return {"status": "error", "detail": str(exc)}
+
+
 @app.get("/api/cron/reset-embeddings")
 def api_cron_reset_embeddings() -> dict[str, Any]:
     """Clear all corrupted embeddings so backfill can regenerate them."""

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,7 @@
     { "path": "/api/cron/seed-minds", "schedule": "0 0 * * 1" },
     { "path": "/api/cron/discover", "schedule": "0 6 * * 3" },
     { "path": "/api/cron/embed-minds", "schedule": "0 0 * * *" },
+    { "path": "/api/cron/voice-minds", "schedule": "0 2 * * *" },
     { "path": "/api/cron/indexnow", "schedule": "0 4 * * *" },
     { "path": "/api/cron/egress-watch", "schedule": "0 8 * * *" }
   ]


### PR DESCRIPTION
Minds created during the Gemini-geoblock window lack `meta_json.voice` (the first-person "In X's own words" hero). Voice goes through `bulk_chat` (the **chat** provider → DeepSeek fallback), **not** the geoblocked embedding API, so it runs fine on Vercel.

- `backfill_mind_voices()` (mirrors `backfill_mind_embeddings`: batched, returns `(voiced, remaining)`)
- `list_minds_missing_voice` / `update_mind_voice` db helpers (SQL-filtered on PG so only missing rows egress)
- `GET /api/cron/voice-minds` (cron-authed, `batch_size=6` to fit the 60s function limit)
- daily **02:00 UTC** Vercel cron (offset from embed-minds at 00:00)

New minds self-fill their voice within ~a day; I'll loop the endpoint post-deploy to backfill the current gap immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)