### PR TITLE
fix(prestore): per-book generation timeout + self-diagnosing cron response

### DIFF
--- a/.github/workflows/drain-overviews.yml
+++ b/.github/workflows/drain-overviews.yml
@@ -18,9 +18,11 @@ jobs:
           for i in $(seq 1 160); do
             RESP=$(curl -s --max-time 110 -H "Authorization: Bearer $CRON_SECRET" "https://api.feynman.wiki/api/cron/prestore-overviews" || echo '{}')
             echo "[$i] $RESP"
-            STATUS=$(echo "$RESP" | jq -r '.status // "fail"')
-            REM=$(echo "$RESP" | jq -r '.remaining // -1')
-            STORED=$(echo "$RESP" | jq -r '.stored // 0')
+            # Non-JSON bodies (Vercel 500 pages) must count as a failed try,
+            # not kill the job — jq exits non-zero under bash -e otherwise.
+            STATUS=$(echo "$RESP" | jq -r '.status // "fail"' 2>/dev/null) || STATUS=fail
+            REM=$(echo "$RESP" | jq -r '.remaining // -1' 2>/dev/null) || REM=-1
+            STORED=$(echo "$RESP" | jq -r '.stored // 0' 2>/dev/null) || STORED=0
             if [ "$STATUS" != "ok" ]; then
               consec=$((consec+1))
               if [ "$consec" -ge 10 ]; then echo "ABORT: 10 consecutive failures"; exit 1; fi

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1719,9 +1719,12 @@ def list_agents_missing_overview(limit: int = 50) -> tuple[list[str], int]:
     json_extract on SQLite) so the prestore cron finds candidates without
     reading hundreds of meta_json blobs per run."""
     if _USE_PG:
+        # jsonb_exists() — NOT the `?` operator: queries here pass through
+        # _q(), whose blind `?`→`%s` rewrite turns the operator into a bogus
+        # placeholder (IndexError at execute). Same semantics, no collision.
         where = (
             "is_deleted = false AND status = 'ready' "
-            "AND NOT (COALESCE(meta_json, '{}')::jsonb ? 'overview')"
+            "AND NOT jsonb_exists(COALESCE(meta_json, '{}')::jsonb, 'overview')"
         )
     else:
         where = (

--- a/app/core/overview.py
+++ b/app/core/overview.py
@@ -215,9 +215,10 @@ def generate_book_overview(
     return parsed
 
 
-def prestore_overviews(batch_size: int = 6) -> tuple[int, int]:
+def prestore_overviews(batch_size: int = 6) -> tuple[int, int, list[dict[str, Any]]]:
     """Generate + persist overviews for ready books that lack one. Returns
-    (stored, remaining).
+    (stored, remaining, details) — details carries per-book timing/provider/
+    error so the caller (cron response → drain-loop logs) is self-diagnosing.
 
     Runs on Vercel (the cron) because grounded mode embeds the RAG query via
     Gemini, which is geoblocked from the dev machine — the embed-minds
@@ -226,25 +227,58 @@ def prestore_overviews(batch_size: int = 6) -> tuple[int, int]:
     meta.overview), so the daily schedule self-fills new books and a manual
     loop drains a backlog. Empty generations (transient LLM failure) are NOT
     stored and retry on the next run."""
+    import time as _time
+    from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FTimeout
     from app.core.db import get_agent, list_agents_missing_overview, update_agent_meta
 
+    _PER_BOOK_TIMEOUT_S = 25.0   # hard cap per generation — a hung provider
+    _TIME_BUDGET_S = 40.0        # stop starting new books past this elapsed
+    #                              (the first drain attempt hung indefinitely
+    #                              inside one generation and the whole call
+    #                              died at the platform limit storing nothing)
+
+    started = _time.time()
     ids, total = list_agents_missing_overview(limit=batch_size)
     stored = 0
-    for agent_id in ids:
-        agent = get_agent(agent_id)
-        if not agent:
-            continue
-        result = generate_book_overview(agent)
-        text = (result.get("overview") or "").strip()
-        if not text:
-            continue
-        update_agent_meta(agent_id, {
-            "overview": text,
-            "key_concepts": result.get("concepts") or [],
-            "overview_grounded": bool(result.get("grounded")),
-        })
-        stored += 1
-    return stored, max(0, total - stored)
+    details: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        for agent_id in ids:
+            if _time.time() - started > _TIME_BUDGET_S:
+                details.append({"id": agent_id[:8], "skipped": "time budget"})
+                break
+            t0 = _time.time()
+            agent = get_agent(agent_id)
+            if not agent:
+                details.append({"id": agent_id[:8], "err": "not found"})
+                continue
+            fut = pool.submit(generate_book_overview, agent)
+            try:
+                result = fut.result(timeout=_PER_BOOK_TIMEOUT_S)
+            except _FTimeout:
+                # Abandon this book for now (the worker thread is left to
+                # finish/die with the invocation); the next run retries it.
+                details.append({"id": agent_id[:8], "err": "timeout",
+                                "ms": int((_time.time() - t0) * 1000)})
+                break  # a hung provider would just eat the remaining budget
+            except Exception as exc:  # generate never raises, but belt+braces
+                details.append({"id": agent_id[:8], "err": str(exc)[:80]})
+                continue
+            ms = int((_time.time() - t0) * 1000)
+            text = (result.get("overview") or "").strip()
+            if not text:
+                details.append({"id": agent_id[:8], "err": "empty", "ms": ms,
+                                "provider": result.get("provider", "")})
+                continue
+            update_agent_meta(agent_id, {
+                "overview": text,
+                "key_concepts": result.get("concepts") or [],
+                "overview_grounded": bool(result.get("grounded")),
+            })
+            stored += 1
+            details.append({"id": agent_id[:8], "ok": True, "ms": ms,
+                            "grounded": bool(result.get("grounded")),
+                            "provider": result.get("provider", "")})
+    return stored, max(0, total - stored), details
 
 
 _TOPIC_OVERVIEW_MAX_CHARS = 1200

--- a/app/main.py
+++ b/app/main.py
@@ -3606,8 +3606,12 @@ def api_cron_prestore_overviews(request: Request) -> dict[str, Any]:
     drain a backlog (returns remaining)."""
     _verify_cron(request)
     try:
-        stored, remaining = overview_module.prestore_overviews(batch_size=6)
-        return {"status": "ok", "stored": stored, "remaining": remaining}
+        batch = max(1, min(8, int(request.query_params.get("batch", "4"))))
+    except ValueError:
+        batch = 4
+    try:
+        stored, remaining, details = overview_module.prestore_overviews(batch_size=batch)
+        return {"status": "ok", "stored": stored, "remaining": remaining, "details": details}
     except Exception as exc:
         log.error("Prestore-overviews cron failed: %s", exc)
         return {"status": "error", "detail": str(exc)}


### PR DESCRIPTION
Drain attempt #2 hung inside the first generation (0 stored, invocation died at the platform limit). This bounds each book (25s future timeout + 40s call budget) so every call returns inside the function window with whatever it completed, and returns per-book `{ms, provider, grounded | err}` details so the GH-Actions drain log is self-diagnosing. `?batch=1-8` (default 4). 296 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)