### PR TITLE
feat(seo): prestore book overviews — cron + persist lazy generations

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1713,6 +1713,29 @@ def update_agent_meta(agent_id: str, updates: dict[str, Any]) -> None:
         _execute(conn, _q("UPDATE agents SET meta_json = ? WHERE id = ?"), (json.dumps(meta), agent_id))
 
 
+def list_agents_missing_overview(limit: int = 50) -> tuple[list[str], int]:
+    """IDs of ready, non-deleted agents with no stored meta.overview, plus the
+    total remaining count. The filter runs SQL-side (jsonb key test on PG,
+    json_extract on SQLite) so the prestore cron finds candidates without
+    reading hundreds of meta_json blobs per run."""
+    if _USE_PG:
+        where = (
+            "is_deleted = false AND status = 'ready' "
+            "AND NOT (COALESCE(meta_json, '{}')::jsonb ? 'overview')"
+        )
+    else:
+        where = (
+            "is_deleted = 0 AND status = 'ready' "
+            "AND json_extract(COALESCE(meta_json, '{}'), '$.overview') IS NULL"
+        )
+    with get_conn() as conn:
+        total_row = _fetchone(conn, f"SELECT count(*) AS n FROM agents WHERE {where}")
+        rows = _fetchall(conn, _q(
+            f"SELECT id FROM agents WHERE {where} ORDER BY created_at ASC LIMIT ?"
+        ), (limit,))
+    return [r["id"] for r in rows], int(total_row["n"] if total_row else 0)
+
+
 def find_agent_by_name(name: str) -> dict[str, Any] | None:
     """Find an agent by name (case-insensitive)."""
     with get_conn() as conn:

--- a/app/core/overview.py
+++ b/app/core/overview.py
@@ -215,6 +215,38 @@ def generate_book_overview(
     return parsed
 
 
+def prestore_overviews(batch_size: int = 6) -> tuple[int, int]:
+    """Generate + persist overviews for ready books that lack one. Returns
+    (stored, remaining).
+
+    Runs on Vercel (the cron) because grounded mode embeds the RAG query via
+    Gemini, which is geoblocked from the dev machine — the embed-minds
+    constraint. Bounded per call to stay inside the function timeout; each
+    stored overview is permanent (generate_book_overview short-circuits on
+    meta.overview), so the daily schedule self-fills new books and a manual
+    loop drains a backlog. Empty generations (transient LLM failure) are NOT
+    stored and retry on the next run."""
+    from app.core.db import get_agent, list_agents_missing_overview, update_agent_meta
+
+    ids, total = list_agents_missing_overview(limit=batch_size)
+    stored = 0
+    for agent_id in ids:
+        agent = get_agent(agent_id)
+        if not agent:
+            continue
+        result = generate_book_overview(agent)
+        text = (result.get("overview") or "").strip()
+        if not text:
+            continue
+        update_agent_meta(agent_id, {
+            "overview": text,
+            "key_concepts": result.get("concepts") or [],
+            "overview_grounded": bool(result.get("grounded")),
+        })
+        stored += 1
+    return stored, max(0, total - stored)
+
+
 _TOPIC_OVERVIEW_MAX_CHARS = 1200
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -3595,6 +3595,24 @@ def api_cron_voice_minds(request: Request) -> dict[str, Any]:
         return {"status": "error", "detail": str(exc)}
 
 
+@app.get("/api/cron/prestore-overviews")
+def api_cron_prestore_overviews(request: Request) -> dict[str, Any]:
+    """Cron-triggered "About this book" prestore for ready books missing
+    meta.overview (556 at introduction — book hubs rendered overview-less and
+    lazy generations were never persisted). Runs ON Vercel because grounded
+    mode embeds the RAG query via Gemini, geoblocked from the dev machine
+    (embed-minds precedent). Bounded per call for the function timeout; the
+    daily schedule self-fills new books; loop with the CRON_SECRET bearer to
+    drain a backlog (returns remaining)."""
+    _verify_cron(request)
+    try:
+        stored, remaining = overview_module.prestore_overviews(batch_size=6)
+        return {"status": "ok", "stored": stored, "remaining": remaining}
+    except Exception as exc:
+        log.error("Prestore-overviews cron failed: %s", exc)
+        return {"status": "error", "detail": str(exc)}
+
+
 @app.get("/api/cron/reset-embeddings")
 def api_cron_reset_embeddings() -> dict[str, Any]:
     """Clear all corrupted embeddings so backfill can regenerate them."""
@@ -4283,6 +4301,20 @@ def api_agent_overview(agent_id: str) -> JSONResponse:
         # pin an empty overview in-process; empty falls through and retries.
         if cached.get("overview"):
             _cache_set(cache_key, cached)
+            # Persist fresh generations so each one is paid for exactly once.
+            # In-process TTL + edge cache both evaporate (deploys, pod churn,
+            # cache windows) — without this, every re-crawl of a book hub
+            # re-ran the RAG + LLM round trip, and 556 ready books sat with no
+            # stored overview. provider=="stored" means it came FROM meta.
+            if cached.get("provider") and cached.get("provider") != "stored":
+                try:
+                    update_agent_meta(agent_id, {
+                        "overview": cached.get("overview", ""),
+                        "key_concepts": cached.get("concepts") or [],
+                        "overview_grounded": bool(cached.get("grounded")),
+                    })
+                except Exception as exc:
+                    log.warning("overview persist failed for %s: %s", agent_id, exc)
     return JSONResponse(
         content={
             "overview": cached.get("overview", ""),

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,7 @@
     { "path": "/api/cron/discover", "schedule": "0 6 * * 3" },
     { "path": "/api/cron/embed-minds", "schedule": "0 0 * * *" },
     { "path": "/api/cron/voice-minds", "schedule": "0 2 * * *" },
+    { "path": "/api/cron/prestore-overviews", "schedule": "30 2 * * *" },
     { "path": "/api/cron/indexnow", "schedule": "0 4 * * *" },
     { "path": "/api/cron/egress-watch", "schedule": "0 8 * * *" }
   ]


### PR DESCRIPTION
## Why
556/600 ready books have no stored \`meta.overview\` — the "About this book" section was lazily generated per crawl (in-process TTL only, never persisted), so most indexable book hubs render without their main content block and every re-crawl re-pays the RAG+LLM round trip.

## What
- **\`/api/cron/prestore-overviews\`** — daily bounded backfill (6/run, fits the 60s function window); loop with \`CRON_SECRET\` bearer to drain the 556 backlog (returns \`remaining\`). Runs on Vercel because grounded mode embeds the RAG query via Gemini (geoblocked locally — same constraint as embed-minds).
- **Persist lazy generations** — \`/api/agents/{id}/overview\` now writes a successful fresh generation back to \`meta\`, so each overview is generated exactly once, ever.
- **\`db.list_agents_missing_overview\`** — SQL-side candidate filter (PG jsonb / SQLite json_extract), no meta blob reads.

Cost of the full drain: ~556 × (1 Gemini flash-lite call + 1 query-embed) ≈ \$1–2; active CPU is small (mostly LLM wait, which Fluid doesn't bill). Approved batch.

## Tests
\`python3 -m pytest tests/\` — 296 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)