### PR TITLE
fix(auth): transient /api/pro/config failure no longer flips a signed-in user to 'Guest'

### DIFF
--- a/web/components/shell/UserMenu.tsx
+++ b/web/components/shell/UserMenu.tsx
@@ -11,7 +11,7 @@ import ThemeToggle from "@/components/theme/ThemeToggle";
  * and just the theme toggle in anonymous mode (auth off, e.g. local dev).
  */
 export default function UserMenu() {
-  const { authEnabled, user, isPro, tierKnown } = useAuth();
+  const { ready, authEnabled, user, isPro, tierKnown } = useAuth();
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
 
@@ -39,7 +39,10 @@ export default function UserMenu() {
   const avatarUrl = meta.avatar_url || meta.picture || "";
   const tier = isPro ? "Pro" : "Free";
   const initial = (user ? name[0] : "")?.toUpperCase() ?? "";
-  const guestLabel = authEnabled ? "Account" : "Guest";
+  // Until auth is resolved (`ready`), show the neutral "Account" — NEVER flash
+  // "Guest" (which implies signed-out) while the config/session are still
+  // loading. "Guest" is only correct on the open-source build (ready + auth off).
+  const guestLabel = authEnabled || !ready ? "Account" : "Guest";
 
   return (
     <div className="sidebar-user-wrap" ref={wrapRef}>

--- a/web/lib/config.ts
+++ b/web/lib/config.ts
@@ -17,16 +17,85 @@ const EMPTY: ProConfig = {
   posthog_key: "",
 };
 
+// Persist the LAST KNOWN-GOOD (auth-enabled) config. This config is static per
+// deployment and GATES auth detection: if a transient /api/pro/config failure is
+// treated as "auth off", a signed-in user silently renders as "Guest" and their
+// authed chats load nothing (the bug this guards against). The supabase url/key
+// are the public anon values the client already ships, so caching them is safe.
+const LS_KEY = "feynman:pro-config";
+
+function isUsable(c: Partial<ProConfig> | null | undefined): c is ProConfig {
+  return !!(c && c.auth_enabled && c.supabase_url && c.supabase_key);
+}
+
+function readGoodConfig(): ProConfig | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return null;
+    const c = JSON.parse(raw) as Partial<ProConfig>;
+    return isUsable(c) ? { ...EMPTY, ...c } : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveGoodConfig(c: ProConfig): void {
+  if (typeof localStorage === "undefined" || !isUsable(c)) return;
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(c));
+  } catch {
+    /* storage blocked/full — non-fatal */
+  }
+}
+
 let _cfg: ProConfig | null = null;
 let _inflight: Promise<ProConfig> | null = null;
 
-/** Fetch once, memoized. Falls back to auth-off config if the API is down. */
+/** One network fetch. Memoizes + persists on success; returns null on failure. */
+async function fetchFresh(): Promise<ProConfig | null> {
+  try {
+    const c = await get<ProConfig>("/api/pro/config");
+    const merged = { ...EMPTY, ...c };
+    saveGoodConfig(merged);
+    _cfg = merged;
+    return merged;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Public frontend config, resolved robustly so a transient failure can never
+ * silently disable auth (which strands a signed-in user as "Guest").
+ *
+ * - Cache-first: a previously-confirmed (auth-enabled) config makes `authEnabled`
+ *   correct on the FIRST paint even if the network is slow/down, and revalidates
+ *   in the background.
+ * - No cache (first load / open-source auth-off): fetch with one retry; on total
+ *   failure return EMPTY but do NOT memoize it, so the next call/load retries
+ *   instead of being stuck signed-out.
+ */
 export async function getProConfig(): Promise<ProConfig> {
   if (_cfg) return _cfg;
+
+  const cached = readGoodConfig();
+  if (cached) {
+    _cfg = cached;
+    void fetchFresh(); // background revalidate (best-effort; never rejects)
+    return _cfg;
+  }
+
   if (!_inflight) {
-    _inflight = get<ProConfig>("/api/pro/config")
-      .then((c) => (_cfg = { ...EMPTY, ...c }))
-      .catch(() => (_cfg = EMPTY));
+    _inflight = (async () => {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const fresh = await fetchFresh();
+        if (fresh) return fresh;
+        if (attempt === 0) await new Promise((r) => setTimeout(r, 400));
+      }
+      _inflight = null; // don't memoize an auth-off failure → allow a retry
+      return EMPTY;
+    })();
   }
   return _inflight;
 }


### PR DESCRIPTION
## Symptom
Signed-in user, after switching a few chats and refreshing, sometimes lands in a **"Guest"** state with an empty chat (screenshot reported). Intermittent.

## Root cause
`web/lib/config.ts` `getProConfig()` memoized the **auth-OFF fallback** on *any* fetch failure:
```js
.catch(() => (_cfg = EMPTY))   // EMPTY.auth_enabled === false
```
`/api/pro/config` is exactly what `auth.tsx` reads to decide `authEnabled` ([auth.tsx:84-87](../blob/main/web/lib/auth.tsx)). So a **transient** failure (cold origin, or a blip in the request burst a refresh fires) disabled auth **for the whole session** — the app fell into open-source **"Guest"** mode, `UserMenu` showed "Guest", and the authed chat loaded nothing. Because `_cfg` was then cached, it stayed stuck until a reload that happened to succeed.

## Fix (frontend-only)
- **`config.ts` — cache-first + never cache a failure.** A previously-confirmed (auth-enabled) config is persisted to `localStorage`; on load we use it immediately (so `authEnabled` is correct on first paint even if the network is slow/down) and revalidate in the background. On a true first-load failure we retry once, then return `EMPTY` **without memoizing** so the next load retries instead of being stuck. A transient failure can no longer disable auth.
- **`UserMenu.tsx` — gate "Guest" on `ready`.** Show the neutral "Account" until auth is actually resolved; "Guest" now only renders on the open-source build (ready + auth off), never as a loading flash.

## Verification
- `tsc --noEmit` clean + full `next build` passes.
- **Core-auth, can't be exercised from this env** (no real Supabase session). Please verify signed-in on the **preview deploy**: switch chats + refresh repeatedly — the menu should stay your account, never flip to "Guest". (The trigger is intermittent — a transient config-fetch failure — so the strongest signal is no recurrence in prod after deploy.)

Related: builds on the auth/session-race hardening in #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)