### PR TITLE
fix(mind-qa): report true remaining via COUNT

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2152,6 +2152,19 @@ def list_minds_missing_questions(limit: int = 50) -> list[dict[str, Any]]:
         return [dict(r) for r in rows]
 
 
+def count_minds_missing_questions() -> int:
+    """True remaining count for the mind-qa backfill. list_minds_missing_questions
+    caps its list (limit param), so `len(list) - done` misreports a large backlog
+    as a constant (e.g. 197 forever with a 200 cap) — which also false-triggers
+    drain-loop stall guards. COUNT(*) is exact and cheap."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT count(*) AS n FROM minds "
+            "WHERE id NOT IN (SELECT DISTINCT mind_id FROM mind_questions)"
+        ), ())
+        return int(row["n"] if row else 0)
+
+
 def list_mind_question_slugs() -> list[dict[str, Any]]:
     """All (mind_id, slug) pairs — one slim query for the sitemap."""
     with get_conn() as conn:

--- a/app/core/minds.py
+++ b/app/core/minds.py
@@ -285,7 +285,10 @@ def backfill_mind_questions(batch_size: int = 3) -> tuple[int, int]:
                 done += 1
         except Exception as exc:
             log.warning("mind-qa generation failed for %s: %s", m.get("name"), exc)
-    return done, max(0, len(missing) - done)
+    # True remaining via COUNT — len(missing) is capped by the list limit, which
+    # made `remaining` read as a constant (e.g. 197) on a large backlog.
+    from .db import count_minds_missing_questions
+    return done, count_minds_missing_questions()
 
 
 def backfill_mind_voices(batch_size: int = 6) -> tuple[int, int]:


### PR DESCRIPTION
`remaining` was `len(missing) - done` with the candidate list capped at 200 → a large backlog read as a constant 197, which misleads progress reads and false-triggers drain-loop stall guards. New `count_minds_missing_questions()` returns the exact count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)