### PR TITLE
perf(egress): minds list projects out fat columns at the SQL layer

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1958,17 +1958,28 @@ def ensure_slug_columns() -> None:
                         pass
 
 
-def list_minds(limit: int | None = None) -> list[dict[str, Any]]:
+def list_minds(limit: int | None = None, lite: bool = False) -> list[dict[str, Any]]:
     """List all minds, ordered by popularity.
 
     `limit` is a defensive cap (see `list_agents` rationale).
+
+    `lite=True` projects out the fat text columns (persona, thinking_style,
+    typical_phrases, works) AT THE SQL LAYER — the egress rule: hot request
+    paths (the /api/minds list, sitemap, llms-full, indexnow, seed-count) must
+    not read those columns out of Postgres only to discard them in Python
+    (~5KB/row × 650 rows ≈ MBs per call otherwise). Callers that need the full
+    persona (chat invites via find_existing_mind_by_keys, scripts) keep the
+    default full read.
     """
-    sql = (
-        "SELECT id, name, slug, era, domain, bio_summary, persona, thinking_style, "
+    cols = (
+        "id, name, slug, era, domain, bio_summary, avatar_seed, "
+        "wikidata_url, wikipedia_url, version, chat_count, created_at"
+        if lite else
+        "id, name, slug, era, domain, bio_summary, persona, thinking_style, "
         "typical_phrases, works, avatar_seed, wikidata_url, wikipedia_url, "
-        "version, chat_count, created_at "
-        "FROM minds ORDER BY chat_count DESC, created_at ASC"
+        "version, chat_count, created_at"
     )
+    sql = f"SELECT {cols} FROM minds ORDER BY chat_count DESC, created_at ASC"
     params: tuple[Any, ...] = ()
     if limit is not None:
         sql += " LIMIT ?"
@@ -1989,10 +2000,12 @@ def _row_to_mind(row: dict[str, Any]) -> dict[str, Any]:
         # First-person "voice" self-intro (generated; meta_json.voice). Drives the
         # Feynman-native first-person About. `.get` — absent on list SELECTs / older rows.
         "voice": (json.loads(row["meta_json"]) if row.get("meta_json") else {}).get("voice") or "",
-        "persona": row["persona"],
-        "thinking_style": row["thinking_style"] or "",
-        "typical_phrases": json.loads(row["typical_phrases"] or "[]"),
-        "works": json.loads(row["works"] or "[]"),
+        # .get — absent on lite list SELECTs (projected out at the SQL layer);
+        # full reads (get_mind, default list_minds) still carry them.
+        "persona": row.get("persona"),
+        "thinking_style": row.get("thinking_style") or "",
+        "typical_phrases": json.loads(row.get("typical_phrases") or "[]"),
+        "works": json.loads(row.get("works") or "[]"),
         "avatar_seed": row["avatar_seed"] or "",
         # Wikidata/Wikipedia identity links (sameAs). `.get` — older rows
         # predate the migration; absent → "".

--- a/app/main.py
+++ b/app/main.py
@@ -915,7 +915,7 @@ def sitemap_xml():
     <priority>0.5</priority>
   </url>
 """
-        all_minds = list_minds(limit=5000)
+        all_minds = list_minds(limit=5000, lite=True)
         # Same slug gate as books: a mind without a slug isn't advertised (see
         # the comment above) — the 2026-06-08 expansion shipped 481 UUID URLs
         # into the sitemap exactly this way.
@@ -1245,7 +1245,7 @@ The project draws inspiration from Richard Feynman's approach to learning:
 
 """
     try:
-        for mind in list_minds(limit=5000):
+        for mind in list_minds(limit=5000, lite=True):
             name = mind.get("name", "Unknown")
             domain = mind.get("domain", "")
             content += f"- [{name}]({_SITE_URL}/mind/{mind['id']}): {domain}\n"
@@ -3533,7 +3533,7 @@ def api_cron_indexnow(request: Request) -> dict[str, Any]:
             continue
         urls.append(f"{_SITE_URL}/book/{a['id']}")
     # Recent minds → /mind/{id}
-    for m in list_minds(limit=2000):
+    for m in list_minds(limit=2000, lite=True):
         if (m.get("created_at") or "") < cutoff:
             continue
         urls.append(f"{_SITE_URL}/mind/{m['id']}")
@@ -3553,7 +3553,7 @@ def api_cron_indexnow(request: Request) -> dict[str, Any]:
 def api_cron_seed_minds(request: Request) -> dict[str, Any]:
     """Cron-triggered mind seeding. Seeds a batch per run (Hobby has 60s timeout)."""
     _verify_cron(request)
-    existing_count = len(list_minds(limit=5000))
+    existing_count = len(list_minds(limit=5000, lite=True))
     if existing_count >= len(SEED_MINDS):
         return {"status": "complete", "total": existing_count}
     seeded = _seed_minds_batch(_SEED_BATCH_SIZE)
@@ -5127,12 +5127,12 @@ _embed_backfill_done = False
 def api_list_minds(background_tasks: BackgroundTasks):
     from fastapi.responses import JSONResponse
     global _embed_backfill_done
-    minds = list_minds(limit=5000)
+    minds = list_minds(limit=5000, lite=True)
     # Lazy seeding: seed 1 mind per request to stay within Vercel's 10s timeout
     if _IS_SERVERLESS and len(minds) < len(SEED_MINDS):
         seeded = _seed_minds_batch(_LAZY_SEED_SIZE)
         if seeded:
-            minds = list_minds(limit=5000)
+            minds = list_minds(limit=5000, lite=True)
     # Lazy embedding backfill: only schedule if there's actual work
     if not _embed_backfill_done:
         _embed_backfill_done = True


### PR DESCRIPTION
Closes the last measured residual Supabase-egress amplifier. An instrumented prod window (pg_stat_statements reset → observe) showed the minds LIST still reads `persona/thinking_style/typical_phrases/works` (~5KB/row × 648 ≈ **2-3MB/call**) and discards them in Python — the same SQL-vs-Python conflation #110 fixed for agents.

- `list_minds(lite=True)` projects the fat columns out **in SQL** (~3MB → ~1MB/call)
- Switched the six verified slim-field hot paths: `/api/minds` ×2, sitemap, llms-full, indexnow, seed-count
- `_row_to_mind` tolerates absent keys (`.get`) — full reads unchanged
- `find_existing_mind_by_keys` deliberately stays FULL: its return feeds chat invites, which need `persona`
- Scripts keep the full default

🤖 Generated with [Claude Code](https://claude.com/claude-code)