### PR TITLE
feat(topics): add Artificial Intelligence + Ethics hubs (data-qualified only)

### DIFF
--- a/app/core/catalog.py
+++ b/app/core/catalog.py
@@ -17,6 +17,14 @@ TOPIC_TAGS = [
     "Computer Science", "Biology", "History", "Mathematics",
     "Business & Strategy", "Neuroscience", "Literature",
     "Political Science", "Sociology", "Art & Design", "Self-Development",
+    # 2026-06-12 expansion — the ONLY two candidates that passed the data gate
+    # (>=8 minds match via is_mind_topic_relevant against real domain strings;
+    # 37 other candidates audited and rejected: most match <5 minds because
+    # mind.domain uses this same coarse vocabulary, and high scorers like
+    # "Political Philosophy" are stem-overlap duplicates of existing hubs).
+    # AI also tracks verified GSC demand (lecun/hinton/hassabis queries) and
+    # grows with every tech-minds batch.
+    "Artificial Intelligence", "Ethics",
 ]
 
 # Number of books to discover per topic


### PR DESCRIPTION
Audited **39 candidate topics** against the production relevance matcher across all 895 minds' real domain strings. Result: topic expansion is mostly **blocked by coarse domain vocabulary** — only two candidates clear a useful bar:

- **Ethics** — 15 matching minds
- **Artificial Intelligence** — 8 and growing with every tech batch; matches verified GSC demand (lecun / hinton / hassabis queries)

Rejected: 37 others (most <5 matches → empty hubs; 'Political Philosophy' (187) is a stem-overlap duplicate of the Philosophy hub). Hubs, /on/ pairs, sitemap and chips derive automatically from the list; the idempotent essay prestore fills the new pairs on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)