### PR TITLE
guard(mind-qa): exclude political-label + first-person-culpability questions

### DIFF
--- a/app/core/minds.py
+++ b/app/core/minds.py
@@ -232,7 +232,15 @@ _QA_SYSTEM = (
     "answer AS the thinker in the first person. Answers must be grounded in the "
     "thinker's documented work and ideas — no invented quotes, dates, or facts. "
     "Strictly avoid religion, party politics, health, and family/private life; for "
-    "living people stay on their public professional record only."
+    "living people stay on their public professional record only. "
+    # Two categories proven problematic in the first full generation pass
+    # (audited 2026-06-11; offending rows deleted by hand):
+    "NEVER write questions that ask whether a living person is a dictator/"
+    "authoritarian or any other political-label question about a living person. "
+    "NEVER write questions asking the thinker to answer for deaths, famines, "
+    "atrocities, or other historical harms in the first person (a persona "
+    "deflecting responsibility reads as apologia) — critiques of their IDEAS are "
+    "fine; trials of their CONDUCT are not."
 )
 
 


### PR DESCRIPTION
Audit of the full Q&A generation pass (3,388 rows / 678 minds, sensitive-keyword scan) found 2 rows in problematic categories — deleted by hand, and this PR encodes the exclusions in `_QA_SYSTEM` so the daily cron can't regenerate them:

1. **Political-label questions about living people** ('Is Milei a dictator?') — violates the existing living-people rule; now explicit.
2. **First-person culpability questions** ('Was Mao Zedong responsible for famine?') — a persona answering for historical harms reads as apologia no matter how it's worded. Critiques of **ideas** stay allowed; trials of **conduct** don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)