### PR TITLE
fix(prestore): jsonb ? operator vs _q placeholder rewrite (cron 500)

### DIFF
--- a/.github/workflows/drain-overviews.yml
+++ b/.github/workflows/drain-overviews.yml
@@ -18,9 +18,11 @@ jobs:
           for i in $(seq 1 160); do
             RESP=$(curl -s --max-time 110 -H "Authorization: Bearer $CRON_SECRET" "https://api.feynman.wiki/api/cron/prestore-overviews" || echo '{}')
             echo "[$i] $RESP"
-            STATUS=$(echo "$RESP" | jq -r '.status // "fail"')
-            REM=$(echo "$RESP" | jq -r '.remaining // -1')
-            STORED=$(echo "$RESP" | jq -r '.stored // 0')
+            # Non-JSON bodies (Vercel 500 pages) must count as a failed try,
+            # not kill the job — jq exits non-zero under bash -e otherwise.
+            STATUS=$(echo "$RESP" | jq -r '.status // "fail"' 2>/dev/null) || STATUS=fail
+            REM=$(echo "$RESP" | jq -r '.remaining // -1' 2>/dev/null) || REM=-1
+            STORED=$(echo "$RESP" | jq -r '.stored // 0' 2>/dev/null) || STORED=0
             if [ "$STATUS" != "ok" ]; then
               consec=$((consec+1))
               if [ "$consec" -ge 10 ]; then echo "ABORT: 10 consecutive failures"; exit 1; fi

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1719,9 +1719,12 @@ def list_agents_missing_overview(limit: int = 50) -> tuple[list[str], int]:
     json_extract on SQLite) so the prestore cron finds candidates without
     reading hundreds of meta_json blobs per run."""
     if _USE_PG:
+        # jsonb_exists() — NOT the `?` operator: queries here pass through
+        # _q(), whose blind `?`→`%s` rewrite turns the operator into a bogus
+        # placeholder (IndexError at execute). Same semantics, no collision.
         where = (
             "is_deleted = false AND status = 'ready' "
-            "AND NOT (COALESCE(meta_json, '{}')::jsonb ? 'overview')"
+            "AND NOT jsonb_exists(COALESCE(meta_json, '{}')::jsonb, 'overview')"
         )
     else:
         where = (


### PR DESCRIPTION
First run of /api/cron/prestore-overviews failed: `_q()` rewrites every `?` to `%s`, turning the jsonb key-exists operator into a bogus placeholder (IndexError). Switch to `jsonb_exists()`; verified against prod (557 candidates). Also hardens the drain workflow's jq parsing. 296 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)