### PR TITLE
feat(share): direct 'Post on X' button on the publish toast

### DIFF
--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -236,6 +236,7 @@ export default function ChatView({
   // either the whole-session discussion (Phase 1) or one shared answer (Phase 2).
   const [toast, setToast] = useState<{
     url: string;
+    text?: string;
     withdraw: () => Promise<void>;
   } | null>(null);
   // Transient inline hint beside the share icon (e.g. the <3-message gate). It
@@ -279,7 +280,7 @@ export default function ChatView({
       if (rec.public_handle !== undefined) setPublicHandle(rec.public_handle ?? null);
       const url = rec.public_url || `/discussions/${sessionId}`;
       setPublicUrl(url);
-      setToast({ url, withdraw: withdrawSession });
+      setToast({ url, text: sessionRef.current?.title || "", withdraw: withdrawSession });
       bumpSessions(); // show the public ● dot in the sidebar
     } catch (e) {
       flashShareHint(
@@ -304,6 +305,7 @@ export default function ChatView({
         const answerId = rec.id || "";
         setToast({
           url: rec.public_url || (answerId ? `/a/${answerId}` : ""),
+          text: sessionRef.current?.title || "",
           withdraw: async () => {
             if (answerId) {
               try {
@@ -1128,7 +1130,7 @@ export default function ChatView({
               title={isPublic ? "Shared publicly" : "Share publicly"}
               onClick={() =>
                 isPublic && publicUrl
-                  ? setToast({ url: publicUrl, withdraw: withdrawSession })
+                  ? setToast({ url: publicUrl, text: sessionRef.current?.title || "", withdraw: withdrawSession })
                   : doShare()
               }
               disabled={sharing}
@@ -1230,6 +1232,7 @@ export default function ChatView({
       {toast && (
         <PublishToast
           url={toast.url}
+          shareText={toast.text}
           onClose={() => setToast(null)}
           onWithdraw={toast.withdraw}
         />

--- a/web/components/chat/ShareModal.tsx
+++ b/web/components/chat/ShareModal.tsx
@@ -18,10 +18,15 @@ import { useState } from "react";
 
 export function PublishToast({
   url,
+  shareText,
   onClose,
   onWithdraw,
 }: {
   url: string;
+  /** Pre-fill for the tweet composer (the question / session title). The card
+   *  itself carries the content, so this is just opening context the user can
+   *  edit in X. */
+  shareText?: string;
   onClose: () => void;
   /** Make-private action. The caller owns the endpoint (session vs single
    *  answer) + any local state updates; the toast only confirms and invokes it. */
@@ -30,9 +35,23 @@ export function PublishToast({
   const [copied, setCopied] = useState(false);
   const [unsharing, setUnsharing] = useState(false);
 
+  // Absolute URL for the tweet intent (public_url is usually absolute already;
+  // absolutize the relative fallback against the current origin).
+  const absUrl =
+    /^https?:\/\//.test(url)
+      ? url
+      : `${typeof window !== "undefined" ? window.location.origin : "https://feynman.wiki"}${url}`;
+
+  const postOnX = () => {
+    const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      (shareText || "").trim(),
+    )}&url=${encodeURIComponent(absUrl)}`;
+    window.open(intent, "_blank", "noopener,noreferrer");
+  };
+
   const copy = () => {
     try {
-      navigator.clipboard.writeText(url);
+      navigator.clipboard.writeText(absUrl);
     } catch {
       /* clipboard unavailable — user can select manually */
     }
@@ -63,13 +82,19 @@ export function PublishToast({
       <p className="publish-toast-title">Published</p>
       <p className="publish-toast-msg">Anyone with this link can read it.</p>
       <div className="publish-toast-link-row">
-        <input className="publish-toast-url" readOnly value={url} onFocus={(e) => e.target.select()} />
+        <input className="publish-toast-url" readOnly value={absUrl} onFocus={(e) => e.target.select()} />
         <button className="publish-toast-copy" onClick={copy}>
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
+      <button className="publish-toast-x" onClick={postOnX} type="button">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+        Post on X
+      </button>
       <div className="publish-toast-actions">
-        <a className="publish-toast-open" href={url} target="_blank" rel="noopener noreferrer">
+        <a className="publish-toast-open" href={absUrl} target="_blank" rel="noopener noreferrer">
           Open
         </a>
         <button className="publish-toast-unshare" onClick={unshare} disabled={unsharing}>

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -4102,6 +4102,17 @@ html.dark .share-status-indicator { background: #60a5fa1a; color: #93c5fd; borde
   font: 500 12px/1 'Inter', sans-serif;
 }
 .publish-toast-copy:hover { background: var(--bg-sidebar); }
+/* Primary "Post on X" CTA — direct tweet alongside the copy-link path. */
+.publish-toast-x {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  width: 100%; margin-bottom: 10px;
+  padding: 10px 14px; border: 0; border-radius: 8px; cursor: pointer;
+  background: #000; color: #fff;
+  font: 600 13.5px/1 'Inter', sans-serif;
+  transition: opacity 0.12s;
+}
+.publish-toast-x:hover { opacity: 0.85; }
+.publish-toast-x svg { flex-shrink: 0; }
 .publish-toast-actions {
   display: flex; gap: 10px; align-items: center;
 }


### PR DESCRIPTION
## What
Sharing a chat reply published the link and showed the `PublishToast` (copy / open / make-private) — but there was **no direct way to tweet it**. This adds a prominent **"Post on X"** button to that toast, so one click publishes and you can then either **Copy link** or **Post on X** — both interaction paths, side by side.

- "Post on X" opens the X composer with the public `/a/{id}` (or `/discussions/{id}`) URL → X fetches the new conversational OG card → pre-filled with the session question (the user edits in X).
- URL absolutized for the intent + the copy/open actions.
- Same toast, no extra modal — keeps the lightweight ChatGPT-style flow.

Follow-up to #123 (the unified share-card system). Frontend-only; gate on the green `feynman-web` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)