### PR TITLE
feat(seo): sharpen SERP hooks — 'Ask Them Anything' / 'Ask the Book'

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -54,7 +54,7 @@ function bookDescription(
   // "{title} wiki" qualifiers (GSC) — answer that intent first, then
   // differentiate with the Type-0 value (the book itself answers, grounded in
   // its text — what no static summary site has).
-  const lead = `Summary and key ideas of this book${by} — then chat with the book itself and get answers grounded in its actual text.`;
+  const lead = `Summary and key ideas of this book${by} — then ask the book itself anything and get answers grounded in its actual text.`;
   return clampDescription(subtitle ? `${lead} ${subtitle}` : lead);
 }
 
@@ -82,7 +82,10 @@ export async function generateMetadata({
   const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(params.id)}`;
   const desc = bookDescription(data.subtitle, data.author);
   return {
-    title: `${data.title} — Summary, Key Ideas & Chat | Feynman`,
+    // "& Chat" read like every static summary site; "Ask the Book" is the
+    // capability nobody else can claim — concrete, three words, query-relevant
+    // neighbors (Summary, Key Ideas) intact.
+    title: `${data.title} — Summary, Key Ideas & Ask the Book | Feynman`,
     description: desc,
     alternates: { canonical },
     ...(isStub ? { robots: { index: false, follow: true } } : {}),

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -48,7 +48,7 @@ function descFor(mind: MindDetail): string {
   // {occupation}") — then differentiates with the Type-0 value (a living entry
   // you can question) instead of reading like another static bio.
   const who = [mind.era, mind.domain].filter(Boolean).join(" · ");
-  const lead = `Who is ${mind.name}?${who ? ` ${who}.` : ""} Biography and key ideas — then ask ${mind.name} directly and get answers in their own voice. A living entry, not a static page.`;
+  const lead = `Who is ${mind.name}?${who ? ` ${who}.` : ""} Biography and key ideas — then ask ${mind.name} anything and get answers in their own voice. A living entry, not a static page.`;
   return metaDescription(mind.bio_summary ? `${lead} ${mind.bio_summary}` : lead);
 }
 
@@ -65,12 +65,12 @@ export async function generateMetadata({
   const ogImage = abs(`/og?type=mind&id=${encodeURIComponent(params.id)}`);
   const desc = descFor(mind);
   return {
-    // Title carries the verified search-intent words (biography/ideas — the
-    // wiki/biography/occupation qualifier cluster in GSC) PLUS the
-    // differentiator (dialogue). "Chat with X" alone matched chat-intent
-    // queries that get zero impressions; pure "Biography" would make us a
-    // worse Wikipedia. Hybrid serves both.
-    title: `${mind.name} — Biography, Key Ideas & Dialogue | Feynman`,
+    // Title = verified intent words (biography/ideas per GSC) + a hook no
+    // static site can write. "& Dialogue" was too abstract — at a glance it
+    // read like Wikipedia/Goodreads. "Ask Them Anything" is concrete (the AMA
+    // format everyone knows), names a capability only a living entry has, and
+    // sits mid-title so it survives SERP truncation.
+    title: `${mind.name} — Biography, Ideas & Ask Them Anything | Feynman`,
     description: desc,
     alternates: { canonical },
     openGraph: {


### PR DESCRIPTION
Follow-up to #138 on user feedback: **'& Dialogue' / '& Chat' were too vague** — at a glance the titles read like Wikipedia/Goodreads, giving no reason to click.

Replace the abstract tail with **concrete capability phrases a static site cannot write**:
- Mind: `{Name} — Biography, Ideas & Ask Them Anything | Feynman` (AMA — instantly recognized format)
- Book: `{Title} — Summary, Key Ideas & Ask the Book | Feynman` (three words, impossible elsewhere)
- Descriptions matched: "ask {Name} anything…", "ask the book itself anything…"

Intent words (Biography/Summary/Key Ideas) stay in front for the verified GSC query patterns; the differentiator is now specific instead of generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)