### PR TITLE
feat(cta): elegant emerald Chat-with buttons (white in dark)

### DIFF
--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -73,19 +73,21 @@ export async function GET(req: Request) {
   const id = searchParams.get("id") || "";
   const slug = searchParams.get("slug") || "";
   const kind = searchParams.get("kind") || "";
+  // Temporary CTA-color preview override (e.g. &pill=%232b3553) — design review only.
+  const pill = searchParams.get("pill") || "";
 
   const fonts = await loadOgFonts();
   const opts = { ...OG_SIZE, fonts, headers: { "Cache-Control": CACHE } };
 
   try {
-    const el = await build(type, id, slug, kind);
+    const el = await build(type, id, slug, kind, pill);
     return new ImageResponse(el, opts);
   } catch {
     return new ImageResponse(<FallbackCard />, opts);
   }
 }
 
-async function build(type: string, id: string, slug: string, kind: string) {
+async function build(type: string, id: string, slug: string, kind: string, pill: string) {
   switch (type) {
     case "mind": {
       const mind = await fetchMind(id);
@@ -124,6 +126,7 @@ async function build(type: string, id: string, slug: string, kind: string) {
             ...related.minds.slice(0, 3).map((m) => mindAccent(m.name)),
             "#5e4285", "#855e42", "#428585",
           ].slice(0, 3)}
+          pillColor={pill || undefined}
         />
       );
     }

--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -73,21 +73,19 @@ export async function GET(req: Request) {
   const id = searchParams.get("id") || "";
   const slug = searchParams.get("slug") || "";
   const kind = searchParams.get("kind") || "";
-  // Temporary CTA-color preview override (e.g. &pill=%232b3553) — design review only.
-  const pill = searchParams.get("pill") || "";
 
   const fonts = await loadOgFonts();
   const opts = { ...OG_SIZE, fonts, headers: { "Cache-Control": CACHE } };
 
   try {
-    const el = await build(type, id, slug, kind, pill);
+    const el = await build(type, id, slug, kind);
     return new ImageResponse(el, opts);
   } catch {
     return new ImageResponse(<FallbackCard />, opts);
   }
 }
 
-async function build(type: string, id: string, slug: string, kind: string, pill: string) {
+async function build(type: string, id: string, slug: string, kind: string) {
   switch (type) {
     case "mind": {
       const mind = await fetchMind(id);
@@ -126,7 +124,6 @@ async function build(type: string, id: string, slug: string, kind: string, pill:
             ...related.minds.slice(0, 3).map((m) => mindAccent(m.name)),
             "#5e4285", "#855e42", "#428585",
           ].slice(0, 3)}
-          pillColor={pill || undefined}
         />
       );
     }

--- a/web/lib/og/cards.tsx
+++ b/web/lib/og/cards.tsx
@@ -25,6 +25,7 @@ import {
   INK_SOFT,
   INK_MUTE,
   HAIRLINE,
+  CHAT_CTA,
   clip,
 } from "@/lib/og/theme";
 
@@ -193,9 +194,9 @@ function ChatIcon({ size = 24 }: { size?: number }) {
 // The chat value prop, made prominent in the MAIN visual (not a tiny footer
 // line): a dark, button-like CTA pill that signals the card is interactive —
 // the whole point of the product, and the click-through driver.
-function ChatPill({ label }: { label: string }) {
+function ChatPill({ label, color }: { label: string; color?: string }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", alignSelf: "flex-start", background: INK, color: "#ffffff", borderRadius: 999, padding: "15px 30px", marginTop: 30, boxShadow: "0 8px 22px rgba(0,0,0,0.14)" }}>
+    <div style={{ display: "flex", alignItems: "center", alignSelf: "flex-start", background: color || CHAT_CTA, color: "#ffffff", borderRadius: 999, padding: "15px 30px", marginTop: 30, boxShadow: "0 8px 22px rgba(0,0,0,0.16)" }}>
       <ChatIcon />
       <div style={{ display: "flex", marginLeft: 13, fontSize: 26, fontWeight: 700, fontFamily: FONT }}>{clip(label, 30)}</div>
     </div>
@@ -240,7 +241,7 @@ export function MindCard({ data, portrait, accent, initials }: { data: MindCardD
   );
 }
 
-export function BookCard({ title, author, subtitle, description, cover, bg, minds }: { title: string; author?: string; subtitle?: string; description?: string; cover: string | null; bg: string; minds?: string[] }) {
+export function BookCard({ title, author, subtitle, description, cover, bg, minds, pillColor }: { title: string; author?: string; subtitle?: string; description?: string; cover: string | null; bg: string; minds?: string[]; pillColor?: string }) {
   const sub = subtitle || description;
   return (
     <Frame
@@ -262,7 +263,7 @@ export function BookCard({ title, author, subtitle, description, cover, bg, mind
               </div>
             ) : null}
             {minds && minds.length ? <MindsCue accents={minds} /> : null}
-            <ChatPill label="Chat with this book" />
+            <ChatPill label="Chat with this book" color={pillColor} />
           </div>
         </div>
       }

--- a/web/lib/og/cards.tsx
+++ b/web/lib/og/cards.tsx
@@ -194,9 +194,9 @@ function ChatIcon({ size = 24 }: { size?: number }) {
 // The chat value prop, made prominent in the MAIN visual (not a tiny footer
 // line): a dark, button-like CTA pill that signals the card is interactive —
 // the whole point of the product, and the click-through driver.
-function ChatPill({ label, color }: { label: string; color?: string }) {
+function ChatPill({ label }: { label: string }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", alignSelf: "flex-start", background: color || CHAT_CTA, color: "#ffffff", borderRadius: 999, padding: "15px 30px", marginTop: 30, boxShadow: "0 8px 22px rgba(0,0,0,0.16)" }}>
+    <div style={{ display: "flex", alignItems: "center", alignSelf: "flex-start", background: CHAT_CTA, color: "#ffffff", borderRadius: 999, padding: "15px 30px", marginTop: 30, boxShadow: "0 8px 22px rgba(0,0,0,0.16)" }}>
       <ChatIcon />
       <div style={{ display: "flex", marginLeft: 13, fontSize: 26, fontWeight: 700, fontFamily: FONT }}>{clip(label, 30)}</div>
     </div>
@@ -241,7 +241,7 @@ export function MindCard({ data, portrait, accent, initials }: { data: MindCardD
   );
 }
 
-export function BookCard({ title, author, subtitle, description, cover, bg, minds, pillColor }: { title: string; author?: string; subtitle?: string; description?: string; cover: string | null; bg: string; minds?: string[]; pillColor?: string }) {
+export function BookCard({ title, author, subtitle, description, cover, bg, minds }: { title: string; author?: string; subtitle?: string; description?: string; cover: string | null; bg: string; minds?: string[] }) {
   const sub = subtitle || description;
   return (
     <Frame
@@ -263,7 +263,7 @@ export function BookCard({ title, author, subtitle, description, cover, bg, mind
               </div>
             ) : null}
             {minds && minds.length ? <MindsCue accents={minds} /> : null}
-            <ChatPill label="Chat with this book" color={pillColor} />
+            <ChatPill label="Chat with this book" />
           </div>
         </div>
       }

--- a/web/lib/og/theme.ts
+++ b/web/lib/og/theme.ts
@@ -19,6 +19,11 @@ export const INK_SOFT = "#3d3b39";
 export const INK_MUTE = "#6e6e73";
 export const HAIRLINE = "rgba(0,0,0,0.10)";
 export const BRAND = "#0071e3";
+// Chat-with CTA color — a deep, elegant ink-navy (not pure black, not the loud
+// brand blue). Share cards are always light, so the pill uses this directly;
+// the live on-page buttons mirror it via the --chat-cta-* CSS tokens (which go
+// white in dark mode). Keep this hex in sync with --chat-cta-bg in app.css.
+export const CHAT_CTA = "#2b3553";
 
 // ── Book cover colors — verbatim from lib/books.ts (so the share cover matches
 //    the in-app cover for the same title). AI books use the purple gradient. ──

--- a/web/lib/og/theme.ts
+++ b/web/lib/og/theme.ts
@@ -19,11 +19,11 @@ export const INK_SOFT = "#3d3b39";
 export const INK_MUTE = "#6e6e73";
 export const HAIRLINE = "rgba(0,0,0,0.10)";
 export const BRAND = "#0071e3";
-// Chat-with CTA color — a deep, elegant ink-navy (not pure black, not the loud
+// Chat-with CTA color — a deep, elegant emerald (not pure black, not the loud
 // brand blue). Share cards are always light, so the pill uses this directly;
 // the live on-page buttons mirror it via the --chat-cta-* CSS tokens (which go
-// white in dark mode). Keep this hex in sync with --chat-cta-bg in app.css.
-export const CHAT_CTA = "#2b3553";
+// white in dark mode). Keep this hex in sync with --chat-cta-bg in liquid.css.
+export const CHAT_CTA = "#15543f";
 
 // ── Book cover colors — verbatim from lib/books.ts (so the share cover matches
 //    the in-app cover for the same title). AI books use the purple gradient. ──

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -3470,7 +3470,7 @@ html.dark .canvas-secondary-btn:hover { background: rgba(255,255,255,0.06); }
    outlined secondaries. No tinted pastels, no blue. Adaptive via --btn-solid-*
    and --text/--border-strong, so no per-mode (html.dark) overrides needed. */
 .canvas-done-actions > .canvas-action-btn:nth-child(1) {
-  background: var(--btn-solid-bg); color: var(--btn-solid-color); border-color: transparent;
+  background: var(--chat-cta-bg); color: var(--chat-cta-fg); border-color: transparent;
 }
 .canvas-done-actions > .canvas-action-btn:nth-child(1):hover { opacity: 0.92; }
 .canvas-done-actions > .canvas-action-btn:nth-child(2),

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -71,7 +71,7 @@
    (the user prefers a color over pure black; dark stays white). Mirrors
    CHAT_CTA in lib/og/theme.ts (the share-card pill). Standalone block so it
    covers default + system-dark (unless forced .light) + forced .dark. */
-:root { --chat-cta-bg: #2b3553; --chat-cta-fg: #ffffff; }
+:root { --chat-cta-bg: #15543f; --chat-cta-fg: #ffffff; }
 @media (prefers-color-scheme: dark) { :root:not(.light) { --chat-cta-bg: #f5f5f7; --chat-cta-fg: #1c1c1e; } }
 :root.dark { --chat-cta-bg: #f5f5f7; --chat-cta-fg: #1c1c1e; }
 

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -67,6 +67,14 @@
   --bg-hover: #f3f4f6;
 }
 
+/* Chat-with CTA color — an elegant ink-navy in light mode, white in dark
+   (the user prefers a color over pure black; dark stays white). Mirrors
+   CHAT_CTA in lib/og/theme.ts (the share-card pill). Standalone block so it
+   covers default + system-dark (unless forced .light) + forced .dark. */
+:root { --chat-cta-bg: #2b3553; --chat-cta-fg: #ffffff; }
+@media (prefers-color-scheme: dark) { :root:not(.light) { --chat-cta-bg: #f5f5f7; --chat-cta-fg: #1c1c1e; } }
+:root.dark { --chat-cta-bg: #f5f5f7; --chat-cta-fg: #1c1c1e; }
+
 /* Dark material — surfaces from the production dark bgs, not tinted. */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
@@ -303,7 +311,7 @@ body { background-color: var(--bg-home); }
    near-white on dark) instead of the loud accent blue, matching the dark
    "Chat with" pill on the share cards. Neutral shadow, soft lift on hover. */
 .seo-action.primary {
-  background: var(--btn-solid-bg); color: var(--btn-solid-color); border-color: transparent;
+  background: var(--chat-cta-bg); color: var(--chat-cta-fg); border-color: transparent;
   box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 4px 14px rgba(0,0,0,0.14);
 }
 .seo-action.primary:hover { transform: translateY(-1px); opacity: 0.92; box-shadow: 0 3px 8px rgba(0,0,0,0.14), 0 10px 26px rgba(0,0,0,0.18); }


### PR DESCRIPTION
Unifies the "Chat with …" CTA color across every surface to a deep, elegant **emerald `#15543f`** (not pure black, not the loud brand blue); **stays white in dark mode**.

- `CHAT_CTA` (theme.ts) drives the share-card Chat pill; `--chat-cta-bg/fg` (liquid.css) drive the on-page buttons — details page primary (`.seo-action.primary`) + write-complete Chat — so all share-card / detail / write-complete Chat CTAs match.
- Removes the temporary `&pill=` color-preview override + its `pillColor` plumbing now that the color is locked.

Applies to book **and** minds cards (and answer/qa/essay/topic/discussion). Frontend-only; gate on the green `feynman-web` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)