### PR TITLE
fix(funnel+seo): mobile sidebar overlay, mind intent through login, truthful sitemap, creation-time slugs

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1012,12 +1012,40 @@ def init_db() -> None:
         pass
 
 
+def _unique_slug(conn, table: str, name: str) -> str | None:
+    """Descriptive URL slug for a new entity, deduped within its table.
+
+    Creation-time companion to scripts/backfill_slugs.py — every creation path
+    (discover cron, chat book_context, minds expansion) must assign a slug at
+    INSERT, otherwise the entity ships a bare-UUID URL into the sitemap and
+    internal links until someone remembers to re-run the backfill (the
+    2026-06-08 minds expansion shipped 481 such URLs). Same slugify + -2/-3
+    dedup as the backfill so the two paths can never disagree. Best-effort on
+    races (no UNIQUE constraint): creation is a low-rate cron/script path, and
+    a rare duplicate slug resolves to the older row, matching backfill order.
+    """
+    from app.core.seo import slugify  # local import — db must stay seo-independent at module load
+
+    base = slugify(name or "", max_len=60)
+    if not base:
+        return None
+    slug = base
+    for k in range(2, 60):
+        row = _fetchone(conn, _q(f"SELECT 1 AS hit FROM {table} WHERE slug = ?"), (slug,))  # noqa: S608 — table is a literal
+        if not row:
+            return slug
+        slug = f"{base}-{k}"
+    # Pathological collision run — fall back to a uuid suffix, never loop.
+    return f"{base}-{uuid.uuid4().hex[:6]}"
+
+
 def create_agent(name: str, agent_type: str, source: str | None, meta: dict[str, Any], user_id: str | None = None) -> str:
     agent_id = str(uuid.uuid4())
     with get_conn() as conn:
