### PR TITLE
mind /q: generate answers from persona + characteristic phrases (voice density)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -2244,11 +2244,15 @@ def get_mind_question(mind_id: str, slug: str) -> dict[str, Any] | None:
 
 
 def list_minds_missing_questions(limit: int = 50) -> list[dict[str, Any]]:
-    """Minds with no stored Q&A yet — drives /api/cron/mind-qa. Slim columns
-    only (the egress rule); ordered by popularity so visible minds fill first."""
+    """Minds with no stored Q&A yet — drives /api/cron/mind-qa. persona +
+    typical_phrases are the voice-density inputs for _qa_prompt (without them the
+    answers read as generic first-person); they're fat columns, so the caller
+    passes limit=batch_size to keep the read tiny (egress rule). Ordered by
+    popularity so visible minds fill first."""
     with get_conn() as conn:
         rows = _fetchall(conn, _q(
-            "SELECT id, name, era, domain, bio_summary, thinking_style, works FROM minds "
+            "SELECT id, name, era, domain, bio_summary, persona, thinking_style, "
+            "typical_phrases, works FROM minds "
             "WHERE id NOT IN (SELECT DISTINCT mind_id FROM mind_questions) "
             "ORDER BY chat_count DESC, created_at ASC LIMIT ?"
         ), (limit,))

--- a/app/core/minds.py
+++ b/app/core/minds.py
@@ -249,18 +249,28 @@ def _qa_prompt(m: dict[str, Any]) -> str:
         works = ", ".join(json.loads(m.get("works") or "[]")[:4])
     except Exception:
         works = ""
+    # Characteristic phrases shape the VOICE (tone, cadence) — they are not
+    # quotes to paste verbatim (the system prompt forbids invented quotes).
+    try:
+        phrases = "; ".join(json.loads(m.get("typical_phrases") or "[]")[:8])
+    except Exception:
+        phrases = ""
     return (
         f"Thinker: {m['name']} ({m.get('era') or ''}; {m.get('domain') or ''}).\n"
         f"Bio: {(m.get('bio_summary') or '')[:400]}\n"
+        f"Persona: {(m.get('persona') or '')[:700]}\n"
         f"Thinking style: {(m.get('thinking_style') or '')[:280]}\n"
+        f"Characteristic phrases (for voice, do not quote verbatim): {phrases}\n"
         f"Notable works: {works}\n\n"
         "Write exactly 5 Q&A pairs that real people would Google about this thinker. "
         "Mix: one \"What is X known for?\"-style; one on their central theory/idea; one "
         "how/why question about their method or influence; one common misconception or "
         "critique; one connecting their ideas to a present-day question. Questions are "
         "phrased in the third person, the way a searcher would type them (40-90 chars). "
-        "Answers are in the FIRST person as the thinker, 90-150 words, concrete, no "
-        "greetings or sign-offs.\n"
+        "Answers are in the FIRST person as the thinker, 130-180 words, concrete and "
+        "specific — name their actual concepts and works, and let the persona and "
+        "characteristic phrases above shape the voice so it reads as unmistakably THIS "
+        "thinker, not a generic first-person summary. No greetings or sign-offs.\n"
         'Return STRICT JSON only: [{"q": "...", "a": "..."}]'
     )
 
@@ -272,7 +282,10 @@ def backfill_mind_questions(batch_size: int = 3) -> tuple[int, int]:
     mind (chat provider → DeepSeek fallback, not geoblocked)."""
     from .seo import slugify
 
-    missing = list_minds_missing_questions(limit=200)
+    # limit=batch_size (not a fixed 200): the row now carries the fat persona +
+    # typical_phrases columns, and we only consume batch_size of them — reading
+    # 200 to use 3 would waste egress. True backlog count comes from COUNT below.
+    missing = list_minds_missing_questions(limit=batch_size)
     done = 0
     for m in missing[:batch_size]:
         try:


### PR DESCRIPTION
## Why
mind /q answers were thin and generic — measured avg **72 words** vs the prompt's own 90-150 target, and they read as 'any LLM in first person' rather than *this* thinker. Root cause: `_qa_prompt` fed bio/thinking_style/works but **never passed the two richest voice fields** — `persona` (full character brief, ~2.9K chars) and `typical_phrases` (the thinker's language fingerprint). `list_minds_missing_questions` had also slimmed them out of its SELECT.

This is the 'persona density' fix from the content-positioning discussion: make the voice unmistakably the thinker (Type-0 'living entity' angle), **not** Wikipedia regurgitation — so the page earns its own distinct supply.

## What
- `list_minds_missing_questions`: add `persona`, `typical_phrases` to the SELECT; caller now reads `limit=batch_size` (they're fat columns — reading 200 to use 3 would waste egress; true backlog still comes from `count_minds_missing_questions`).
- `_qa_prompt`: feed persona (700c) + phrases (8, explicitly **for voice, not verbatim quotes** — system prompt still forbids invented quotes); raise answer floor to 130-180 words; instruct naming real concepts/works.

## Scope / cost
- **Forward-fill only.** The 4,471 existing rows are untouched (they're frozen out of the sitemap by #151 and get refreshed per release tranche when they have GSC signal). The **running expansion picks this up on its next `mind-qa` drain** — zero extra LLM spend beyond what's already generating.
- No schema change; `py_compile` clean; single caller verified (`backfill_mind_questions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)