### PR TITLE
feat(seo): redesign perspective page into a hub + refine CTA buttons

### DIFF
--- a/web/app/mind/[id]/on/[slug]/page.tsx
+++ b/web/app/mind/[id]/on/[slug]/page.tsx
@@ -9,6 +9,10 @@ import {
   breadcrumbJsonLd,
   fetchMind,
   fetchMindOnTopic,
+  fetchMinds,
+  fetchTopics,
+  filterMindsByTopic,
+  isMindTopicRelevant,
   metaDescription,
   mindEssayJsonLd,
   resolveTopicSlug,
@@ -126,6 +130,18 @@ export default async function MindOnTopicPage({
     [topic, canonical],
   ]);
 
+  const eraDomain = [mind.era, mind.domain].filter(Boolean).join(" · ");
+  // Exploration data — turn the page from a dead-end essay into a hub: the mind's
+  // OTHER perspectives, plus how OTHER minds approach the same topic. Both are
+  // cached lite-list fetches and the page is ISR (renders ~once/day per URL).
+  const [allTopics, allMinds] = await Promise.all([fetchTopics(), fetchMinds()]);
+  const otherTopics = allTopics
+    .filter((t) => isMindTopicRelevant(mind, t) && topicSlug(t) !== canonicalSlug)
+    .slice(0, 6);
+  const otherMinds = filterMindsByTopic(allMinds, topic, 8)
+    .filter((m) => m.id !== mind.id)
+    .slice(0, 6);
+
   return (
     <SeoColumn>
       <JsonLd data={articleLd} />
@@ -138,55 +154,80 @@ export default async function MindOnTopicPage({
       <h1>
         How {mind.name} might approach {topic}
       </h1>
+      {eraDomain ? <p className="seo-meta perspective-byline">{eraDomain}</p> : null}
 
       <section className="seo-section">
         {essayParagraphs.length ? (
-          <>
-            {essayParagraphs.map((p, i) => (
-              <p key={i}>{p}</p>
-            ))}
-          </>
+          essayParagraphs.map((p, i) => <p key={i}>{p}</p>)
         ) : (
           <>
             <p>
               This is a framed view of how {mind.name}
-              {mind.era ? ` (${mind.era})` : ""} might reason about {topic},
-              drawing on the methods, values, and concerns their work exhibits.
+              {mind.era ? ` (${mind.era})` : ""} might reason about {topic}, drawing
+              on the methods, values, and concerns their work exhibits.
               {mind.domain ? ` ${mind.name} is best known in ${mind.domain}.` : ""}
             </p>
             {mind.bio_summary ? <p>{mind.bio_summary}</p> : null}
             <p>
-              The fullest version of this perspective is interactive — put a
-              question to {mind.name} directly and follow the reasoning where it
-              leads.
+              The fullest version of this perspective is interactive — put a question
+              to {mind.name} directly and follow the reasoning where it leads.
             </p>
           </>
         )}
-        <p>
-          <small>
-            Imagined perspective — an AI synthesis grounded in {mind.name}&rsquo;s
-            recorded ideas and methods, not a quotation or a statement they
-            actually made.
-          </small>
+        <p className="perspective-disclaimer">
+          Imagined perspective — an AI synthesis grounded in {mind.name}&rsquo;s
+          recorded ideas and methods, not a quotation or a statement they actually
+          made.
         </p>
       </section>
 
-      <p className="seo-cta-row">
+      <div className="seo-cta-row perspective-cta">
         <a className="primary" href={readerUrl}>
           Chat with {mind.name} →
         </a>
-        <Link className="secondary" href={`/topic/${canonicalSlug}`}>
-          {topic} on Feynman
-        </Link>
-      </p>
+        <span className="perspective-cta-hint">
+          Ask {mind.name} directly — the perspective comes alive in conversation.
+        </span>
+      </div>
 
-      <footer className="seo-explore-footer">
-        <small>
-          Read more: <Link href={`/mind/${params.id}`}>About {mind.name}</Link>
-          {" · "}
-          <Link href={`/topic/${canonicalSlug}`}>{topic} on Feynman</Link>
-        </small>
-      </footer>
+      {otherTopics.length ? (
+        <section className="seo-section">
+          <h2>More perspectives from {mind.name}</h2>
+          <div className="mind-topic-cards">
+            {otherTopics.map((t) => (
+              <Link
+                key={t}
+                href={`/mind/${params.id}/on/${topicSlug(t)}`}
+                className="mind-topic-card"
+              >
+                <span className="mind-topic-card-eyebrow">How {mind.name} approaches</span>
+                <span className="mind-topic-card-title">{t}</span>
+                <span className="mind-topic-card-cta">Read the perspective →</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {otherMinds.length ? (
+        <section className="seo-section">
+          <h2>How other minds approach {topic}</h2>
+          <ul className="perspective-minds">
+            {otherMinds.map((m) => (
+              <li key={m.id}>
+                <Link href={`/mind/${m.slug || m.id}/on/${canonicalSlug}`}>
+                  <span className="perspective-minds-name">{m.name}</span>
+                  {m.era ? <span className="perspective-minds-era">{m.era}</span> : null}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <p className="perspective-explore">
+        <Link href={`/topic/${canonicalSlug}`}>Explore all of {topic} on Feynman →</Link>
+      </p>
     </SeoColumn>
   );
 }

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -290,18 +290,23 @@ body { background-color: var(--bg-home); }
 /* Top action bar — Read / Preview / Chat / Share, prominent, above the fold. */
 .seo-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
 .seo-action {
-  display: inline-flex; align-items: center; gap: 7px;
-  padding: 10px 20px; border-radius: var(--r-control);
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 10px 18px; border-radius: var(--r-control);
   font-size: 14px; font-weight: 600; cursor: pointer; white-space: nowrap;
-  border: 1px solid transparent; transition: opacity 0.15s, background 0.15s;
+  border: 1px solid transparent;
+  transition: background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.12s ease, color 0.18s ease, filter 0.18s ease;
   font-family: inherit;
 }
-.seo-action.primary { background: var(--accent); color: #fff; }
-.seo-action.primary:hover { opacity: 0.9; }
-.seo-action.secondary { background: var(--bg-chat); color: var(--text); border-color: var(--border-strong); }
-.seo-action.secondary:hover { background: rgba(128,128,128,0.08); }
+.seo-action.primary {
+  background: var(--accent); color: #fff; border-color: transparent;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 2px 8px rgba(10,110,230,0.22);
+}
+.seo-action.primary:hover { filter: brightness(0.95); transform: translateY(-1px); box-shadow: 0 3px 6px rgba(0,0,0,0.12), 0 6px 18px rgba(10,110,230,0.30); opacity: 1; }
+.seo-action.primary:active { filter: brightness(0.9); transform: translateY(0); box-shadow: 0 1px 2px rgba(0,0,0,0.14); }
+.seo-action.secondary { background: var(--bg-chat); color: var(--text); border-color: var(--border-strong); box-shadow: 0 1px 1px rgba(0,0,0,0.03); }
+.seo-action.secondary:hover { background: rgba(128,128,128,0.08); border-color: var(--text-muted); transform: translateY(-1px); }
 .seo-action.ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-strong); }
-.seo-action.ghost:hover { color: var(--text); background: rgba(128,128,128,0.08); }
+.seo-action.ghost:hover { color: var(--text); background: rgba(128,128,128,0.06); border-color: var(--text-muted); }
 
 
 /* Feynman share popup (custom — NOT the OS share sheet). */
@@ -543,13 +548,43 @@ body { background-color: var(--bg-home); }
 .discussion-list-by { color: var(--text-muted); font-size: 13px; }
 
 /* Legacy single-column CTA row (kept for q/insights pages that still use it). */
-.seo-cta-row { display: flex; gap: 10px; flex-wrap: wrap; margin: 1.6em 0; }
+.seo-cta-row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin: 1.6em 0; }
 .seo-cta-row a {
-  display: inline-block; padding: 11px 20px; border-radius: var(--r-control);
-  font-weight: 600; text-decoration: none;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 10px 18px; border-radius: var(--r-control);
+  font-size: 14px; font-weight: 600; text-decoration: none;
+  border: 1px solid transparent;
+  transition: background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.12s ease, color 0.18s ease, filter 0.18s ease;
 }
-.seo-cta-row a.primary { background: var(--accent); color: #fff; }
-.seo-cta-row a.secondary { background: transparent; color: var(--accent); border: 1px solid var(--accent); }
+.seo-cta-row a.primary {
+  background: var(--accent); color: #fff;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 2px 8px rgba(10,110,230,0.22);
+}
+.seo-cta-row a.primary:hover { filter: brightness(0.95); transform: translateY(-1px); box-shadow: 0 3px 6px rgba(0,0,0,0.12), 0 6px 18px rgba(10,110,230,0.30); }
+.seo-cta-row a.primary:active { filter: brightness(0.9); transform: translateY(0); }
+.seo-cta-row a.secondary {
+  background: var(--bg-chat); color: var(--text); border: 1px solid var(--border-strong);
+  box-shadow: 0 1px 1px rgba(0,0,0,0.03);
+}
+.seo-cta-row a.secondary:hover { background: rgba(128,128,128,0.08); border-color: var(--text-muted); transform: translateY(-1px); }
+
+/* ── Perspective page (How X approaches Y) — hub layout ── */
+.perspective-byline { margin-top: -6px; }
+.perspective-disclaimer { margin-top: 16px; font-size: 13px; color: var(--text-muted); }
+.perspective-cta { align-items: center; gap: 14px 18px; margin: 1.8em 0 0.4em; }
+.perspective-cta-hint { font-size: 14px; color: var(--text-secondary); max-width: 380px; line-height: 1.5; }
+.perspective-minds { list-style: none; padding: 0; margin: 6px 0 0; }
+.perspective-minds li a {
+  display: flex; align-items: baseline; gap: 10px;
+  padding: 11px 12px; margin: 0 -12px; border-radius: var(--r-control);
+  text-decoration: none; transition: background 0.15s ease;
+}
+.perspective-minds li a:hover { background: rgba(128,128,128,0.07); }
+.perspective-minds-name { font-weight: 600; color: var(--accent); }
+.perspective-minds-era { font-size: 13px; color: var(--text-muted); }
+.perspective-explore { margin-top: 30px; }
+.perspective-explore a { font-weight: 600; color: var(--accent); text-decoration: none; }
+.perspective-explore a:hover { text-decoration: underline; }
 
 @media (max-width: 860px) {
   .seo-grid.has-rail { grid-template-columns: 1fr; }


### PR DESCRIPTION
Redesigns the 'How {mind} might approach {topic}' page (your feedback: thin info density, wrong two-button presentation, redundant footer).

**Before:** essay + two competing buttons (Chat + 'History on Feynman') + a redundant 'Read more: About X · History on Feynman' footer.

**After — a hub:**
- era/domain byline for context
- the imagined essay (unchanged core)
- **one clear Chat CTA + a hint** (not two competing buttons)
- **'More perspectives from {mind}'** — cards linking the mind's other /on/ topic pages
- **'How other minds approach {topic}'** — links to other minds' takes on the same topic
- a single **'Explore all of {topic}'** link (replaces the footer + the secondary button)

Adds information density, internal linking (SEO), and exploration paths (conversion). Also ships the refined `.seo-action`/`.seo-cta-row` button styling (subtle shadow + hover-lift, neutral secondary) — supersedes #117. Exploration data is cached lite-list fetches on an ISR page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)