### PR TITLE
perf(infra): pin function region to sfo1 — colocate with the us-west-1 database

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["sfo1"],
   "builds": [
     { "src": "app/main.py", "use": "@vercel/python", "config": { "maxDuration": 60 } }
   ],

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["sfo1"],
   "rewrites": [
     { "source": "/api/:path*", "destination": "https://api.feynman.wiki/api/:path*" },
     { "source": "/sitemap.xml", "destination": "https://api.feynman.wiki/sitemap.xml" },


### PR DESCRIPTION
PR 2 of the detail-page latency plan (after #145 pooled connections).

## Why
`x-vercel-id` shows functions run in **iad1** (US East, the Vercel default) while Supabase lives in **us-west-1**. Every DB query pays ~65ms cross-country RTT; a detail-page MISS render fires 4–7 serialized API fetches, each running several queries. #145 removed the per-query TLS handshake; this removes most of the per-query RTT by pinning both projects (`vercel.json` + `web/vercel.json`) to **sfo1**, the closest region to us-west-1.

Side effects: strictly better for Asia-based users too (SFO is nearer than IAD); cached/HIT pages unaffected (edge-served); crons just run from sfo1.

## Measured so far (post-#145 baseline, warm-instance MISS)
- mind detail ~2.6–3.9s · book detail ~2.3–3.4s · `/api/agents` ~1.9–2.5s

Expected after colocation: detail-page MISS ≈ 1–2s. Will re-measure with the same curl method post-deploy and post numbers.

## Verification plan
- Preview: confirm the deployment picks up `regions: ["sfo1"]` (function region visible in response routing headers / deployment metadata).
- Post-merge: same TTFB measurement battery as #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)