### PR TITLE
perf: kill uuid→slug 301 hop, add loading skeletons, give async buttons pending states

### DIFF
--- a/web/app/a/[id]/loading.tsx
+++ b/web/app/a/[id]/loading.tsx
@@ -1,0 +1,8 @@
+import { SeoColumnSkeleton } from "@/components/seo/EntitySkeleton";
+
+// Instant fallback for the public shared-answer permalink (awaits
+// fetchPublicAnswer before render). Streams the shell first instead of a
+// blank page.
+export default function Loading() {
+  return <SeoColumnSkeleton />;
+}

--- a/web/app/book/[id]/loading.tsx
+++ b/web/app/book/[id]/loading.tsx
@@ -1,0 +1,8 @@
+import EntitySkeleton from "@/components/seo/EntitySkeleton";
+
+// Instant Suspense fallback for /book/[id] (the page awaits 5 enrichment fetches
+// before first byte). Without it, clicking a book's Details sat on the previous
+// page with no feedback for the whole round-trip.
+export default function Loading() {
+  return <EntitySkeleton variant="book" />;
+}

--- a/web/app/discussions/[id]/loading.tsx
+++ b/web/app/discussions/[id]/loading.tsx
@@ -1,0 +1,8 @@
+import { SeoColumnSkeleton } from "@/components/seo/EntitySkeleton";
+
+// Instant fallback for the public shared-discussion permalink (awaits
+// fetchPublicDiscussion before render). Streams the shell first instead of a
+// blank page.
+export default function Loading() {
+  return <SeoColumnSkeleton />;
+}

