### PR TITLE
feat(seo): intent-hybrid titles + Notable quotes + Summary wording (GSC-driven)

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -50,10 +50,11 @@ function bookDescription(
   author: string,
 ): string {
   const by = author ? ` by ${author}` : "";
-  // Lead with the interactive hook so the SERP snippet differentiates from a
-  // static book summary; append the subtitle for context (clampDescription trims,
-  // keeping the hook up front where it survives SERP truncation).
-  const lead = `Read & chat with this book${by} on Feynman — ask it anything and get answers grounded in its actual text.`;
+  // Hybrid intent: searchers reach book pages with "summary"/"key ideas"/
+  // "{title} wiki" qualifiers (GSC) — answer that intent first, then
+  // differentiate with the Type-0 value (the book itself answers, grounded in
+  // its text — what no static summary site has).
+  const lead = `Summary and key ideas of this book${by} — then chat with the book itself and get answers grounded in its actual text.`;
   return clampDescription(subtitle ? `${lead} ${subtitle}` : lead);
 }
 
@@ -81,7 +82,7 @@ export async function generateMetadata({
   const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(params.id)}`;
   const desc = bookDescription(data.subtitle, data.author);
   return {
-    title: `Read & chat with ${data.title} — Feynman`,
+    title: `${data.title} — Summary, Key Ideas & Chat | Feynman`,
     description: desc,
     alternates: { canonical },
     ...(isStub ? { robots: { index: false, follow: true } } : {}),
@@ -319,15 +320,20 @@ export default async function BookLandingPage({ params }: PageProps) {
 
       <section className="seo-section">
         {overview ? (
-          overview.overview
-            .split(/\n\n+/)
-            .map((p) => p.trim())
-            .filter(Boolean)
-            .map((p, i) => (
-              <p key={i} className="book-about">
-                {p}
-              </p>
-            ))
+          <>
+            {/* "Summary" is the literal query word searchers use (GSC:
+                "daodejing summary" etc.) — the heading matches the intent. */}
+            <h2>Summary</h2>
+            {overview.overview
+              .split(/\n\n+/)
+              .map((p) => p.trim())
+              .filter(Boolean)
+              .map((p, i) => (
+                <p key={i} className="book-about">
+                  {p}
+                </p>
+              ))}
+          </>
         ) : (
           <p className="book-about">{aboutLine}</p>
         )}

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -43,12 +43,12 @@ export function generateStaticParams() {
 }
 
 function descFor(mind: MindDetail): string {
-  const domain = mind.domain ? ` about ${mind.domain}` : "";
-  // Lead with the interactive hook — what a static encyclopedia can't offer — so
-  // the SERP snippet differentiates from Wikipedia instead of reading like another
-  // third-person bio. The bio is appended for context/keywords; metaDescription
-  // trims, keeping the hook up front (where it survives SERP truncation).
-  const lead = `Chat with ${mind.name} on Feynman — ask${domain}, answered in their own words. An interactive great mind, not a static encyclopedia entry.`;
+  // Hybrid intent: GSC shows searchers qualify with wiki/biography/who-is/
+  // occupation — so the snippet opens by ANSWERING that intent ("Who is X?
+  // {occupation}") — then differentiates with the Type-0 value (a living entry
+  // you can question) instead of reading like another static bio.
+  const who = [mind.era, mind.domain].filter(Boolean).join(" · ");
+  const lead = `Who is ${mind.name}?${who ? ` ${who}.` : ""} Biography and key ideas — then ask ${mind.name} directly and get answers in their own voice. A living entry, not a static page.`;
   return metaDescription(mind.bio_summary ? `${lead} ${mind.bio_summary}` : lead);
 }
 
@@ -65,7 +65,12 @@ export async function generateMetadata({
   const ogImage = abs(`/og?type=mind&id=${encodeURIComponent(params.id)}`);
   const desc = descFor(mind);
   return {
-    title: `Chat with ${mind.name} — Feynman`,
+    // Title carries the verified search-intent words (biography/ideas — the
+    // wiki/biography/occupation qualifier cluster in GSC) PLUS the
+    // differentiator (dialogue). "Chat with X" alone matched chat-intent
+    // queries that get zero impressions; pure "Biography" would make us a
+    // worse Wikipedia. Hybrid serves both.
+    title: `${mind.name} — Biography, Key Ideas & Dialogue | Feynman`,
     description: desc,
     alternates: { canonical },
     openGraph: {
@@ -287,12 +292,12 @@ export default async function MindPage({
       ) : null}
 
       {/* ③ In their voice — signature phrases + core approach (first-person feel). */}
-      <MindPhrases phrases={mind.typical_phrases} />
+      <MindPhrases phrases={mind.typical_phrases} name={mind.name} mindId={params.id} />
       {/* Full persona stays private; the API exposes a bounded excerpt. */}
       <MindPersonaExcerpt persona={mind.persona_excerpt || mind.persona} />
 
       {/* ④ Encyclopedic context — demoted below the distinctive content. */}
-      <MindBio bio={mind.bio_summary} />
+      <MindBio bio={mind.bio_summary} name={mind.name} />
       <MindThinkingStyle style={mind.thinking_style} />
 
       {libraryExtra.length ? (

--- a/web/components/seo/mind/MindSections.tsx
+++ b/web/components/seo/mind/MindSections.tsx
@@ -36,10 +36,12 @@ export function Section({
   );
 }
 
-export function MindBio({ bio }: { bio?: string }) {
+export function MindBio({ bio, name }: { bio?: string; name?: string }) {
   if (!bio) return null;
+  // Question-form heading — matches the verified "who is/was X" query pattern
+  // (GSC) and the People-Also-Ask format; "About" matched nothing.
   return (
-    <Section heading="About">
+    <Section heading={name ? `Who is ${name}?` : "About"}>
       <p>{bio}</p>
     </Section>
   );
@@ -56,19 +58,43 @@ export function MindThinkingStyle({ style }: { style?: string }) {
 
 export function MindPhrases({
   phrases,
+  name,
+  mindId,
   limit = 6,
 }: {
   phrases?: string[];
+  name?: string;
+  mindId?: string;
   limit?: number;
 }) {
   const list = (phrases || []).filter(Boolean).slice(0, limit);
   if (!list.length) return null;
+  // "Notable quotes" — quote-fragment reverse lookups already rank with zero
+  // effort (GSC: '"things generate themselves" guo xiang' at pos ~7), so each
+  // quote gets an anchored, indexable block. The ask-link is the Type-0
+  // differentiator: on Feynman a quote isn't a dead string — the author is
+  // right there to explain it (quote → prefilled chat).
   return (
-    <Section heading="Characteristic phrases">
-      <ul className="characteristic-phrases">
+    <Section heading="Notable quotes">
+      {name ? (
+        <p className="seo-meta">
+          In {name}&apos;s own words — and you can ask about any of them.
+        </p>
+      ) : null}
+      <ul className="notable-quotes">
         {list.map((p, i) => (
-          <li key={i}>
-            <q>{p}</q>
+          <li key={i} id={`quote-${i + 1}`} className="notable-quote">
+            <blockquote>{`“${p}”`}</blockquote>
+            {name && mindId ? (
+              <Link
+                className="notable-quote-ask"
+                href={`/?mind=${encodeURIComponent(mindId)}&q=${encodeURIComponent(
+                  `What did you mean by "${p}"?`,
+                )}`}
+              >
+                Ask {name} about this →
+              </Link>
+            ) : null}
           </li>
         ))}
       </ul>

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -587,6 +587,20 @@ body { background-color: var(--bg-home); }
 .insight-card-who { display: block; font-size: 12px; font-weight: 600; color: var(--accent); margin-bottom: 5px; }
 .insight-card p { margin: 0; line-height: 1.6; color: var(--text); }
 
+/* ── Notable quotes — anchored, indexable quote blocks; each one can be asked
+   about directly (quote → prefilled chat), the living-entry differentiator. ── */
+.notable-quotes { list-style: none; padding: 0; margin: 10px 0 0; display: flex; flex-direction: column; gap: 18px; }
+.notable-quote blockquote {
+  margin: 0; padding: 2px 0 2px 16px;
+  border-left: 3px solid var(--accent);
+  font-size: 16.5px; line-height: 1.55; font-style: italic; color: var(--text);
+}
+.notable-quote-ask {
+  display: inline-block; margin: 6px 0 0 19px;
+  font-size: 13px; font-weight: 600; color: var(--accent); text-decoration: none;
+}
+.notable-quote-ask:hover { text-decoration: underline; }
+
 /* ── "Think with X" — Type-2 imagined-perspective cards (the distinctive supply) ── */
 .mind-topic-cards {
   display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));


### PR DESCRIPTION
Implements items 1+2 of the GSC keyword analysis, balancing **search intent** with the **Type-0 differentiation** (docs taxonomy: live primary-text dialogue, not another static bio/summary site).

**1. Titles/descriptions (intent first, differentiation second)**
- Mind: `Chat with {X} — Feynman` → **`{X} — Biography, Key Ideas & Dialogue | Feynman`**; description opens **"Who is {X}?"** then pivots to "ask {X} directly… a living entry, not a static page". (GSC: wiki/biography/who-is/occupation qualifiers dominate; chat-intent queries got zero impressions.)
- Book: `Read & chat with {T}` → **`{T} — Summary, Key Ideas & Chat | Feynman`**; description leads with summary intent, differentiates with grounded chat.
- Book overview section gets an explicit **"Summary"** H2 (the literal query word; we just prestored 600 overviews — content exists, wording now matches).
- MindBio heading: "About" → **"Who is {Name}?"** (question form = PAA-eligible).

**2. Notable quotes (new indexable surface + living-entry interaction)**
- MindPhrases ('Characteristic phrases' plain list) → **'Notable quotes'**: anchored blockquotes (`#quote-n`), each with **"Ask {Name} about this →"** → prefilled chat (`/?mind=&q=What did you mean by …`). Quote reverse-lookups already rank ~pos 7 with zero effort (GSC) — now each quote is a deliberate, anchored target that can also talk back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)