### PR TITLE
perf(egress): discover cron reads the lite agents list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -586,7 +586,7 @@ def _background_discover(topic: str) -> None:
 def _discover_books() -> None:
     """Scheduled discovery: pick underrepresented categories and discover new books via LLM."""
     try:
-        agents = list_agents(limit=5000)
+        agents = list_agents(limit=5000, lite=True)
         # Count books per category
         cat_counts: dict[str, int] = {}
         for a in agents:
@@ -3485,13 +3485,13 @@ def api_cron_discover(request: Request, background_tasks: BackgroundTasks) -> di
     _verify_cron(request)
     if not _DISCOVER_CRON_ENABLED:
         return {"status": "disabled"}
-    agents = list_agents(limit=5000)
+    agents = list_agents(limit=5000, lite=True)
     if not agents:
         return {"status": "skip", "reason": "no agents yet"}
     _discover_books()
     # Bounded learning for new catalog agents (cap per run → bounded CPU).
     queued = 0
-    for a in list_agents(limit=5000):
+    for a in list_agents(limit=5000, lite=True):
         if a["status"] == "catalog":
             background_tasks.add_task(_learn_agent, a["id"])
             queued += 1


### PR DESCRIPTION
The weekly `discover` cron read `list_agents(limit=5000)` **non-lite (~2.9MB)** three times (category counts in `_discover_books`, an existence check, and the catalog-learn loop using `status`/`id`). All three only need fields in the lite projection (`category` in the slim meta; `status`/`id` are top-level columns the indexnow cron already reads via `lite=True`). → ~2.9MB → ~163KB per read, **~6-9MB/week saved**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)