### PR TITLE
fix(share): slug share URLs (X-card fix) + elegant Chat CTA

### DIFF
--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -20,6 +20,7 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { bookShareSlug } from "@/lib/catalog";
 import type { Outline, OutlineChapter, BookStatus, AiBookStatus } from "@/lib/aibooks";
 
 export type CanvasPhase = "outlining" | "writing";
@@ -102,11 +103,18 @@ function ChatIcon() {
 /** Share popup (Twitter / Copy URL / Email) building ${origin}/book/{id}. */
 function CanvasShare({ title, readId }: { title: string; readId: string }) {
   const [open, setOpen] = useState(false);
+  // Share the canonical SLUG, not the uuid: /book/{uuid} 301-redirects to the
+  // slug and X's card crawler won't follow it, so the OG card doesn't render in
+  // the tweet. Resolve once on mount (cached); falls back to readId.
+  const [slug, setSlug] = useState(readId);
   const wrapRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    bookShareSlug(readId).then(setSlug).catch(() => {});
+  }, [readId]);
   const shareUrl =
     typeof window !== "undefined"
-      ? `${window.location.origin}/book/${encodeURIComponent(readId)}`
-      : `https://feynman.wiki/book/${encodeURIComponent(readId)}`;
+      ? `${window.location.origin}/book/${encodeURIComponent(slug)}`
+      : `https://feynman.wiki/book/${encodeURIComponent(slug)}`;
 
   useEffect(() => {
     if (!open) return;

--- a/web/components/reader/Reader.tsx
+++ b/web/components/reader/Reader.tsx
@@ -18,6 +18,7 @@ import {
 import { useAuth } from "@/lib/auth";
 import { savePendingBookIntent } from "@/lib/pendingIntent";
 import { track } from "@/lib/analytics";
+import { bookShareSlug } from "@/lib/catalog";
 import styles from "./Reader.module.css";
 
 /**
@@ -69,7 +70,15 @@ export default function Reader({ id }: { id: string }) {
   const totalRef = useRef(1);
   totalRef.current = totalPages;
 
-  const detailsHref = `/book/${encodeURIComponent(id)}`;
+  // Share/details links use the canonical SLUG, not the uuid — /book/{uuid}
+  // 301-redirects to the slug and X's card crawler won't follow the redirect, so
+  // a shared uuid URL renders the bare summary fallback instead of the OG card.
+  // Resolve once on mount (cached); falls back to the id.
+  const [shareSlug, setShareSlug] = useState(id);
+  useEffect(() => {
+    bookShareSlug(id).then(setShareSlug).catch(() => {});
+  }, [id]);
+  const detailsHref = `/book/${encodeURIComponent(shareSlug)}`;
 
   // ── Data load ─────────────────────────────────────────────────────────
   useEffect(() => {
@@ -268,8 +277,8 @@ export default function Reader({ id }: { id: string }) {
   // ── Share helpers (port of reader-share-* handlers) ───────────────────
   const shareUrl =
     typeof window !== "undefined"
-      ? `${window.location.origin}/book/${encodeURIComponent(id)}`
-      : `https://feynman.wiki/book/${encodeURIComponent(id)}`;
+      ? `${window.location.origin}/book/${encodeURIComponent(shareSlug)}`
+      : `https://feynman.wiki/book/${encodeURIComponent(shareSlug)}`;
 
   function copyLink() {
     navigator.clipboard?.writeText(shareUrl).then(

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -219,6 +219,9 @@ export const del = <T = unknown>(path: string, init?: RequestInit) =>
 export interface Agent {
   id: string;
   name: string;
+  /** Descriptive URL slug. Share URLs MUST use this (not the uuid): /book/{uuid}
+   *  301-redirects to /book/{slug}, and X's card crawler doesn't follow 301s. */
+  slug?: string | null;
   author?: string;
   status?: string;
   type?: string;

--- a/web/lib/catalog.ts
+++ b/web/lib/catalog.ts
@@ -70,3 +70,20 @@ export async function getAgentCached(id: string): Promise<Agent> {
   _agents.set(id, { at: Date.now(), agent });
   return agent;
 }
+
+/**
+ * Resolve a book's canonical slug for SHARE URLs (falls back to the id).
+ *
+ * Share links MUST be /book/{slug}, never /book/{uuid}: the uuid 301-redirects
+ * to the slug, and X's (Twitter) card crawler does NOT follow 301s — a shared
+ * uuid URL renders the bare summary fallback instead of the OG card. Cached via
+ * getAgentCached, so resolving on mount is a no-op on repeat.
+ */
+export async function bookShareSlug(id: string): Promise<string> {
+  try {
+    const a = await getAgentCached(id);
+    return a?.slug || id;
+  } catch {
+    return id;
+  }
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -297,12 +297,15 @@ body { background-color: var(--bg-home); }
   transition: background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.12s ease, color 0.18s ease, filter 0.18s ease;
   font-family: inherit;
 }
+/* Primary "Chat with …" CTA — refined adaptive ink (near-black on light,
+   near-white on dark) instead of the loud accent blue, matching the dark
+   "Chat with" pill on the share cards. Neutral shadow, soft lift on hover. */
 .seo-action.primary {
-  background: var(--accent); color: #fff; border-color: transparent;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 2px 8px rgba(10,110,230,0.22);
+  background: var(--btn-solid-bg); color: var(--btn-solid-color); border-color: transparent;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 4px 14px rgba(0,0,0,0.14);
 }
-.seo-action.primary:hover { filter: brightness(0.95); transform: translateY(-1px); box-shadow: 0 3px 6px rgba(0,0,0,0.12), 0 6px 18px rgba(10,110,230,0.30); opacity: 1; }
-.seo-action.primary:active { filter: brightness(0.9); transform: translateY(0); box-shadow: 0 1px 2px rgba(0,0,0,0.14); }
+.seo-action.primary:hover { transform: translateY(-1px); opacity: 0.92; box-shadow: 0 3px 8px rgba(0,0,0,0.14), 0 10px 26px rgba(0,0,0,0.18); }
+.seo-action.primary:active { transform: translateY(0); opacity: 1; box-shadow: 0 1px 2px rgba(0,0,0,0.16); }
 .seo-action.secondary { background: var(--bg-chat); color: var(--text); border-color: var(--border-strong); box-shadow: 0 1px 1px rgba(0,0,0,0.03); }
 .seo-action.secondary:hover { background: rgba(128,128,128,0.08); border-color: var(--text-muted); transform: translateY(-1px); }
 .seo-action.ghost { background: transparent; color: var(--text-secondary); border-color: var(--border-strong); }


### PR DESCRIPTION
## Two fixes

### 1. Share buttons emitted the uuid → broken X card
**Proven on prod:** `/book/{uuid}` returns a **301** to `/book/{slug}`, and X's card crawler doesn't follow 301s → it shows the bare summary fallback, not the OG card. The details-page share emits the **slug** directly, so its card renders. The write-complete (`BookCanvas` `CanvasShare`) and reader (`Reader`) shares emitted the **uuid**.

Fix: new `bookShareSlug(id)` (resolves uuid→slug via the cached agent fetch); both share points resolve on mount and share `/book/{slug}`. `Agent` gains a typed `slug`.

### 2. Restyle the primary "Chat with …" button
Loud accent-blue → refined **adaptive ink** (`--btn-solid-bg`: near-black on light, near-white on dark), matching the dark "Chat with" pill on the share cards. Neutral shadow + soft hover lift.

Frontend-only; gate on the green `feynman-web` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)