### PR TITLE
perf(write-book): cut a round-trip + add button feedback to 'Write the Book You Need'

### DIFF
--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -101,6 +101,9 @@ export default function HomeComposer() {
   const [booksOpen, setBooksOpen] = useState(false);
   const [mindsOpen, setMindsOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  // "Write a book" (pencil) creates a session before navigating — its own busy
+  // flag drives the spinner so the click isn't a dead multi-second wait.
+  const [writingBook, setWritingBook] = useState(false);
   // Time-based greeting (legacy app.js 665-667: "Good morning/afternoon/evening
   // [, FirstName]"). Computed client-side after mount to avoid SSR/hydration
   // drift (the hour + the localStorage userName are client-only).
@@ -450,9 +453,17 @@ export default function HomeComposer() {
             className="composer-icon-btn"
             title="Write the book you need, on-demand"
             aria-label="Write the book you need"
-            onClick={() => startWriteBook(router, { authEnabled, user, requirePro })}
+            disabled={writingBook}
+            onClick={async () => {
+              if (writingBook) return;
+              setWritingBook(true);
+              // Navigates on success (and anon → /login); only reset when we
+              // stayed (non-pro overlay / failure) so the icon re-enables.
+              const id = await startWriteBook(router, { authEnabled, user, requirePro });
+              if (!id) setWritingBook(false);
+            }}
           >
-            <WriteBookIcon />
+            {writingBook ? <span className="inline-spinner" aria-hidden="true" /> : <WriteBookIcon />}
           </button>
         </div>
         <button

--- a/web/components/library/Library.tsx
+++ b/web/components/library/Library.tsx
@@ -34,6 +34,9 @@ export default function Library() {
   const [filter, setFilter] = useState<"recent" | "all">("recent");
   const [loading, setLoading] = useState(() => getCachedCatalogBooks() === null);
   const [discovering, setDiscovering] = useState(false);
+  // "Write the Book You Need" is in flight (creates a session before navigating)
+  // — drives the button's spinner/disabled state so the click isn't a dead 7-8s.
+  const [writing, setWriting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   // IDs of books found+added by search — kept visible across keystrokes even
@@ -246,13 +249,26 @@ export default function Library() {
           type="button"
           className="create-book-btn"
           title="Write the book you need, on-demand"
-          onClick={() => startWriteBook(router, { authEnabled, user, requirePro })}
+          disabled={writing}
+          onClick={async () => {
+            if (writing) return;
+            setWriting(true);
+            // startWriteBook navigates on success (and anon → /login); only reset
+            // when we STAYED on the page (non-pro overlay / failure) so the button
+            // re-enables instead of spinning forever.
+            const id = await startWriteBook(router, { authEnabled, user, requirePro });
+            if (!id) setWriting(false);
+          }}
         >
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 20h9" />
-            <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-          </svg>
-          <span>Write the Book You Need</span>
+          {writing ? (
+            <span className="inline-spinner" aria-hidden="true" />
+          ) : (
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+          )}
+          <span>{writing ? "Starting your book…" : "Write the Book You Need"}</span>
         </button>
         <div className="filter-tags">
           <button

--- a/web/lib/writeBook.ts
+++ b/web/lib/writeBook.ts
@@ -70,13 +70,14 @@ export async function startWriteBook(
       meta: { write_book: true },
     });
 
-    // Belt-and-suspenders PATCH (mirrors production, which PATCHes after
-    // createSession). Harmless if the create already persisted the meta.
-    try {
-      await updateSession(session.id, { meta: { write_book: true } });
-    } catch (e) {
-      console.warn("Failed to set write_book meta:", e);
-    }
+    // Belt-and-suspenders meta PATCH — createSession already persisted the same
+    // meta in its POST body (see lib/chat.ts createSession), so this is pure
+    // insurance. Fire-and-forget so it stays OFF the click→navigate critical
+    // path: on a cold origin three sequential awaits (create + this PATCH + the
+    // greeting) were the 7-8s "Write the Book You Need" stall.
+    updateSession(session.id, { meta: { write_book: true } }).catch((e) =>
+      console.warn("Failed to set write_book meta:", e),
+    );
 
     // Seed the greeting assistant message, persisted so it survives a reload /
     // reopen (port of app.js `_queueSessionMessage(sessionId,'assistant',greeting)`).


### PR DESCRIPTION
Follow-up to #120 — same "click and nothing happens for several seconds" class, this time the **"Write the Book You Need"** button (reported at 7-8s).

## Root cause
`startWriteBook` ran **three sequential awaited round-trips before navigating**: `createSession` → a redundant `updateSession` meta PATCH → the greeting persist. On a cold Python origin that's the 7-8s stall, and the button had **no busy/disabled state** so it looked frozen. Both entry points (Library button + composer pencil) were fire-and-forget with no feedback.

## Fix
- **`writeBook.ts`** — the `updateSession` PATCH is pure insurance (`createSession` already persists the same `meta` in its POST body), so **fire-and-forget it off the critical path**. One fewer blocking round-trip.
- **`Library.tsx` + `HomeComposer.tsx`** — both write-book entry points now show a **spinner + disabled + "Starting your book…"** while the session is created (reusing `.inline-spinner` from #120). Reset only when the action *stayed* on the page (non-pro overlay / failure), so success/login navigations don't setState after unmount.

## Verification
- `tsc --noEmit` clean + full `next build` passes.
- Visual/end-to-end (the actual 7-8s→faster + spinner) needs a signed-in Pro session on the Vercel preview — can't drive that from this env.

## Not done here (would need more than a frontend change)
- The remaining latency is `createSession` itself on a cold origin (~unavoidable client-side; it returns the server-generated id we navigate to). A bigger win — navigate immediately + render the greeting optimistically — would need a ChatView change on the Pro write-book flow; deferred as higher-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)