### PR TITLE
fix(book): author+subtitle source, Chat-first, unified action buttons

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -14,6 +14,7 @@ import PopularQuestions from "@/components/seo/book/PopularQuestions";
 import {
   SITE_URL,
   getBookData,
+  getBookReadMeta,
   getQuestions,
   getSamplePassages,
   getRelatedForBook,
@@ -107,13 +108,20 @@ export default async function BookLandingPage({ params }: PageProps) {
   if (!data) notFound();
 
   // Enrichment — all independent, all degrade to empty on failure.
-  const [questions, passages, related, overview, topics] = await Promise.all([
+  const [questions, passages, related, overview, topics, readMeta] = await Promise.all([
     getQuestions(id),
     getSamplePassages(id, 3),
     getRelatedForBook(id),
     getBookOverview(id),
     fetchTopics(),
+    getBookReadMeta(id),
   ]);
+  // Author + subtitle for AI books live in the ai_books row (the /read endpoint),
+  // NOT the agent meta_json — so they must come from readMeta to match what the
+  // reader cover shows ("{creator} · AI" + the real subtitle), falling back to
+  // the agent-derived values for catalog books.
+  const displayAuthor = readMeta.author || data.author;
+  const displaySubtitle = readMeta.subtitle || data.subtitle;
 
   // Map the book's free-form category to a canonical topic hub (or null) so the
   // "Topic" rail links to a real /topic/{slug} instead of 404'ing on ad-hoc
@@ -158,16 +166,16 @@ export default async function BookLandingPage({ params }: PageProps) {
   // preselects the book), NOT the reader — so catalog stubs with no readable
   // text still start a chat (fixes the dead-end). Read/Preview appear only when
   // the book actually has content, and go to the reader.
+  // Chat is ALWAYS the primary action and listed FIRST — chatting with the book
+  // is the core product moment; Read/Preview are secondary even when available.
   const chatHref = `/?book=${encodeURIComponent(id)}`;
-  const actions: EntityAction[] = [];
+  const actions: EntityAction[] = [
+    { label: `Chat with this book`, href: chatHref, variant: "primary" },
+  ];
   if (caps.read) {
-    actions.push({ label: `Read`, href: `/read/${encodeURIComponent(id)}`, variant: "primary" });
-    actions.push({ label: `Chat with this book`, href: chatHref, variant: "secondary" });
+    actions.push({ label: `Read`, href: `/read/${encodeURIComponent(id)}`, variant: "secondary" });
   } else if (caps.preview) {
-    actions.push({ label: `Preview`, href: `/read/${encodeURIComponent(id)}`, variant: "primary" });
-    actions.push({ label: `Chat with this book`, href: chatHref, variant: "secondary" });
-  } else {
-    actions.push({ label: `Chat with this book`, href: chatHref, variant: "primary" });
+    actions.push({ label: `Preview`, href: `/read/${encodeURIComponent(id)}`, variant: "secondary" });
   }
 
   const metaBits: string[] = [];
@@ -212,7 +220,8 @@ export default async function BookLandingPage({ params }: PageProps) {
       <div className="seo-hero-body">
         <p className="seo-meta">Book{cleanCategory ? ` · ${cleanCategory}` : ""}</p>
         <h1>{data.title}</h1>
-        {data.author ? <p className="seo-author">by {data.author}</p> : null}
+        {displaySubtitle ? <p className="seo-subtitle">{displaySubtitle}</p> : null}
+        {displayAuthor ? <p className="seo-author">by {displayAuthor}</p> : null}
         {metaBits.length ? <p className="seo-meta">{metaBits.join(" · ")}</p> : null}
         <EntityActions actions={actions} shareUrl={canonical} shareTitle={data.title} />
         {chipQs.length ? (

--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/lib/seo-mind";
 import {
   getBookData,
+  getBookReadMeta,
   getQuestions,
   findQuestionBySlug,
   getBookQa,
@@ -107,15 +108,16 @@ async function build(type: string, id: string, slug: string, kind: string) {
       const data = await getBookData(id);
       if (!data) return <HomeCard />;
       const isAi = (data.agent.type || "").toLowerCase() === "ai_book";
-      const [cover, related] = await Promise.all([
+      const [cover, related, readMeta] = await Promise.all([
         isAi ? Promise.resolve(null) : bookCoverDataUri(isbnOf(data.meta)),
         getRelatedForBook(id),
+        getBookReadMeta(id),
       ]);
       return (
         <BookCard
           title={data.title}
-          author={data.author}
-          description={data.description || data.subtitle}
+          author={readMeta.author || data.author}
+          subtitle={readMeta.subtitle || data.subtitle}
           cover={cover}
           bg={bookAccent(data.title, isAi)}
           minds={[

--- a/web/lib/og/cards.tsx
+++ b/web/lib/og/cards.tsx
@@ -240,24 +240,25 @@ export function MindCard({ data, portrait, accent, initials }: { data: MindCardD
   );
 }
 
-export function BookCard({ title, author, description, cover, bg, minds }: { title: string; author?: string; description?: string; cover: string | null; bg: string; minds?: string[] }) {
+export function BookCard({ title, author, subtitle, description, cover, bg, minds }: { title: string; author?: string; subtitle?: string; description?: string; cover: string | null; bg: string; minds?: string[] }) {
+  const sub = subtitle || description;
   return (
     <Frame
       body={
         <div style={{ display: "flex", alignItems: "center", flexGrow: 1 }}>
           <BookCover src={cover} title={title} author={author} bg={bg} />
           <div style={{ display: "flex", flexDirection: "column", marginLeft: 50, flexGrow: 1, minWidth: 0 }}>
-            <div style={{ display: "flex", fontSize: 54, fontWeight: 700, color: INK, lineHeight: 1.08, maxWidth: 720 }}>
-              {clip(title, 68)}
+            <div style={{ display: "flex", fontSize: 52, fontWeight: 700, color: INK, lineHeight: 1.08, maxWidth: 720 }}>
+              {clip(title, 64)}
             </div>
-            {author ? (
-              <div style={{ display: "flex", fontSize: 27, color: INK_MUTE, marginTop: 16, fontStyle: "italic", maxWidth: 720 }}>
-                {clip(author, 48)}
+            {sub ? (
+              <div style={{ display: "flex", fontSize: 26, color: INK_SOFT, marginTop: 14, lineHeight: 1.32, maxWidth: 720 }}>
+                {clip(sub, 92)}
               </div>
             ) : null}
-            {description ? (
-              <div style={{ display: "flex", fontSize: 24, color: INK_SOFT, marginTop: 20, lineHeight: 1.45, maxWidth: 720 }}>
-                {clip(description, 104)}
+            {author ? (
+              <div style={{ display: "flex", fontSize: 23, color: INK_MUTE, marginTop: 14, fontStyle: "italic", maxWidth: 720 }}>
+                {clip(author, 48)}
               </div>
             ) : null}
             {minds && minds.length ? <MindsCue accents={minds} /> : null}

--- a/web/lib/seo-book.ts
+++ b/web/lib/seo-book.ts
@@ -473,8 +473,42 @@ interface ReadResponse {
   chunks?: { index?: number; text?: string }[];
   paragraphs?: string[];
   chapters?: { number?: number; title?: string; content?: string }[];
+  title?: string;
   subtitle?: string;
+  author?: string;
   total_words?: number;
+}
+
+export interface BookReadMeta {
+  title?: string;
+  subtitle?: string;
+  author?: string;
+}
+
+/**
+ * Author + subtitle from the public /read endpoint.
+ *
+ * For AI-written books these live in the ai_books row, NOT the agent's
+ * meta_json — so /api/agents (getBookData) returns source="ai_writer" with NO
+ * subtitle, while /read returns the real "{creator} · AI" author + the book's
+ * subtitle (exactly what the reader cover shows). The detail page already
+ * fetches /read (getSamplePassages), so Next dedupes this within the request.
+ * Empty object on failure → callers fall back to getBookData. Public,
+ * edge-cached, no auth — crawler-safe (used by the OG route too).
+ */
+export async function getBookReadMeta(id: string): Promise<BookReadMeta> {
+  try {
+    const res = await get<ReadResponse>(
+      `/api/public/book/${encodeURIComponent(id)}/read`,
+    );
+    return {
+      title: (res?.title || "").trim() || undefined,
+      subtitle: (res?.subtitle || "").trim() || undefined,
+      author: (res?.author || "").trim() || undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -3463,30 +3463,22 @@ html.dark .canvas-secondary-btn:hover { background: rgba(255,255,255,0.06); }
   white-space: nowrap;
   text-decoration: none;
 }
-.canvas-action-btn:hover { transform: translateY(-1px); filter: brightness(0.95); }
-html.dark .canvas-action-btn:hover { filter: brightness(1.15); }
+.canvas-action-btn:hover { transform: translateY(-1px); }
 
-/* Chat — warm amber */
+/* Unified, minimal action set (matches the share-card "Chat with" pill + the
+   SEO entity actions): Chat = solid ink primary; Read + Share = restrained
+   outlined secondaries. No tinted pastels, no blue. Adaptive via --btn-solid-*
+   and --text/--border-strong, so no per-mode (html.dark) overrides needed. */
 .canvas-done-actions > .canvas-action-btn:nth-child(1) {
-  background: #faf3e8; color: #8a6b35; border-color: #ecdcbe;
+  background: var(--btn-solid-bg); color: var(--btn-solid-color); border-color: transparent;
 }
-html.dark .canvas-done-actions > .canvas-action-btn:nth-child(1) {
-  background: rgba(200,160,100,0.13); color: #d4ad60; border-color: rgba(200,160,100,0.25);
-}
-/* Read — cool slate */
-.canvas-done-actions > .canvas-action-btn:nth-child(2) {
-  background: #eef3fa; color: #4a6a8f; border-color: #d0dced;
-}
-html.dark .canvas-done-actions > .canvas-action-btn:nth-child(2) {
-  background: rgba(120,160,220,0.12); color: #8ab4dc; border-color: rgba(120,160,220,0.22);
-}
-/* Share — soft sage */
+.canvas-done-actions > .canvas-action-btn:nth-child(1):hover { opacity: 0.92; }
+.canvas-done-actions > .canvas-action-btn:nth-child(2),
 .canvas-share-wrap .canvas-action-btn {
-  background: #eef6f1; color: #437a56; border-color: #c8e0d0;
+  background: transparent; color: var(--text); border-color: var(--border-strong);
 }
-html.dark .canvas-share-wrap .canvas-action-btn {
-  background: rgba(100,200,140,0.11); color: #6cc490; border-color: rgba(100,200,140,0.22);
-}
+.canvas-done-actions > .canvas-action-btn:nth-child(2):hover,
+.canvas-share-wrap .canvas-action-btn:hover { background: rgba(128,128,128,0.07); border-color: var(--text-muted); }
 
 /* Share popup wrapper */
 .canvas-share-wrap {

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -284,6 +284,8 @@ body { background-color: var(--bg-home); }
   margin: 0 0 0.25em; color: var(--text);
 }
 .seo-hero .seo-author { color: var(--text-secondary); font-size: 16px; margin: 0 0 2px; }
+/* Book subtitle — sits between the title and the author (book convention). */
+.seo-hero .seo-subtitle { color: var(--text); font-size: 19px; line-height: 1.4; font-weight: 400; margin: 4px 0 8px; max-width: 42rem; }
 .seo-hero .seo-meta { color: var(--text-muted); font-size: 14px; margin: 0; }
 .seo-hero .seo-backlink { display: inline-block; color: var(--text-muted); font-size: 14px; margin-bottom: 12px; }
 
@@ -399,7 +401,7 @@ body { background-color: var(--bg-home); }
 }
 .fy-share-cancel:hover { background: rgba(128,128,128,0.08); }
 .fy-share-go {
-  border: none; background: var(--accent); color: #fff;
+  border: none; background: var(--btn-solid-bg); color: var(--btn-solid-color);
   font-family: inherit; font-size: 13.5px; font-weight: 600;
   padding: 9px 18px; border-radius: var(--r-control, 10px); cursor: pointer;
 }


### PR DESCRIPTION
Follow-up to the share work, addressing four book-surface issues.

### 1. Author + subtitle were wrong/missing
For **AI books** the author + subtitle live in the `ai_books` row (the `/read` endpoint), not the agent `meta_json`. So `/api/agents` (which `getBookData` uses) returns `source: "ai_writer"` with **no subtitle**, while the reader cover correctly shows `"{creator} · AI"` + the real subtitle. New `getBookReadMeta(id)` sources them from `/read` (deduped with the page's existing `/read` fetch) → details page + OG card now match the cover, falling back to the agent values for catalog books.

### 2. Subtitle now rendered
On the details page (title → **subtitle** → author) and on the OG card (subtitle line under the title).

### 3. Chat-first
Details-page actions now always lead with **Chat with this book** (primary); Read/Preview are secondary even when available.

### 4. Unified, no-blue action buttons
Write-complete Chat/Read/Share (were amber / slate / sage pastels) → **ink primary + outlined secondaries**; ShareDialog "Post on X" → ink. Matches the share-card Chat pill and the SEO entity actions — elegant, premium, minimal.

Frontend-only; gate on the green `feynman-web` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)