### PR TITLE
feat(seo): Type-0 titles — lead with the chattable entity (§3.5 rule)

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -82,9 +82,13 @@ export async function generateMetadata({
   const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(params.id)}`;
   const desc = bookDescription(data.subtitle, data.author);
   return {
-    // Intent words (summary/key-ideas per GSC) + the product verb. "Chat" over
-    // "Ask the Book" per user decision — matches the on-page CTA language.
-    title: `${data.title} — Summary, Key Ideas & Chat | Feynman`,
+    // Type-0 title rule (seo-geo-master-plan §3.5): state the unique artifact
+    // plainly — the chattable book. Curly quotes mark the title as the book so
+    // "Chat with" parses; author gives the Goodreads-style context. Intent
+    // words (summary/key-ideas per GSC) follow. FROZEN until GSC CTR data.
+    title: data.author
+      ? `Chat with “${data.title}” by ${data.author} — Summary & Key Ideas | Feynman`
+      : `Chat with “${data.title}” — Summary & Key Ideas | Feynman`,
     description: desc,
     alternates: { canonical },
     ...(isStub ? { robots: { index: false, follow: true } } : {}),

--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -67,11 +67,13 @@ export async function generateMetadata({
   const ogImage = abs(`/og?type=mind&id=${encodeURIComponent(params.id)}`);
   const desc = descFor(mind);
   return {
-    // Title = verified intent words (biography/ideas per GSC) + the product's
-    // own verb. "Chat" over "Ask …" per user decision — Chat is the brand
-    // language everywhere (every CTA says "Chat with X"), so the SERP promise
-    // and the on-page action match.
-    title: `${mind.name} — Biography, Ideas & Chat | Feynman`,
+    // Type-0 title rule (seo-geo-master-plan §3.5): the title states the
+    // unique artifact plainly — here, the chattable thinker — like every other
+    // type does (Type 1 = the question, Type 2 = "How X might approach Y").
+    // "Chat with {Name}" LEADS (the capability no static site has, and the
+    // exact on-page CTA), intent words (biography/ideas per GSC) follow.
+    // FROZEN until GSC CTR data says otherwise — do not wordsmith further.
+    title: `Chat with ${mind.name} — Biography & Key Ideas | Feynman`,
     description: desc,
     alternates: { canonical },
     openGraph: {


### PR DESCRIPTION
Title system finalized from `docs/seo-geo-master-plan.md` §3.5 (per Steve): **every type's title = plain statement of its unique artifact**. Type 1 = the question itself; Type 2 = 'How X might approach Y'; Type 4 = 'AI dialogues with X' — and Type 0 (the chattable entity hubs) therefore **leads with the entity you can chat with**, instead of keyword-sandwiching it as an '& Chat' suffix:

- Mind: `Chat with Pierre Hadot — Biography & Key Ideas | Feynman`
- Book: `Chat with “Shop Management” by Frederick Winslow Taylor — Summary & Key Ideas | Feynman`

Intent words (biography/summary/key-ideas — the verified GSC qualifier cluster) remain for query matching. **Titles are now FROZEN until GSC CTR data arrives.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)