--- a/web/app/mind/[id]/chat/loading.tsx
+++ b/web/app/mind/[id]/chat/loading.tsx
@@ -1,0 +1,41 @@
+import AppShell from "@/components/shell/AppShell";
+
+// Instant fallback for the 1:1 mind chat (force-dynamic → always awaits fetchMind
+// before render). A chat-shaped shimmer inside the app shell beats a blank page
+// while the mind loads. Its own loading.tsx (rather than the parent /mind/[id]
+// one) keeps the profile skeleton from flashing on a chat navigation.
+function Bar({ w, h = 14, r = 6, mt = 0 }: { w: number | string; h?: number; r?: number; mt?: number }) {
+  return (
+    <span
+      className="skeleton-block"
+      style={{ display: "block", width: w, height: h, borderRadius: r, marginTop: mt }}
+      aria-hidden="true"
+    />
+  );
+}
+
+export default function Loading() {
+  return (
+    <AppShell>
+      <div
+        style={{ maxWidth: 760, margin: "0 auto", padding: "32px 20px", width: "100%" }}
+        aria-busy="true"
+        aria-label="Loading chat"
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <span className="skeleton-block" style={{ width: 44, height: 44, borderRadius: "50%" }} aria-hidden="true" />
+          <div>
+            <Bar w={160} h={18} r={6} />
+            <Bar w={100} h={12} mt={8} />
+          </div>
+        </div>
+        <Bar w="85%" h={14} mt={40} />
+        <Bar w="92%" h={14} mt={12} />
+        <Bar w="60%" h={14} mt={12} />
+        <div style={{ marginTop: 28 }}>
+          <Bar w="100%" h={52} r={16} />
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/web/app/mind/[id]/loading.tsx
+++ b/web/app/mind/[id]/loading.tsx
@@ -1,0 +1,8 @@
+import EntitySkeleton from "@/components/seo/EntitySkeleton";
+
+// Instant Suspense fallback for /mind/[id] (the page awaits the mind + 6 parallel
+// enrichment fetches). Without it, clicking a mind's Profile sat on the previous
+// page with no feedback for the whole round-trip.
+export default function Loading() {
+  return <EntitySkeleton variant="mind" />;
+}

--- a/web/app/topic/[slug]/loading.tsx
+++ b/web/app/topic/[slug]/loading.tsx
@@ -1,0 +1,8 @@
+import EntitySkeleton from "@/components/seo/EntitySkeleton";
+
+// Instant Suspense fallback for /topic/[slug] — the most frequently navigated
+// SEO hub (4 parallel fetches: agents, minds, topics, overview). Without it,
+// clicking a topic sat on the previous page with no feedback.
+export default function Loading() {
+  return <EntitySkeleton variant="topic" />;
+}

--- a/web/components/auth/LoginForm.tsx
+++ b/web/components/auth/LoginForm.tsx
@@ -22,6 +22,7 @@ export default function LoginForm() {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [busy, setBusy] = useState(false);
+  const [googleBusy, setGoogleBusy] = useState(false);
 
   function toggleMode() {
     setIsSignUp((v) => !v);
@@ -37,10 +38,14 @@ export default function LoginForm() {
       setError("Authentication is not configured.");
       return;
     }
+    // OAuth redirects away on success, so only clear busy on error — the button
+    // stays "Connecting…" until the navigation happens.
+    setGoogleBusy(true);
     try {
       await signInWithOAuth("google");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
+      setGoogleBusy(false);
     }
   }
 
@@ -129,14 +134,14 @@ export default function LoginForm() {
           An interactive knowledge network of books, minds, and ideas.
         </p>
 
-        <button type="button" className="login-google" onClick={onGoogle}>
+        <button type="button" className="login-google" onClick={onGoogle} disabled={googleBusy}>
           <svg width="20" height="20" viewBox="0 0 24 24">
             <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
             <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
             <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.96 10.96 0 0 0 1 12c0 1.77.42 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
             <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
           </svg>
-          Continue with Google
+          {googleBusy ? "Connecting…" : "Continue with Google"}
         </button>
         <p className="login-oauth-terms">
           By continuing, you agree to our{" "}

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -266,7 +266,9 @@ export default function ChatView({
   // "Anonymous" (ChatGPT-style), then surface the clean PublishToast. The
   // backend's <3-message gate (422, string detail — no code) becomes a small
   // inline hint instead of a modal.
+  const [sharing, setSharing] = useState(false);
   const doShare = useCallback(async () => {
+    setSharing(true);
     try {
       const rec = await post<ShareRecord>(
         `/api/chat-sessions/${encodeURIComponent(sessionId)}/share`,
@@ -285,6 +287,8 @@ export default function ChatView({
           ? "Start the chat before sharing it."
           : apiErrorText(e, "Couldn’t publish — please try again."),
       );
+    } finally {
+      setSharing(false);
     }
   }, [sessionId, flashShareHint, withdrawSession]);
 
@@ -1127,8 +1131,9 @@ export default function ChatView({
                   ? setToast({ url: publicUrl, withdraw: withdrawSession })
                   : doShare()
               }
+              disabled={sharing}
             >
-              <ShareIcon />
+              {sharing ? <span className="inline-spinner" aria-hidden="true" /> : <ShareIcon />}
               {isPublic && (
                 <span
                   id="share-status-indicator"

--- a/web/components/chat/ComposerPickers.tsx
+++ b/web/components/chat/ComposerPickers.tsx
@@ -35,6 +35,9 @@ export interface SelectedBook {
   agentId: string;
   title: string;
   author: string;
+  /** True while a preselected book's title is still resolving — renders an
+   *  optimistic shimmer chip so the composer never sits visibly empty. */
+  loading?: boolean;
 }
 
 export interface SelectedMind {
@@ -64,19 +67,25 @@ export function SelectedChips({
   if (!books.size && !minds.size) return null;
   return (
     <div className="selected-chips">
-      {[...books.entries()].map(([id, b]) => (
-        <div className="book-chip" key={id}>
-          <span>{b.title}</span>
-          <button
-            type="button"
-            className="chip-remove"
-            aria-label={`Remove ${b.title}`}
-            onClick={() => onRemoveBook(id)}
-          >
-            ×
-          </button>
-        </div>
-      ))}
+      {[...books.entries()].map(([id, b]) =>
+        b.loading ? (
+          <div className="book-chip loading" key={id} aria-label="Loading book" aria-busy="true">
+            <span className="chip-skeleton" />
+          </div>
+        ) : (
+          <div className="book-chip" key={id}>
+            <span>{b.title}</span>
+            <button
+              type="button"
+              className="chip-remove"
+              aria-label={`Remove ${b.title}`}
+              onClick={() => onRemoveBook(id)}
+            >
+              ×
+            </button>
+          </div>
+        ),
+      )}
       {[...minds.entries()].map(([id, m]) => (
         <div className="mind-chip" key={id}>
           <span className="mind-chip-avatar" style={{ background: mindColor(m.name) }}>

--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -16,7 +16,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { getMind, type Agent, type Mind } from "@/lib/api";
-import { getAgentCached } from "@/lib/catalog";
+import { getAgentCached, getCachedCatalogBooks } from "@/lib/catalog";
 import { createSession, bumpSessions } from "@/lib/chat";
 import { startWriteBook } from "@/lib/writeBook";
 import { useAuth } from "@/lib/auth";
@@ -198,33 +198,53 @@ export default function HomeComposer() {
   // first (cheap, already cached), falling back to a direct /api/agents/{id}
   // fetch for books the catalog filter excludes (matches the legacy fallback).
   const preselectBook = (bookId: string) => {
-    // Resolve the book id → chip via the single-agent endpoint, which the slug
-    // middleware resolves for BOTH a uuid and a descriptive slug. Going direct
-    // (instead of downloading the full ~7MB /api/agents catalog and scanning it)
-    // is the fix for "Chat with this book" landing on an empty composer: a slug
-    // never matched the uuid-keyed catalog, so it fell through to this same
-    // fetch anyway — but only after a multi-second catalog download, leaving the
-    // composer empty ~4s. Now it's one small request.
+    // Fast path: when the catalog is already warm in this session (the common
+    // case — the user came from Library, which fetches it), resolve the chip
+    // title SYNCHRONOUSLY. No network wait, no flash: the chip is correct on the
+    // first paint. Match a uuid OR a descriptive slug (?book= carries either).
+    const cached = getCachedCatalogBooks()?.find(
+      (b) => b.agentId === bookId || b.slug === bookId,
+    );
+    if (cached) {
+      setBooks(
+        new Map([
+          [cached.agentId, { id: cached.agentId, agentId: cached.agentId, title: cached.title, author: cached.author }],
+        ]),
+      );
+      return;
+    }
+
+    // Cold path (direct ?book= link, catalog not loaded): show an optimistic
+    // LOADING chip immediately so the composer never sits visibly empty, then
+    // swap in the real title when the single-agent fetch lands. Resolving via
+    // the single-agent endpoint (the slug middleware resolves both a uuid and a
+    // slug) is the fix for the old "download the ~7MB catalog and scan it" path
+    // that left the composer empty ~4s.
+    setBooks(new Map([[bookId, { id: bookId, agentId: bookId, title: "", author: "", loading: true }]]));
     getAgentCached(bookId)
       .then((agent: Agent) => {
-        if (agent?.id) {
-          setBooks(
-            new Map([
-              [
-                agent.id,
-                {
-                  id: agent.id,
-                  agentId: agent.id,
-                  title: agent.name,
-                  author: (agent.author as string) || "",
-                },
-              ],
-            ]),
-          );
-        }
+        setBooks((prev) => {
+          const next = new Map(prev);
+          next.delete(bookId); // drop the optimistic placeholder
+          if (agent?.id) {
+            next.set(agent.id, {
+              id: agent.id,
+              agentId: agent.id,
+              title: agent.name,
+              author: (agent.author as string) || "",
+            });
+          }
+          return next;
+        });
       })
       .catch(() => {
-        /* book preselect is best-effort */
+        // Best-effort: drop the placeholder so a failed lookup doesn't leave a
+        // permanent shimmer (the user can still pick the book manually).
+        setBooks((prev) => {
+          const next = new Map(prev);
+          next.delete(bookId);
+          return next;
+        });
       });
   };
 

--- a/web/components/chat/MessageList.tsx
+++ b/web/components/chat/MessageList.tsx
@@ -51,18 +51,37 @@ function ShareGlyph() {
 }
 
 /** Hover "Share" action under an assistant/mind answer (per-turn share entry). */
-function ShareAnswerAction({ onClick }: { onClick: () => void }) {
+function ShareAnswerAction({
+  onShare,
+  index,
+}: {
+  onShare: (index: number) => void | Promise<void>;
+  index: number;
+}) {
+  // Own the pending state locally so a per-turn share shows immediate feedback
+  // (the publish POST can take ~1s) without threading a sharing-index down from
+  // ChatView through MessageList.
+  const [busy, setBusy] = useState(false);
   return (
     <div className={styles.msgActions}>
       <button
         type="button"
         className={styles.shareMsgBtn}
-        onClick={onClick}
+        disabled={busy}
+        onClick={async () => {
+          if (busy) return;
+          setBusy(true);
+          try {
+            await onShare(index);
+          } finally {
+            setBusy(false);
+          }
+        }}
         aria-label="Share this answer"
         title="Share this answer"
       >
         <ShareGlyph />
-        <span>Share</span>
+        <span>{busy ? "Sharing…" : "Share"}</span>
       </button>
     </div>
   );
@@ -175,7 +194,7 @@ function AssistantMessage({
 }: {
   msg: Message;
   index: number;
-  onShare?: (index: number) => void;
+  onShare?: (index: number) => void | Promise<void>;
 }) {
   const refs = msg.opts?.references || [];
   const webSrcs = msg.opts?.webSources || [];
@@ -273,7 +292,7 @@ function AssistantMessage({
             {usage.total_tokens} tokens
           </div>
         )}
-        {onShare && <ShareAnswerAction onClick={() => onShare(index)} />}
+        {onShare && <ShareAnswerAction onShare={onShare} index={index} />}
       </div>
     </div>
   );
@@ -416,7 +435,7 @@ function MindMessage({
 }: {
   msg: Message;
   index: number;
-  onShare?: (index: number) => void;
+  onShare?: (index: number) => void | Promise<void>;
 }) {
   const name = msg.mindName || "";
   const raw = String(msg.content ?? "");
@@ -449,7 +468,7 @@ function MindMessage({
             {usage.total_tokens} tokens
           </div>
         )}
-        {onShare && <ShareAnswerAction onClick={() => onShare(index)} />}
+        {onShare && <ShareAnswerAction onShare={onShare} index={index} />}
       </div>
     </div>
   );
@@ -494,7 +513,7 @@ export default function MessageList({
   /** When provided, each assistant/mind answer shows a hover "Share" action
    *  that publishes that single turn (index = position in this list, which
    *  matches the persisted transcript order the backend indexes by). */
-  onShareMessage?: (index: number) => void;
+  onShareMessage?: (index: number) => void | Promise<void>;
 }) {
   return (
     <>

--- a/web/components/chat/RelatedBooks.tsx
+++ b/web/components/chat/RelatedBooks.tsx
@@ -78,7 +78,8 @@ export default function RelatedBooks({
         {related.map((b) => (
           <Link
             key={b.id}
-            href={`/book/${encodeURIComponent(b.agentId)}`}
+            // Slug (not uuid) → skip the middleware's blocking uuid→slug 301 hop.
+            href={`/book/${encodeURIComponent(b.slug || b.agentId)}`}
             className="sidebar-book-item"
           >
             <div className="sidebar-book-info">

--- a/web/components/chat/ShareModal.tsx
+++ b/web/components/chat/ShareModal.tsx
@@ -28,6 +28,7 @@ export function PublishToast({
   onWithdraw: () => Promise<void>;
 }) {
   const [copied, setCopied] = useState(false);
+  const [unsharing, setUnsharing] = useState(false);
 
   const copy = () => {
     try {
@@ -40,16 +41,20 @@ export function PublishToast({
   };
 
   const unshare = async () => {
+    if (unsharing) return;
     if (
       !window.confirm(
         "Make this private again? The public link will stop working immediately.",
       )
     )
       return;
+    setUnsharing(true);
     try {
       await onWithdraw();
     } catch {
       /* fail silently — caller handles errors */
+    } finally {
+      setUnsharing(false);
     }
   };
 
@@ -67,8 +72,8 @@ export function PublishToast({
         <a className="publish-toast-open" href={url} target="_blank" rel="noopener noreferrer">
           Open
         </a>
-        <button className="publish-toast-unshare" onClick={unshare}>
-          Make private
+        <button className="publish-toast-unshare" onClick={unshare} disabled={unsharing}>
+          {unsharing ? "Making private…" : "Make private"}
         </button>
         <button className="publish-toast-close" aria-label="Dismiss" onClick={onClose}>
           ×

--- a/web/components/library/BookCard.tsx
+++ b/web/components/library/BookCard.tsx
@@ -30,7 +30,10 @@ export default function BookCard({
   const canRead = book.hasFullText;
   const canPreview = !book.hasFullText && book.status === "ready";
   const overlay = canRead ? "Read" : canPreview ? "Preview" : "";
-  const detailHref = `/book/${encodeURIComponent(book.agentId)}`;
+  // Link the descriptive slug (not the uuid) so the details navigation skips the
+  // middleware's blocking uuid→slug origin fetch + 301 redirect. Falls back to the
+  // uuid for un-backfilled rows (still resolves, just via the legacy hop).
+  const detailHref = `/book/${encodeURIComponent(book.slug || book.agentId)}`;
   const readHref = `/read/${encodeURIComponent(book.agentId)}`;
   const chatHref = `/?book=${encodeURIComponent(book.agentId)}`;
   // The cover block reads/previews when there's content; a catalog stub has

--- a/web/components/mind/MindChat.tsx
+++ b/web/components/mind/MindChat.tsx
@@ -184,7 +184,8 @@ function MindMetaSidebar({ mind }: { mind: MindDetail }) {
   // chat_count isn't always in the minds JSON; read it defensively (MindDetail
   // has an index signature). Falls back to 0 like the legacy `|| 0`.
   const chatCount = Number((mind as { chat_count?: number }).chat_count || 0);
-  const profileHref = `/mind/${encodeURIComponent(mind.id)}`;
+  // Slug (not uuid) → skip the middleware's blocking uuid→slug 301 hop.
+  const profileHref = `/mind/${encodeURIComponent(mind.slug || mind.id)}`;
 
   const [shareOpen, setShareOpen] = useState(false);
   const [copied, setCopied] = useState(false);

--- a/web/components/minds/MindsGraph.tsx
+++ b/web/components/minds/MindsGraph.tsx
@@ -380,7 +380,8 @@ export default function MindsGraph() {
         const cx = e.clientX - rect.left;
         const cy = e.clientY - rect.top;
         const n = nodeAt(cx, cy, transform.invert([cx, cy]));
-        if (n) router.push(`/mind/${encodeURIComponent(n.id)}`);
+        // Slug (not uuid) → skip the middleware's blocking uuid→slug 301 hop.
+        if (n) router.push(`/mind/${encodeURIComponent(n.slug || n.id)}`);
       },
       { signal },
     );
@@ -668,7 +669,9 @@ export default function MindsGraph() {
               <button
                 className="tt-profile-btn"
                 title={`View ${tooltip.node.name}'s profile`}
-                onClick={() => router.push(`/mind/${encodeURIComponent(tooltip.node.id)}`)}
+                // Link the descriptive slug (not the uuid) so navigation skips the
+                // middleware's blocking uuid→slug origin fetch + 301 redirect.
+                onClick={() => router.push(`/mind/${encodeURIComponent(tooltip.node.slug || tooltip.node.id)}`)}
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
@@ -684,7 +687,7 @@ export default function MindsGraph() {
                 // 1:1 chat page (legacy #/mind/{id} WAS this chat surface).
                 onClick={() =>
                   requirePro(() =>
-                    router.push(`/mind/${encodeURIComponent(tooltip.node.id)}/chat`),
+                    router.push(`/mind/${encodeURIComponent(tooltip.node.slug || tooltip.node.id)}/chat`),
                   )
                 }
               >

--- a/web/components/seo/EntitySkeleton.tsx
+++ b/web/components/seo/EntitySkeleton.tsx
@@ -1,0 +1,97 @@
+import EntityLayout from "@/components/seo/EntityLayout";
+import SeoColumn from "@/components/seo/SeoColumn";
+
+/**
+ * Instant loading skeleton for the SEO entity routes (/book/[id], /mind/[id]).
+ *
+ * These pages are Server Components that await 5–7 enrichment fetches before
+ * the first byte. With no `loading.tsx` the browser sat on the PREVIOUS page
+ * for the whole round-trip — the "click Profile / Details and nothing happens
+ * for a few seconds" bug. Rendering this through the SAME EntityLayout (hero +
+ * grid + rail inside the app shell) means the shell stays put and only the
+ * content cross-fades from shimmer → real, so navigation feels immediate.
+ */
+function Bar({ w, h = 14, r = 6, mt = 0 }: { w: number | string; h?: number; r?: number; mt?: number }) {
+  return (
+    <span
+      className="skeleton-block"
+      style={{ display: "block", width: w, height: h, borderRadius: r, marginTop: mt }}
+      aria-hidden="true"
+    />
+  );
+}
+
+export default function EntitySkeleton({ variant }: { variant: "book" | "mind" | "topic" }) {
+  const heroBody = (
+    <div className="seo-hero-body">
+      <Bar w={64} h={12} />
+      <Bar w="68%" h={30} r={8} mt={12} />
+      <Bar w={150} h={14} mt={12} />
+      <div style={{ display: "flex", gap: 8, marginTop: 18 }}>
+        <Bar w={150} h={38} r={999} />
+        <Bar w={130} h={38} r={999} />
+      </div>
+    </div>
+  );
+
+  const hero =
+    variant === "book" ? (
+      <div className="seo-hero-with-cover">
+        <span className="seo-hero-cover skeleton-block" aria-hidden="true" />
+        {heroBody}
+      </div>
+    ) : (
+      heroBody
+    );
+
+  const rail = (
+    <>
+      {[0, 1].map((i) => (
+        <div className="seo-rail-card" key={i}>
+          <Bar w={140} h={16} />
+          <Bar w="90%" h={12} mt={14} />
+          <Bar w="80%" h={12} mt={10} />
+          <Bar w="85%" h={12} mt={10} />
+        </div>
+      ))}
+    </>
+  );
+
+  return (
+    <EntityLayout hero={hero} rail={rail}>
+      <div className="seo-section" aria-busy="true" aria-label="Loading">
+        <Bar w="100%" h={14} />
+        <Bar w="96%" h={14} mt={12} />
+        <Bar w="98%" h={14} mt={12} />
+        <Bar w="60%" h={14} mt={12} />
+        <Bar w={180} h={20} r={6} mt={32} />
+        <Bar w="100%" h={14} mt={18} />
+        <Bar w="92%" h={14} mt={12} />
+        <Bar w="70%" h={14} mt={12} />
+      </div>
+    </EntityLayout>
+  );
+}
+
+/**
+ * Single-column loading skeleton for the SeoColumn-shelled share/permalink
+ * pages (/discussions/[id], /a/[id]) — same instant-feedback rationale as
+ * EntitySkeleton, shaped as a title + a short thread of content blocks.
+ */
+export function SeoColumnSkeleton() {
+  return (
+    <SeoColumn>
+      <div className="seo-section" aria-busy="true" aria-label="Loading">
+        <Bar w="55%" h={26} r={8} />
+        <Bar w={160} h={13} mt={12} />
+        <Bar w="100%" h={14} mt={28} />
+        <Bar w="94%" h={14} mt={12} />
+        <Bar w="88%" h={14} mt={12} />
+        <Bar w="64%" h={14} mt={12} />
+        <Bar w="100%" h={72} r={14} mt={28} />
+        <Bar w="90%" h={14} mt={20} />
+        <Bar w="80%" h={14} mt={12} />
+      </div>
+    </SeoColumn>
+  );
+}

--- a/web/components/shell/UserMenu.tsx
+++ b/web/components/shell/UserMenu.tsx
@@ -115,16 +115,25 @@ export default function UserMenu() {
 
 function SignOutItem({ onDone }: { onDone: () => void }) {
   const { signOut } = useAuth();
+  const [busy, setBusy] = useState(false);
   return (
     <button
       type="button"
       className="user-menu-item user-menu-signout"
+      disabled={busy}
+      // Keep the menu open showing "Signing out…" until signOut resolves (it
+      // usually redirects); close it afterward (or on failure) via onDone.
       onClick={async () => {
-        onDone();
-        await signOut();
+        if (busy) return;
+        setBusy(true);
+        try {
+          await signOut();
+        } finally {
+          onDone();
+        }
       }}
     >
-      Sign out
+      {busy ? "Signing out…" : "Sign out"}
     </button>
   );
 }

--- a/web/lib/books.ts
+++ b/web/lib/books.ts
@@ -7,6 +7,7 @@
 export interface AgentRow {
   id: string;
   name: string;
+  slug?: string | null; // descriptive URL slug; null for un-backfilled rows
   type?: string; // "ai_book" | "upload" | "catalog" | ...
   status?: string;
   source?: string;
@@ -27,6 +28,9 @@ export interface AgentRow {
 export interface Book {
   id: string;
   agentId: string;
+  /** Descriptive URL slug. Link to /book/{slug} to skip the uuid→slug 301 hop;
+   *  null for un-backfilled rows (callers fall back to agentId). */
+  slug: string | null;
   title: string;
   author: string;
   isbn: string | null;
@@ -57,6 +61,7 @@ export function mapAgentsToBooks(agents: AgentRow[]): Book[] {
       return {
         id: a.id,
         agentId: a.id,
+        slug: a.slug ?? null,
         title: a.name,
         author: meta.author || a.source || "",
         isbn: meta.isbn || null,

--- a/web/lib/minds.ts
+++ b/web/lib/minds.ts
@@ -20,6 +20,9 @@
 export interface Mind {
   id: string;
   name: string;
+  /** Descriptive URL slug. Link to /mind/{slug} to skip the uuid→slug 301 hop
+   *  (the slug-resolution middleware fetches the cold origin on every uuid). */
+  slug?: string | null;
   era?: string;
   domain?: string;
   bio_summary?: string;
@@ -49,6 +52,8 @@ export interface GraphData {
 // ── d3 node/link working shapes (mutated by the simulation) ─────────────
 export interface GraphNode {
   id: string;
+  /** Descriptive slug for navigation (falls back to id when un-backfilled). */
+  slug: string | null;
   name: string;
   era: string;
   domain: string;
@@ -222,6 +227,7 @@ export function buildGraphData(
 
   const nodes: GraphNode[] = minds.map((m) => ({
     id: m.id,
+    slug: m.slug ?? null,
     name: m.name,
     era: m.era || "",
     domain: m.domain || "",

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -1531,6 +1531,29 @@ body {
   font-size: 15px; line-height: 1; opacity: 0.6; transition: opacity 0.15s;
 }
 .chip-remove:hover { opacity: 1; }
+/* Optimistic loading chip — a shimmer pill while a preselected book's title
+   resolves, so the composer never sits visibly empty after "Chat with book". */
+.book-chip.loading { padding: 3px 10px; }
+.chip-skeleton {
+  display: inline-block; width: 84px; height: 11px; border-radius: 999px;
+  background: var(--accent); animation: pulse 1.4s ease-in-out infinite;
+}
+/* Generic skeleton placeholder for the entity loading.tsx fallbacks. Neutral,
+   theme-agnostic fill + the shared `pulse` so it reads as "loading" either
+   theme. Dimensions/radius are set per-instance (inline) by the skeleton. */
+.skeleton-block {
+  background: rgba(128, 128, 128, 0.16);
+  border-radius: 6px;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+/* Generic inline spinner (icon-button pending state, e.g. share). Inherits the
+   button's currentColor; reuses the existing toast-spin keyframe. */
+.inline-spinner {
+  display: inline-block; width: 14px; height: 14px; border-radius: 50%;
+  border: 2px solid color-mix(in srgb, currentColor 28%, transparent);
+  border-top-color: currentColor;
+  animation: toast-spin 0.7s linear infinite;
+}
 
 /* Book / Mind lists in popover */
 .popover-book-list { max-height: 180px; overflow-y: auto; }


### PR DESCRIPTION
Systematic fix for two classes of "I click something and nothing happens for a few seconds."

## Class 1 — navigation latency (the reported Profile / Details / Chat delays)

**A. The uuid→slug 301 middleware hop.** Internal links emitted raw uuids, so `web/middleware.ts` did a **blocking origin fetch + 301 redirect** on every `/book/*` and `/mind/*` click before the page even started rendering. The slug is already in the list payloads (`list_agents(lite=True)` / `list_minds`) — it just wasn't surfaced on the client types. Now every interactive link emits `slug || id` (uuid fallback for un-backfilled rows):
- Great Minds graph — node click + tooltip Profile + tooltip Chat
- Library book cards (details)
- In-chat "Related books" sidebar
- 1:1 mind chat → profile link

**B. No `loading.tsx` anywhere.** Detail/profile/topic/share routes are async Server Components that await 4–7 fetches; with no Suspense fallback the browser sat on the *previous* page the whole time. Added `EntitySkeleton` + `SeoColumnSkeleton` and `loading.tsx` for: `book/[id]`, `mind/[id]`, `mind/[id]/chat`, `topic/[slug]`, `discussions/[id]`, `a/[id]`. (The `/book/[id]/*` and `/mind/[id]/*` children inherit the parent skeleton.)

**C. Composer book chip resolved async with no placeholder.** "Chat with this book" opened an empty composer for seconds. Now: a **synchronous warm-catalog title peek** (instant when arriving from Library) + an **optimistic loading chip** on the cold path.

## Class 2 — async buttons with no feedback (same "looks like a bug" symptom)

Found via a broader sweep; added pending/disabled state to:
- Session share + per-message share (`ChatView` / `MessageList`)
- Google sign-in, sign-out, and "Make private" (un-share)

## Verification
- `tsc --noEmit` clean
- full `next build` passes (compile + lint + 11/11 static pages)
- Local browser preview not feasible in this env (the sandbox blackholes the prod API), so visual/end-to-end verification should come from the Vercel preview deploy + a signed-in prod spot-check.

## Deferred (noted, not fixed)
- The rare duplicate-mind upload modal's "Open it" link still emits a uuid — its `/api/minds/create-from-content` duplicate response carries no slug, so removing that one hop needs a small backend field. Lowest-traffic path; still works (just one redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)