### PR TITLE
fix(gate): login before paywall + gated mind chat renders the real chat UI

### DIFF
--- a/web/components/mind/MindChat.module.css
+++ b/web/components/mind/MindChat.module.css
@@ -83,3 +83,31 @@
   font-weight: 600;
   text-decoration: none;
 }
+
+/* Gated chat shell — the greeting bubble + composer are visible (the product,
+   not a wall); send routes to sign-in / the Pro overlay. */
+.gateGreetName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 4px;
+}
+.gateGreetText {
+  margin: 0;
+  line-height: 1.6;
+}
+.gateHint {
+  padding: 6px 16px 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: center;
+}
+.gateUpgradeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+}

--- a/web/components/mind/MindChat.tsx
+++ b/web/components/mind/MindChat.tsx
@@ -18,8 +18,10 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { track } from "@/lib/analytics";
+import { savePendingMindIntent } from "@/lib/pendingIntent";
 import { useProGate } from "@/components/pro/ProOverlay";
 import { createSession, bumpSessions, queueSaveMessage } from "@/lib/chat";
 import { post } from "@/lib/api";
@@ -38,6 +40,10 @@ export default function MindChat({
 }) {
   const { ready, authEnabled, user } = useAuth();
   const { isProUser, requirePro } = useProGate();
+  const router = useRouter();
+  // Draft typed into the GATED composer (anonymous / free users) — saved as a
+  // pending intent on send so it survives the sign-in round trip.
+  const [draft, setDraft] = useState("");
 
   // Anonymous (auth on, not signed in) → sign-in prompt; signed-in non-pro
   // (hosted) → paywall. Open-source → isProUser always true so neither fires.
@@ -119,37 +125,93 @@ export default function MindChat({
     domain: mind.domain,
   };
 
-  // Gated (hosted) — show the prompt alongside the agent-info sidebar, no chat.
+  // Gated (hosted) — render the REAL chat surface (the mind's first-person
+  // greeting + a live composer) so a SEO-funnel visitor sees the product, not
+  // a bare wall. The gate fires on SEND: anonymous → the draft is saved as a
+  // pending intent (restored + auto-sent after sign-in, the #131 flow) and we
+  // go to /login; signed-in free → the Pro overlay. Minds chat itself stays
+  // Pro-only.
   if (gated) {
+    const greeting =
+      (mind.voice || "").trim() ||
+      `I'm ${mind.name}. Ask me anything — I answer in my own voice, grounded in my work.`;
+    const chatPath = `/mind/${mind.slug || mindId}/chat`;
+    const gateSend = () => {
+      const q = draft.trim();
+      if (needsSignIn) {
+        if (q) {
+          savePendingMindIntent(mindId, { question: q, via: "mind_chat_gate" });
+          track("pending_intent_saved", { surface: "mind_chat_gate", mind_id: mindId });
+        }
+        // With a message saved, land on the composer surface (/) where the
+        // intent auto-restores and sends after sign-in; bare sends come back.
+        router.push(`/login?next=${encodeURIComponent(q ? "/" : chatPath)}`);
+        return;
+      }
+      requirePro();
+    };
     return (
       <div className={`mind-page ${styles.page}`}>
         <div className="chat-with-sidebar">
           <div className="chat-main">
             <div className="chat-messages">
-              <div className={styles.fallback}>
+              <div className="chat-message assistant">
+                <div className={styles.gateGreetName}>{mind.name}</div>
+                <p className={styles.gateGreetText}>{greeting}</p>
+              </div>
+              <p className={styles.gateHint}>
                 {needsSignIn ? (
                   <>
-                    <p>Sign in to chat with {mind.name}</p>
+                    Sign in to reply — your first message will be sent right after.{" "}
                     <Link
-                      href={`/login?next=${encodeURIComponent(`/mind/${mind.slug || mindId}/chat`)}`}
                       className={styles.fallbackLink}
+                      href={`/login?next=${encodeURIComponent(chatPath)}`}
                     >
                       Sign in →
                     </Link>
                   </>
                 ) : (
                   <>
-                    <p>Chatting with {mind.name} is a Pro feature.</p>
+                    Chatting with {mind.name} is a Pro feature.{" "}
                     <button
                       type="button"
-                      className={styles.fallbackLink}
-                      style={{ background: "none", border: "none", cursor: "pointer" }}
+                      className={styles.gateUpgradeBtn}
                       onClick={() => requirePro()}
                     >
                       Upgrade to Pro →
                     </button>
                   </>
                 )}
+              </p>
+            </div>
+            <div className="chat-composer chat-composer-inline">
+              <textarea
+                className="composer-input"
+                rows={1}
+                placeholder={`Message ${mind.name}…`}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    gateSend();
+                  }
+                }}
+              />
+              <div className="composer-toolbar">
+                <div className="composer-left" />
+                <button
+                  type="button"
+                  className="composer-send-btn"
+                  title="Send"
+                  aria-label="Send"
+                  onClick={gateSend}
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <line x1="12" y1="19" x2="12" y2="5" />
+                    <polyline points="5 12 12 5 19 12" />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>

--- a/web/components/pro/ProOverlay.tsx
+++ b/web/components/pro/ProOverlay.tsx
@@ -151,6 +151,8 @@ export interface ProGate {
 export function useProGate(): ProGate {
   const isProUser = useIsProUser();
   const { showProOverlay } = useProOverlay();
+  const { authEnabled, user } = useAuth();
+  const router = useRouter();
 
   const requirePro = useCallback(
     (action?: () => void): boolean => {
@@ -158,10 +160,22 @@ export function useProGate(): ProGate {
         action?.();
         return true;
       }
+      // Gate ORDER: an anonymous visitor must be sent to sign-in, never shown
+      // the paywall — a plans modal means nothing without an account, and
+      // closing it stranded people on /login anyway (the reported bug). Only
+      // a signed-in free user sees the upgrade overlay.
+      if (authEnabled && !user) {
+        const next =
+          typeof window !== "undefined"
+            ? window.location.pathname + window.location.search
+            : "/";
+        router.push(`/login?next=${encodeURIComponent(next)}`);
+        return false;
+      }
       showProOverlay();
       return false;
     },
-    [isProUser, showProOverlay],
+    [isProUser, authEnabled, user, router, showProOverlay],
   );
 
   return { isProUser, requirePro, showProOverlay };


### PR DESCRIPTION
Fixes the two reported funnel issues:

1. **Anonymous users saw the paywall first.** `requirePro` only checked Pro status — an anonymous click on any minds-gated action opened the Plans modal, and both Upgrade and close landed on /login anyway. Now: anonymous → `/login?next=<current>`; only signed-in free users see the upgrade overlay.
2. **Gated mind chat was a bare wall.** `/mind/{id}/chat` for gated users now renders the real chat surface — the mind's first-person greeting (its `voice`) + a live composer. Typing and sending while anonymous **saves the message as a pending intent** (existing #131 mechanism) → after sign-in it's restored and auto-sent. Signed-in free users get the Pro overlay on send. Minds chat remains Pro-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)