+        slug = _unique_slug(conn, "agents", name)
         _execute(conn, _q(
-            "INSERT INTO agents (id, name, type, source, status, meta_json, user_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-        ), (agent_id, name, agent_type, source, "indexing", json.dumps(meta), user_id, _utcnow()))
+            "INSERT INTO agents (id, name, slug, type, source, status, meta_json, user_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        ), (agent_id, name, slug, agent_type, source, "indexing", json.dumps(meta), user_id, _utcnow()))
     return agent_id
 
 
@@ -1817,14 +1845,16 @@ def create_mind(data: dict[str, Any]) -> str:
     """Insert a new mind agent. Returns mind_id."""
     mind_id = str(uuid.uuid4())
     with get_conn() as conn:
+        slug = _unique_slug(conn, "minds", data["name"])
         _execute(conn, _q(
             """INSERT INTO minds
-               (id, name, era, domain, bio_summary, persona, thinking_style,
+               (id, name, slug, era, domain, bio_summary, persona, thinking_style,
                 typical_phrases, works, avatar_seed, version, chat_count, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?)"""
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?)"""
         ), (
             mind_id,
             data["name"],
+            slug,
             data.get("era", ""),
             data.get("domain", ""),
             data.get("bio_summary", ""),

--- a/app/main.py
+++ b/app/main.py
@@ -819,7 +819,6 @@ def sitemap_redirect():
 @app.get("/sitemap.xml")
 def sitemap_xml():
     from fastapi.responses import Response
-    from datetime import date
 
     cached = _cache_get("sitemap_xml", _SEO_CACHE_TTL)
     if cached is not None:
@@ -832,7 +831,19 @@ def sitemap_xml():
             },
         )
 
-    today = date.today().isoformat()
+    def _lastmod(ts) -> str:
+        """<lastmod> line from a stored created_at, or '' to omit the tag.
+
+        Google only trusts lastmod when it's consistently truthful — the
+        previous render stamped every URL with date.today(), which (a) taught
+        Google to ignore our lastmod entirely and (b) wasted the strongest
+        crawl-prioritization signal a crawl-budget-limited young domain has.
+        created_at is the honest timestamp we store for entities; URLs with no
+        real timestamp simply omit the tag (valid per the protocol).
+        """
+        s = str(ts or "")[:10]
+        return f"\n    <lastmod>{s}</lastmod>" if len(s) == 10 else ""
+
     pages = [
         {"loc": "/", "priority": "1.0", "changefreq": "daily"},
         {"loc": "/terms", "priority": "0.3", "changefreq": "yearly"},
@@ -842,7 +853,6 @@ def sitemap_xml():
     for p in pages:
         urls += f"""  <url>
     <loc>{_SITE_URL}{p["loc"]}</loc>
-    <lastmod>{today}</lastmod>
     <changefreq>{p["changefreq"]}</changefreq>
     <priority>{p["priority"]}</priority>
   </url>
@@ -873,11 +883,18 @@ def sitemap_xml():
         chunks_by_agent = count_chunks_batch(ready_ids)
         for agent in ready_agents:
             agent_id = agent["id"]
-            aslug = agent.get("slug") or agent_id  # descriptive URL; UUID fallback
+            # Slug-less entities stay OUT of the sitemap. Advertising the bare
+            # UUID URL throws away the keyword signal and — once the slug
+            # backfill runs — turns the advertised URL into a 301, churning
+            # crawl budget twice for the same page. backfill_slugs.py (or the
+            # creation-time slug in db.py) makes this gate a no-op in steady
+            # state; it exists so a future batch import can't regress it.
+            aslug = agent.get("slug")
+            if not aslug:
+                continue
             priority = "0.7" if agent.get("type") == "ai_book" else "0.5"
             urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{aslug}</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/book/{aslug}</loc>{_lastmod(agent.get("created_at"))}
     <changefreq>monthly</changefreq>
     <priority>{priority}</priority>
   </url>
@@ -893,17 +910,19 @@ def sitemap_xml():
                 if not qslug:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{aslug}/q/{qslug}</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/book/{aslug}/q/{qslug}</loc>{_lastmod(agent.get("created_at"))}
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 """
         all_minds = list_minds(limit=5000)
-        for mind in all_minds:
+        # Same slug gate as books: a mind without a slug isn't advertised (see
+        # the comment above) — the 2026-06-08 expansion shipped 481 UUID URLs
+        # into the sitemap exactly this way.
+        slugged_minds = [m for m in all_minds if m.get("slug")]
+        for mind in slugged_minds:
             urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/mind/{mind["slug"]}</loc>{_lastmod(mind.get("created_at"))}
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -911,7 +930,7 @@ def sitemap_xml():
         # Phase 4B — mind-on-topic compound URLs. Only emit pairs that
         # pass the relevance filter so we don't list /mind/X/on/Y for
         # combos that the route would 404 anyway.
-        for mind in all_minds:
+        for mind in slugged_minds:
             for topic in TOPIC_TAGS:
                 if not qa_module.is_mind_topic_relevant(mind, topic):
                     continue
@@ -919,8 +938,7 @@ def sitemap_xml():
                 if not tslug:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}/on/{tslug}</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/mind/{mind["slug"]}/on/{tslug}</loc>{_lastmod(mind.get("created_at"))}
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -933,7 +951,6 @@ def sitemap_xml():
                 continue
             urls += f"""  <url>
     <loc>{_SITE_URL}/topic/{slug}</loc>
-    <lastmod>{today}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -949,24 +966,24 @@ def sitemap_xml():
                 [a["id"] for a in ready_agents]
             )
             for agent in ready_agents:
+                if not agent.get("slug"):
+                    continue
                 if agent_insight_counts.get(agent["id"], 0) < insight_count_min:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent.get("slug") or agent["id"]}/insights</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/book/{agent["slug"]}/insights</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
 """
             mind_insight_counts = count_assistant_messages_for_minds_batch(
-                [m["id"] for m in all_minds]
+                [m["id"] for m in slugged_minds]
             )
-            for mind in all_minds:
+            for mind in slugged_minds:
                 if mind_insight_counts.get(mind["id"], 0) < insight_count_min:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}/dialogues</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/mind/{mind["slug"]}/dialogues</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -986,24 +1003,24 @@ def sitemap_xml():
                 [a["id"] for a in ready_agents]
             )
             for agent in ready_agents:
+                if not agent.get("slug"):
+                    continue
                 if agent_discussion_counts.get(agent["id"], 0) < 1:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/book/{agent.get("slug") or agent["id"]}/discussions</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/book/{agent["slug"]}/discussions</loc>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
 """
             mind_discussion_counts = count_approved_public_sessions_per_mind(
-                [m["id"] for m in all_minds]
+                [m["id"] for m in slugged_minds]
             )
-            for mind in all_minds:
+            for mind in slugged_minds:
                 if mind_discussion_counts.get(mind["id"], 0) < 1:
                     continue
                 urls += f"""  <url>
-    <loc>{_SITE_URL}/mind/{mind.get("slug") or mind["id"]}/discussions</loc>
-    <lastmod>{today}</lastmod>
+    <loc>{_SITE_URL}/mind/{mind["slug"]}/discussions</loc>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/scripts/backfill_slugs.py
+++ b/scripts/backfill_slugs.py
@@ -68,7 +68,11 @@ def main() -> int:
     # before we read. Adding a NULL column is harmless on a dry run.
     ensure_slug_columns()
 
-    agents = list_agents(limit=100000)
+    # lite=True — the backfill only reads id/name/slug/created_at; the full
+    # SELECT * pulls every book's ~9KB meta_json (~8MB+) through the
+    # non-pooling DSN, which is both needless Supabase egress and flaky over
+    # long-haul connections (observed server-side disconnect mid-read).
+    agents = list_agents(limit=100000, lite=True)
     minds = list_minds(limit=100000)
     print(f"loaded {len(agents)} agents, {len(minds)} minds", file=sys.stderr)
     na = backfill("book", agents, update_agent_slug, args.apply)

--- a/web/components/auth/LoginForm.tsx
+++ b/web/components/auth/LoginForm.tsx
@@ -38,6 +38,18 @@ export default function LoginForm() {
       setError("Authentication is not configured.");
       return;
     }
+    // The OAuth round-trip is a full-page redirect that lands back on the
+    // origin, so a ?next= return path can't ride the URL the way the password
+    // flow's router.push does. Stash it in sessionStorage (same tab survives
+    // the redirect); AuthProvider consumes it once the session lands.
+    try {
+      const next = new URLSearchParams(window.location.search).get("next");
+      if (next && next.startsWith("/") && !next.startsWith("//")) {
+        sessionStorage.setItem("feynman:postLoginNext", next);
+      }
+    } catch {
+      /* best-effort */
+    }
     // OAuth redirects away on success, so only clear busy on error — the button
     // stays "Connecting…" until the navigation happens.
     setGoogleBusy(true);

--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -21,7 +21,11 @@ import { createSession, bumpSessions } from "@/lib/chat";
 import { startWriteBook } from "@/lib/writeBook";
 import { useAuth } from "@/lib/auth";
 import { useProGate } from "@/components/pro/ProOverlay";
-import { restorePendingBookIntent, savePendingBookIntent } from "@/lib/pendingIntent";
+import {
+  restorePendingBookIntent,
+  savePendingBookIntent,
+  savePendingMindIntent,
+} from "@/lib/pendingIntent";
 import { track } from "@/lib/analytics";
 import {
   SelectedChips,
@@ -188,9 +192,11 @@ export default function HomeComposer() {
     const intent = restorePendingBookIntent();
     if (intent) {
       if (intent.question) setValue(intent.question);
-      preselectBook(intent.bookId);
+      if (intent.bookId) preselectBook(intent.bookId);
+      if (intent.mindId) preselectMind(intent.mindId);
       track("pending_intent_restored", {
         via: intent.via,
+        entity: intent.bookId ? "book" : "mind",
         had_question: !!intent.question,
       });
     }
@@ -274,19 +280,33 @@ export default function HomeComposer() {
   const submit = async () => {
     const msg = value.trim();
     if (!msg || busy) return;
-    // Anonymous visitor on the hosted build: stash the book + question they came
-    // for, then bounce through login. After sign-up the composer restores the
-    // intent and resumes the chat (mirrors Reader.askQuestion + the
-    // pending-intent system). The cross-surface "Chat" CTAs route anonymous
-    // users into this composer with a book preselected, so this is the single
-    // funnel gate that keeps the book from being lost through login.
+    // Anonymous visitor on the hosted build: stash the entity (book OR mind) +
+    // question they came for, then bounce through login. After sign-up the
+    // composer restores the intent and resumes the chat (mirrors
+    // Reader.askQuestion + the pending-intent system). The cross-surface "Chat"
+    // CTAs route anonymous users into this composer with an entity preselected,
+    // so this is the single funnel gate that keeps it from being lost through
+    // login. The ?next= return path carries the same state explicitly — it
+    // survives the password flow's router.push and (via the sessionStorage
+    // handoff in LoginForm/auth) the Google OAuth full-page redirect.
     if (authEnabled && !user) {
       const book = [...books.values()][0];
+      const mind = [...minds.values()][0];
       if (book) {
         savePendingBookIntent(book.agentId || book.id, { question: msg, via: "home_composer" });
+      } else if (mind) {
+        savePendingMindIntent(mind.id, { question: msg, via: "home_composer" });
       }
-      track("pending_intent_saved", { via: "home_composer" });
-      router.push("/login");
+      track("pending_intent_saved", {
+        via: "home_composer",
+        entity: book ? "book" : mind ? "mind" : "none",
+      });
+      const qs = new URLSearchParams();
+      if (book) qs.set("book", book.agentId || book.id);
+      else if (mind) qs.set("mind", mind.id);
+      if (msg) qs.set("q", msg);
+      const search = qs.toString();
+      router.push(search ? `/login?next=${encodeURIComponent(`/?${search}`)}` : "/login");
       return;
     }
     // Inviting minds requires pro on the hosted build (legacy app.js 3149).

--- a/web/components/mind/MindChat.tsx
+++ b/web/components/mind/MindChat.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth";
+import { track } from "@/lib/analytics";
 import { useProGate } from "@/components/pro/ProOverlay";
 import { createSession, bumpSessions, queueSaveMessage } from "@/lib/chat";
 import { post } from "@/lib/api";
@@ -43,6 +44,16 @@ export default function MindChat({
   const needsSignIn = authEnabled && !user;
   const needsPaywall = !needsSignIn && !isProUser;
   const gated = needsSignIn || needsPaywall;
+
+  // Measure the gate itself: how many SEO-funnel visitors reach this surface
+  // and which wall they hit. Together with chat_cta_clicked (EntityActions)
+  // and upgrade_prompt_shown (ProOverlay) this makes the hard-gate funnel
+  // readable in PostHog: cta → wall → login/upgrade → paid.
+  useEffect(() => {
+    if (!ready) return;
+    if (needsSignIn) track("signin_wall_shown", { surface: "mind_chat", mind_id: mindId });
+    else if (needsPaywall) track("paywall_shown", { surface: "mind_chat", mind_id: mindId });
+  }, [ready, needsSignIn, needsPaywall, mindId]);
 
   // The session backing this chat (created once, when not gated).
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -119,7 +130,10 @@ export default function MindChat({
                 {needsSignIn ? (
                   <>
                     <p>Sign in to chat with {mind.name}</p>
-                    <Link href="/login" className={styles.fallbackLink}>
+                    <Link
+                      href={`/login?next=${encodeURIComponent(`/mind/${mind.slug || mindId}/chat`)}`}
+                      className={styles.fallbackLink}
+                    >
                       Sign in →
                     </Link>
                   </>

--- a/web/components/seo/EntityActions.tsx
+++ b/web/components/seo/EntityActions.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import ShareDialog from "@/components/share/ShareDialog";
+import { track } from "@/lib/analytics";
 
 /**
  * Top action bar for SEO entity pages: prominent primary actions (Read /
@@ -33,7 +34,18 @@ export default function EntityActions({
   return (
     <div className="seo-actions">
       {actions.map((a) => (
-        <Link key={a.label} href={a.href} className={`seo-action ${a.variant}`}>
+        <Link
+          key={a.label}
+          href={a.href}
+          className={`seo-action ${a.variant}`}
+          onClick={() => {
+            // The SEO→chat funnel's intent step. href carries the entity
+            // (/?book={slug} | /mind/{slug}/chat), so no per-page wiring.
+            if (/^chat\b/i.test(a.label)) {
+              track("chat_cta_clicked", { label: a.label, href: a.href });
+            }
+          }}
+        >
           {a.label}
         </Link>
       ))}

--- a/web/components/shell/Sidebar.tsx
+++ b/web/components/shell/Sidebar.tsx
@@ -10,7 +10,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import ChatHistory from "@/components/chat/ChatHistory";
 import UserMenu from "./UserMenu";
 
@@ -75,6 +75,21 @@ export default function Sidebar() {
   const pathname = usePathname() || "/";
   const [collapsed, setCollapsed] = useState(false);
 
+  // Small screens start collapsed: ≤900px the sidebar becomes a fixed overlay
+  // (app.css), so the desktop expanded-by-default covered the page content on
+  // every mobile visit. Keyed on pathname so navigating FROM the open overlay
+  // also dismisses it (it would otherwise sit over the destination page).
+  // Layout effect rather than a state initializer — the SSR markup is
+  // "expanded", and flipping before first paint avoids both the hydration
+  // mismatch and a visible flash.
+  useLayoutEffect(() => {
+    try {
+      if (window.matchMedia("(max-width: 900px)").matches) setCollapsed(true);
+    } catch {
+      /* matchMedia unavailable → keep the desktop default */
+    }
+  }, [pathname]);
+
   // The collapse styling lives on `.app-layout.sidebar-collapsed` (styles.css),
   // but this aside can't set a class on its parent in JSX — so sync it
   // imperatively. The migration toggled `data-collapsed` on the aside instead,
@@ -86,6 +101,7 @@ export default function Sidebar() {
   }, [collapsed]);
 
   return (
+    <>
     <aside className="app-sidebar" id="app-sidebar" data-collapsed={collapsed}>
       <div className="sidebar-header">
         <Link
@@ -166,5 +182,22 @@ export default function Sidebar() {
         <UserMenu />
       </div>
     </aside>
+    {/* Mobile-only floating opener (index.html #sidebar-float-btn). ≤900px the
+        collapsed sidebar is width:0 — the in-rail brand glyph collapses with
+        it, so without this sibling button there is no way to reopen. CSS shows
+        it only when .sidebar-collapsed is active under 900px. */}
+    <button
+      id="sidebar-float-btn"
+      className="sidebar-float-btn"
+      title="Open sidebar"
+      aria-label="Open sidebar"
+      onClick={() => setCollapsed(false)}
+    >
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <line x1="9" y1="3" x2="9" y2="21" />
+      </svg>
+    </button>
+    </>
   );
 }

--- a/web/lib/auth.tsx
+++ b/web/lib/auth.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import type { Session, SupabaseClient, User } from "@supabase/supabase-js";
 import { getProConfig, type ProConfig } from "@/lib/config";
 import { initSupabase } from "@/lib/supabase";
@@ -40,6 +41,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // true, so a Pro user never flashes "Free" before the tier resolves.
   const [tierKnown, setTierKnown] = useState(false);
   const [config, setConfig] = useState<ProConfig | null>(null);
+  const router = useRouter();
   const clientRef = useRef<SupabaseClient | null>(null);
   // The signed-in identity we last fetched the tier for. onAuthStateChange fires
   // applySession on every TOKEN_REFRESHED; without this guard each fire re-ran an
@@ -147,6 +149,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
     return { error: null };
   }, []);
+
+  // Post-OAuth return path. Google OAuth is a full-page redirect that always
+  // lands on the origin, so LoginForm stashes any same-site ?next= in
+  // sessionStorage before redirecting; once the session lands here, finish the
+  // journey. Keyed on identity + guarded on the key existing, so token
+  // refreshes and ordinary sign-ins never navigate.
+  useEffect(() => {
+    if (!user) return;
+    let next: string | null = null;
+    try {
+      next = sessionStorage.getItem("feynman:postLoginNext");
+      if (next) sessionStorage.removeItem("feynman:postLoginNext");
+    } catch {
+      /* best-effort */
+    }
+    if (next && next.startsWith("/") && !next.startsWith("//")) router.push(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   const signInWithOAuth = useCallback(async (provider: "google") => {
     const client = clientRef.current;

--- a/web/lib/pendingIntent.ts
+++ b/web/lib/pendingIntent.ts
@@ -19,22 +19,31 @@
 export const PENDING_INTENT_KEY = "feynman:pendingChat";
 const TTL_MS = 24 * 60 * 60 * 1000;
 
-export interface PendingBookIntent {
-  bookId: string;
+/**
+ * A pending chat intent carries the ENTITY the visitor came for — a book
+ * (`bookId`, the original shape) or a great mind (`mindId`). Exactly one is
+ * set. Minds were silently dropped through login before this field existed —
+ * and mind pages are the majority of the SEO surface.
+ */
+export interface PendingChatIntent {
+  bookId?: string;
+  mindId?: string;
   question: string;
   via: string;
   ts: number;
 }
 
-/** Persist a book-chat intent. Best-effort; storage failures are swallowed. */
-export function savePendingBookIntent(
-  bookId: string,
-  opts: { question?: string; via?: string } = {},
+/** Back-compat alias (original book-only shape). */
+export type PendingBookIntent = PendingChatIntent;
+
+function saveIntent(
+  entity: Partial<PendingChatIntent>,
+  opts: { question?: string; via?: string },
 ): void {
-  if (!bookId || typeof window === "undefined") return;
+  if (typeof window === "undefined") return;
   try {
-    const intent: PendingBookIntent = {
-      bookId,
+    const intent: PendingChatIntent = {
+      ...entity,
       question: opts.question || "",
       via: opts.via || "reader",
       ts: Date.now(),
@@ -45,20 +54,39 @@ export function savePendingBookIntent(
   }
 }
 
+/** Persist a book-chat intent. Best-effort; storage failures are swallowed. */
+export function savePendingBookIntent(
+  bookId: string,
+  opts: { question?: string; via?: string } = {},
+): void {
+  if (!bookId) return;
+  saveIntent({ bookId }, opts);
+}
+
+/** Persist a mind-chat intent (the /?mind= composer + mind-page gates). */
+export function savePendingMindIntent(
+  mindId: string,
+  opts: { question?: string; via?: string } = {},
+): void {
+  if (!mindId) return;
+  saveIntent({ mindId }, opts);
+}
+
 /** Read + validate TTL. Returns the intent or null. Does NOT clear it. */
-export function readPendingBookIntent(): PendingBookIntent | null {
+export function readPendingBookIntent(): PendingChatIntent | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = localStorage.getItem(PENDING_INTENT_KEY);
     if (!raw) return null;
-    const intent = JSON.parse(raw) as Partial<PendingBookIntent>;
-    if (!intent?.bookId) return null;
+    const intent = JSON.parse(raw) as Partial<PendingChatIntent>;
+    if (!intent?.bookId && !intent?.mindId) return null;
     if (intent.ts && Date.now() - intent.ts > TTL_MS) {
       localStorage.removeItem(PENDING_INTENT_KEY);
       return null;
     }
     return {
       bookId: intent.bookId,
+      mindId: intent.mindId,
       question: intent.question || "",
       via: intent.via || "reader",
       ts: intent.ts || Date.now(),


### PR DESCRIPTION
## Why

A full anonymous-visitor audit of the SEO→chat funnel found three conversion killers and one crawl-budget leak:

1. **Every SEO landing page was broken on phones** — the sidebar starts expanded, and ≤900px CSS turns it into a fixed overlay covering the content. Google's mobile-first crawler and ~all mobile clicks saw a nav menu instead of the page.
2. **The login bounce dropped minds** — typing a question in the /?mind= composer and pressing Enter went to /login losing both the mind and the question (only book intents were stashed). Google OAuth (the primary auth) additionally lost any ?next= return path.
3. **Sitemap lastmod was date.today() on all 2,387 URLs** — request-time stamps teach Google to ignore lastmod entirely, wasting the strongest crawl-prioritization signal a young crawl-budget-limited domain has. Plus **481 bare-UUID URLs** (the 6/08 minds expansion never got slugs) were advertised, which become 301 churn the moment slugs backfill.

## What

- **Mobile**: sidebar initializes collapsed ≤900px (layout effect, no hydration mismatch), restores the legacy `#sidebar-float-btn` reopen control (CSS already shipped), auto-dismisses on navigation.
- **Funnel**: `savePendingMindIntent` + restore; anonymous send bounces to `/login?next=/?mind={id}&q={question}`; LoginForm carries `next` through the OAuth full-page redirect via sessionStorage, consumed once in AuthProvider; MindChat sign-in link returns to the chat page.
- **Sitemap**: per-entity `created_at` as lastmod (omitted when unknown); slugless entities excluded; static/topic/live pages drop the fake stamp.
- **Pipeline**: `create_agent`/`create_mind` assign a deduped slug at INSERT so imports can't regress; `backfill_slugs.py` reads the lite agents projection (`SELECT *` pulled 8MB+ meta_json and dropped mid-transfer).
- **Analytics**: `chat_cta_clicked`, `signin_wall_shown`, `paywall_shown` — makes the minds hard-gate experiment measurable in PostHog.

## Ops (already done, no deploy dependency)

`backfill_slugs.py --apply` run against prod: 227 slugless minds (Rousseau, Camus, Hegel, Sartre…) now have descriptive URLs; books were already complete.

## Tests

- `python3 -m pytest tests/` — 296 passed locally.
- Verify on preview: mobile render of /mind/pierre-hadot, sitemap lastmod variety + zero UUID locs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)