### PR TITLE
fix(seo): mind title — 'Ask Me Anything' (canonical AMA, first-person voice)

### DIFF
--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata({
     // read like Wikipedia/Goodreads. "Ask Them Anything" is concrete (the AMA
     // format everyone knows), names a capability only a living entry has, and
     // sits mid-title so it survives SERP truncation.
-    title: `${mind.name} — Biography, Ideas & Ask Them Anything | Feynman`,
+    title: `${mind.name} — Biography, Ideas & Ask Me Anything | Feynman`,
     description: desc,
     alternates: { canonical },
     openGraph: {


### PR DESCRIPTION
One-word fix on #139 per feedback: 'Ask **Them** Anything' read impersonal/off after a named person (we used singular-they because minds have no gender field). '**Ask Me Anything**' is the canonical AMA phrase, has no pronoun problem, and matches the first-person voice framing of the mind pages — the entry itself speaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)