### PR TITLE
feat: multi-mind debates — the Type-4 generation engine

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1141,6 +1141,42 @@ def init_db() -> None:
     except Exception:
         pass
 
+    # Multi-mind debates (Type-4 generated content: 2-4 minds argue one question,
+    # the emergent transcript is the unique indexable artifact). Two plain new
+    # tables — CREATE TABLE IF NOT EXISTS only, NO ALTER, so this never blocks a
+    # cold start (cf. the 2026-06-10 zombie-lock incident). PG + SQLite share the
+    # DDL, so it lives once here instead of in both schema branches above.
+    try:
+        with get_conn() as conn:
+            _execute(conn, """
+                CREATE TABLE IF NOT EXISTS debates (
+                    id TEXT PRIMARY KEY,
+                    slug TEXT,
+                    question TEXT NOT NULL,
+                    topic TEXT,
+                    mind_ids TEXT NOT NULL DEFAULT '[]',
+                    status TEXT NOT NULL DEFAULT 'published',
+                    created_at TEXT NOT NULL
+                )
+            """)
+            _execute(conn, "CREATE INDEX IF NOT EXISTS idx_debates_slug ON debates(slug)")
+            _execute(conn, "CREATE INDEX IF NOT EXISTS idx_debates_created ON debates(created_at DESC)")
+            _execute(conn, """
+                CREATE TABLE IF NOT EXISTS debate_turns (
+                    id TEXT PRIMARY KEY,
+                    debate_id TEXT NOT NULL,
+                    mind_id TEXT NOT NULL,
+                    mind_name TEXT NOT NULL,
+                    turn_index INTEGER NOT NULL,
+                    content TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+            """)
+            _execute(conn, "CREATE INDEX IF NOT EXISTS idx_debate_turns_debate ON debate_turns(debate_id, turn_index)")
+    except Exception:
+        import logging as _log
+        _log.getLogger(__name__).warning("debates schema init skipped", exc_info=True)
+
 
 def _unique_slug(conn, table: str, name: str) -> str | None:
     """Descriptive URL slug for a new entity, deduped within its table.
@@ -3474,6 +3510,93 @@ def list_related_minds(mind_id: str, domain: str, limit: int = 6) -> list[dict[s
                LIMIT ?"""
         ), (mind_id, f"%{primary}%", limit))
         return [dict(r) for r in rows]
+
+
+# ─── Multi-mind debates (Type 4) ───
+
+def get_mind_by_name(name: str) -> dict[str, Any] | None:
+    """Case-insensitive exact-name lookup with the voice fields the debate
+    generator needs (persona/typical_phrases/works). Returns None if absent."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT id, name, slug, era, domain, bio_summary, persona, thinking_style, "
+            "typical_phrases, works FROM minds WHERE LOWER(name) = LOWER(?) "
+            "ORDER BY chat_count DESC LIMIT 1"
+        ), (name.strip(),))
+        return dict(row) if row else None
+
+
+def create_debate(question: str, topic: str, mind_ids: list[str]) -> dict[str, Any]:
+    """Insert a debate shell (turns added separately). Returns {id, slug}."""
+    did = str(uuid.uuid4())
+    with get_conn() as conn:
+        slug = _unique_slug(conn, "debates", question[:60]) or did[:8]
+        _execute(conn, _q(
+            "INSERT INTO debates (id, slug, question, topic, mind_ids, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, 'published', ?)"
+        ), (did, slug, question, topic or "", json.dumps(mind_ids), _utcnow()))
+    return {"id": did, "slug": slug}
+
+
+def add_debate_turn(debate_id: str, mind_id: str, mind_name: str, turn_index: int, content: str) -> None:
+    with get_conn() as conn:
+        _execute(conn, _q(
+            "INSERT INTO debate_turns (id, debate_id, mind_id, mind_name, turn_index, content, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)"
+        ), (str(uuid.uuid4()), debate_id, mind_id, mind_name, turn_index, content, _utcnow()))
+
+
+def get_debate_by_slug(slug: str) -> dict[str, Any] | None:
+    """A debate + its ordered turns, by slug (the /debate/{slug} render)."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q(
+            "SELECT id, slug, question, topic, mind_ids, created_at FROM debates "
+            "WHERE slug = ? AND status = 'published'"
+        ), (slug,))
+        if not row:
+            return None
+        d = dict(row)
+        turns = _fetchall(conn, _q(
+            "SELECT mind_id, mind_name, turn_index, content FROM debate_turns "
+            "WHERE debate_id = ? ORDER BY turn_index ASC"
+        ), (d["id"],))
+        d["turns"] = [dict(t) for t in turns]
+        try:
+            d["mind_ids"] = json.loads(d.get("mind_ids") or "[]")
+        except Exception:
+            d["mind_ids"] = []
+        return d
+
+
+def list_debates(limit: int = 200) -> list[dict[str, Any]]:
+    """All published debates (slug + question + recency) — the sitemap + index."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            "SELECT slug, question, topic, created_at FROM debates "
+            "WHERE status = 'published' AND slug IS NOT NULL "
+            "ORDER BY created_at DESC LIMIT ?"
+        ), (limit,))
+        return [dict(r) for r in rows]
+
+
+def list_debates_for_mind(mind_id: str, limit: int = 10) -> list[dict[str, Any]]:
+    """Debates a given mind argued in — the 'Recent debates' rail on /mind/{id}
+    and /mind/{id}/dialogues (the per-mind aggregation, philosophie.ai-style)."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            "SELECT DISTINCT d.slug, d.question, d.created_at FROM debates d "
+            "JOIN debate_turns t ON t.debate_id = d.id "
+            "WHERE t.mind_id = ? AND d.status = 'published' AND d.slug IS NOT NULL "
+            "ORDER BY d.created_at DESC LIMIT ?"
+        ), (mind_id, limit))
+        return [dict(r) for r in rows]
+
+
+def debate_question_exists(question: str) -> bool:
+    """Idempotency guard for the generator — skip a question already debated."""
+    with get_conn() as conn:
+        row = _fetchone(conn, _q("SELECT 1 AS hit FROM debates WHERE question = ?"), (question,))
+        return bool(row)
 
 
 # ─── Mind memories ───

--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -1,0 +1,180 @@
+"""Multi-mind debates — the Type-4 generation engine.
+
+2-4 great minds argue ONE question in a written symposium; each speaker (after
+the first) sees the prior remarks and engages them by name, so the transcript
+has the cross-reference *emergence* a single /q answer never has. That emergent,
+multi-perspective text is the unique indexable artifact (Type 4): it doesn't
+exist on Wikipedia (dead biography), Goodreads (reviews), or Wikiquote (isolated
+quotes), and — unlike /q/on programmatic pages — it's far less templated, so it
+reads as genuine applied dialogue rather than fill-in-the-blank.
+
+Why generated, not mined from real chats: the per-mind dialogues page mines real
+sessions, but chat volume is ~0, so that surface is empty. Debates are the
+chat-volume-independent way to seed Type 4 (the philosophie.ai insight). Quality
+comes from a CURATED seed list (contrasting thinkers per question), not blind
+auto-selection.
+
+Provider: bulk_chat → DeepSeek fallback (NOT geoblocked), so this runs locally.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from .db import (
+    add_debate_turn,
+    create_debate,
+    debate_question_exists,
+    get_mind_by_name,
+)
+from .providers import bulk_chat
+
+log = logging.getLogger(__name__)
+
+_DEBATE_SYSTEM = (
+    "You are simulating one of history's great thinkers speaking in their own "
+    "first-person voice in a written symposium with other great minds. Stay true "
+    "to the thinker's documented ideas and characteristic way of reasoning — no "
+    "invented quotes, dates, or biography. When prior remarks are provided, ENGAGE "
+    "them: name a previous speaker and sharpen, extend, or rebut them, then advance "
+    "your own distinct position. This is a debate of ideas, never a personal attack. "
+    "Write tight, substantive prose — no greetings, no sign-offs, no stage directions."
+)
+
+
+def _voice_bits(m: dict[str, Any]) -> tuple[str, str]:
+    try:
+        phrases = "; ".join(json.loads(m.get("typical_phrases") or "[]")[:6])
+    except Exception:
+        phrases = ""
+    try:
+        works = ", ".join(json.loads(m.get("works") or "[]")[:3])
+    except Exception:
+        works = ""
+    return phrases, works
+
+
+def _debate_prompt(question: str, m: dict[str, Any], transcript: str, is_first: bool) -> str:
+    phrases, works = _voice_bits(m)
+    head = (
+        f"You are {m['name']} ({m.get('era') or ''}; {m.get('domain') or ''}).\n"
+        f"Persona: {(m.get('persona') or '')[:600]}\n"
+        f"Thinking style: {(m.get('thinking_style') or '')[:240]}\n"
+        f"Characteristic phrases (for voice, do not quote verbatim): {phrases}\n"
+        f"Your works: {works}\n\n"
+        f'The symposium question: "{question}"\n\n'
+    )
+    if is_first:
+        body = (
+            f"You open the symposium. State your position as {m['name']} — the core "
+            "claim and the reasoning that makes it unmistakably yours."
+        )
+    else:
+        body = (
+            f"Remarks already made:\n{transcript}\n\n"
+            f"Now respond as {m['name']}. Reference at least one prior speaker by name "
+            "where you agree or disagree, then advance your own position."
+        )
+    return head + body + "\n\nFirst person, 110-170 words, concrete and specific. No greetings or sign-offs."
+
+
+def _clean(text: str) -> str:
+    t = (text or "").strip()
+    t = re.sub(r"^```.*?\n|\n```$", "", t, flags=re.S).strip()
+    # strip a leading "Name:" the model sometimes prepends
+    t = re.sub(r"^[A-Z][A-Za-z .'-]{2,40}:\s*", "", t)
+    return t.strip()
+
+
+def generate_debate(question: str, minds: list[dict[str, Any]], rounds: int = 1) -> list[dict[str, Any]]:
+    """Round-robin generation. Each speaker sees the running transcript. Returns
+    a list of {mind, turn_index, content}. A failed/short turn is skipped."""
+    turns: list[dict[str, Any]] = []
+    transcript = ""
+    idx = 0
+    for _r in range(rounds):
+        for m in minds:
+            try:
+                res, _ = bulk_chat(system=_DEBATE_SYSTEM, user=_debate_prompt(question, m, transcript, idx == 0))
+            except Exception as exc:
+                log.warning("debate turn failed for %s: %s", m.get("name"), exc)
+                continue
+            content = _clean(res.content or "")
+            if len(content.split()) < 40:
+                continue
+            turns.append({"mind": m, "turn_index": idx, "content": content})
+            transcript += f"\n\n— {m['name']}:\n{content}"
+            idx += 1
+    return turns
+
+
+# Curated seeds: contrasting thinkers per question. Names must match minds.name
+# (case-insensitive); a missing/persona-less thinker is dropped, and a debate
+# needs >= 2 survivors. Topics align with TOPIC_TAGS where possible.
+SEED_DEBATES: list[dict[str, Any]] = [
+    {"q": "Should we fear death?", "topic": "Personal Meaning",
+     "minds": ["Socrates", "Marcus Aurelius", "Epicurus", "Zhuangzi"]},
+    {"q": "Does free will exist, or is it a useful illusion?", "topic": "Personal Meaning",
+     "minds": ["Friedrich Nietzsche", "Baruch Spinoza", "Jean-Paul Sartre", "David Hume"]},
+    {"q": "What does a just society owe its weakest members?", "topic": "Politics & Governance",
+     "minds": ["Plato", "John Rawls", "Karl Marx", "Adam Smith"]},
+    {"q": "Is morality objective, or invented by humans?", "topic": "Ethics & Morality",
+     "minds": ["Immanuel Kant", "Friedrich Nietzsche", "David Hume", "Confucius"]},
+    {"q": "Can a machine truly think?", "topic": "Technology & AI",
+     "minds": ["Alan Turing", "René Descartes", "John Searle", "Daniel Dennett"]},
+    {"q": "What makes a life meaningful?", "topic": "Personal Meaning",
+     "minds": ["Aristotle", "Albert Camus", "Confucius", "Friedrich Nietzsche"]},
+    {"q": "Should the state direct the economy, or stay out of it?", "topic": "Economics & Inequality",
+     "minds": ["Karl Marx", "Adam Smith", "John Maynard Keynes", "Friedrich Hayek"]},
+    {"q": "Is human nature fundamentally good or self-interested?", "topic": "Ethics & Morality",
+     "minds": ["Mencius", "Thomas Hobbes", "Jean-Jacques Rousseau", "Xunzi"]},
+    {"q": "Does technology liberate us or enslave us?", "topic": "Technology & AI",
+     "minds": ["Karl Marx", "Martin Heidegger", "Marshall McLuhan", "Hannah Arendt"]},
+    {"q": "What is the right relationship between the individual and the state?", "topic": "Politics & Governance",
+     "minds": ["John Stuart Mill", "Confucius", "Niccolò Machiavelli", "Hannah Arendt"]},
+    {"q": "Can we know anything for certain?", "topic": "Education",
+     "minds": ["René Descartes", "David Hume", "Immanuel Kant", "Socrates"]},
+    {"q": "Is inequality a natural and acceptable feature of society?", "topic": "Economics & Inequality",
+     "minds": ["Jean-Jacques Rousseau", "Adam Smith", "Karl Marx", "Aristotle"]},
+    {"q": "Should we always tell the truth?", "topic": "Ethics & Morality",
+     "minds": ["Immanuel Kant", "Confucius", "Friedrich Nietzsche", "John Stuart Mill"]},
+    {"q": "What is the purpose of education?", "topic": "Education",
+     "minds": ["Confucius", "John Dewey", "Plato", "Jean-Jacques Rousseau"]},
+    {"q": "Is the pursuit of happiness the right aim of life?", "topic": "Personal Meaning",
+     "minds": ["Aristotle", "Epicurus", "Arthur Schopenhauer", "John Stuart Mill"]},
+]
+
+
+def run_debate_batch(limit: int | None = None, rounds: int = 1) -> tuple[int, int]:
+    """Generate + store debates from the seed list. Idempotent (skips questions
+    already debated). Returns (created, remaining). Drives a local script."""
+    created = 0
+    remaining = 0
+    for seed in SEED_DEBATES:
+        if debate_question_exists(seed["q"]):
+            continue
+        remaining += 1
+        if limit is not None and created >= limit:
+            continue
+        minds = []
+        seen = set()
+        for nm in seed["minds"]:
+            m = get_mind_by_name(nm)
+            if m and m.get("persona") and m["id"] not in seen:
+                minds.append(m)
+                seen.add(m["id"])
+        if len(minds) < 2:
+            log.warning("debate %r: only %d debaters found, skipping", seed["q"], len(minds))
+            continue
+        turns = generate_debate(seed["q"], minds, rounds=rounds)
+        if len(turns) < 2:
+            log.warning("debate %r: only %d turns generated, skipping", seed["q"], len(turns))
+            continue
+        d = create_debate(seed["q"], seed["topic"], [t["mind"]["id"] for t in turns])
+        for t in turns:
+            add_debate_turn(d["id"], t["mind"]["id"], t["mind"]["name"], t["turn_index"], t["content"])
+        created += 1
+        log.info("debate created: %r (%d turns) → /debate/%s", seed["q"], len(turns), d["slug"])
+    return created, max(0, remaining - created)

--- a/app/main.py
+++ b/app/main.py
@@ -995,6 +995,21 @@ def sitemap_xml():
     <priority>0.8</priority>
   </url>
 """
+        # Multi-mind debates (Type 4) — emergent symposium transcripts. High
+        # uniqueness + low template-risk (multi-perspective, cross-referencing),
+        # so these ARE advertised, unlike the frozen /q /on editorial layer. The
+        # curated seed set keeps the count small, so no scaled-content footprint.
+        from .core.db import list_debates as _list_debates
+        for _d in _list_debates(limit=500):
+            _dslug = _d.get("slug")
+            if not _dslug:
+                continue
+            urls += f"""  <url>
+    <loc>{_SITE_URL}/debate/{_dslug}</loc>{_lastmod(_d.get("created_at"))}
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+"""
         # Phase 8 — live AI insights / dialogues. Only entities with
         # ≥3 publishable assistant messages get a sitemap entry — empty
         # /insights pages would burn crawl budget and trigger "thin
@@ -4475,6 +4490,57 @@ def api_mind_dialogues(mind_id: str) -> JSONResponse:
     publishable = insights_module.select_publishable(raw, limit=10)
     return JSONResponse(
         content={"dialogues": publishable},
+        headers={"Cache-Control": "public, max-age=1800, s-maxage=1800"},
+    )
+
+
+@app.get("/api/debates/{slug}")
+def api_debate(slug: str) -> JSONResponse:
+    """A multi-mind debate + its ordered turns (the /debate/{slug} render).
+    Public, no feature flag — debates are curated generated content, not UGC."""
+    from .core.db import get_debate_by_slug, get_mind
+    d = get_debate_by_slug(slug)
+    if not d:
+        raise HTTPException(status_code=404, detail="Debate not found")
+    # Attach each participating mind's slug (for chat-funnel links on the page).
+    mind_slugs: dict[str, str] = {}
+    for t in d.get("turns", []):
+        mid = t.get("mind_id")
+        if mid and mid not in mind_slugs:
+            m = get_mind(mid)
+            if m:
+                mind_slugs[mid] = m.get("slug") or mid
+    d["mind_slugs"] = mind_slugs
+    return JSONResponse(
+        content=d,
+        headers={"Cache-Control": "public, max-age=1800, s-maxage=86400"},
+    )
+
+
+@app.get("/api/debates")
+def api_debates_list() -> JSONResponse:
+    """All published debates (slug + question + topic) — the /debates index."""
+    from .core.db import list_debates
+    try:
+        rows = list_debates(limit=500)
+    except Exception:
+        rows = []
+    return JSONResponse(
+        content={"debates": rows},
+        headers={"Cache-Control": "public, max-age=1800, s-maxage=3600"},
+    )
+
+
+@app.get("/api/minds/{mind_id}/debates")
+def api_mind_debates(mind_id: str) -> JSONResponse:
+    """Debates this mind argued in — the 'Recent debates' rail on /mind/{id}."""
+    from .core.db import list_debates_for_mind
+    try:
+        rows = list_debates_for_mind(mind_id, limit=10)
+    except Exception:
+        rows = []
+    return JSONResponse(
+        content={"debates": rows},
         headers={"Cache-Control": "public, max-age=1800, s-maxage=1800"},
     )
 

--- a/web/app/debate/[slug]/page.tsx
+++ b/web/app/debate/[slug]/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import SeoColumn from "@/components/seo/SeoColumn";
+import JsonLd from "@/components/seo/JsonLd";
+import {
+  SITE_URL,
+  abs,
+  breadcrumbJsonLd,
+  debateJsonLd,
+  fetchDebate,
+  metaDescription,
+} from "@/lib/seo-mind";
+
+// Type-4 multi-mind debate: 2-4 great minds argue ONE question, each engaging
+// the prior speakers by name. The emergent cross-referencing transcript is the
+// unique citable artifact — it exists nowhere else (Wikipedia is dead bio,
+// Wikiquote is isolated quotes). Curated + generated, so it's advertised in the
+// sitemap (unlike the frozen /q /on editorial layer).
+
+export const revalidate = 86400;
+export const dynamicParams = true;
+// Empty generateStaticParams() opts this dynamic route into ISR caching.
+export function generateStaticParams() {
+  return [];
+}
+
+function uniqueNames(turns: { mind_name: string }[]): string[] {
+  return Array.from(new Set(turns.map((t) => t.mind_name)));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const d = await fetchDebate(params.slug);
+  if (!d) return { title: "Debate not found — Feynman" };
+  const names = uniqueNames(d.turns);
+  const canonical = abs(`/debate/${d.slug}`);
+  const title = `${d.question} — ${names.slice(0, 3).join(", ")} debate | Feynman`;
+  const desc = metaDescription(
+    `${names.join(", ")} debate the question "${d.question}" — each argues in their own voice, engaging the others, then you can join the conversation. A living symposium, not a static page.`,
+  );
+  const ogImage = abs(`/og?type=debate&slug=${encodeURIComponent(d.slug)}`);
+  return {
+    title,
+    description: desc,
+    alternates: { canonical },
+    openGraph: {
+      type: "article",
+      title: d.question,
+      description: desc,
+      url: canonical,
+      siteName: "Feynman",
+      images: [ogImage],
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: "@steve_yeow",
+      title: d.question,
+      description: desc,
+      images: [ogImage],
+    },
+  };
+}
+
+export default async function DebatePage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const d = await fetchDebate(params.slug);
+  if (!d) notFound();
+
+  const canonical = abs(`/debate/${d.slug}`);
+  const names = uniqueNames(d.turns);
+  const ref = (mindId: string) => d.mind_slugs?.[mindId] || mindId;
+
+  const ld = debateJsonLd({
+    question: d.question,
+    url: canonical,
+    created: d.created_at,
+    turns: d.turns.map((t) => ({
+      name: t.mind_name,
+      text: t.content,
+      url: abs(`/mind/${ref(t.mind_id)}`),
+    })),
+  });
+  const breadcrumbLd = breadcrumbJsonLd([
+    ["Feynman", SITE_URL],
+    ["Debates", abs("/debates")],
+    [d.question, canonical],
+  ]);
+
+  return (
+    <SeoColumn>
+      <JsonLd data={ld} />
+      <JsonLd data={breadcrumbLd} />
+
+      {d.topic ? <p className="seo-meta">{d.topic} · Debate</p> : <p className="seo-meta">Debate</p>}
+      <h1>{d.question}</h1>
+      <p className="seo-meta">
+        {names.length} great minds in conversation — each argues in their own
+        voice, grounded in their documented ideas, engaging the others by name.
+        An AI-mediated symposium you can join.
+      </p>
+
+      <section className="seo-section insights">
+        {d.turns.map((t, i) => (
+          <article key={i} className="insight-card">
+            <Link
+              href={`/mind/${encodeURIComponent(ref(t.mind_id))}`}
+              className="insight-card-who"
+            >
+              {t.mind_name}
+            </Link>
+            {t.content
+              .split(/\n\n+/)
+              .map((p) => p.trim())
+              .filter(Boolean)
+              .map((p, j) => (
+                <p key={j}>{p}</p>
+              ))}
+          </article>
+        ))}
+      </section>
+
+      <p className="seo-cta-row">
+        <a
+          className="primary"
+          href={`/mind/${encodeURIComponent(ref(d.turns[0].mind_id))}/chat`}
+        >
+          Chat with {d.turns[0].mind_name} →
+        </a>
+      </p>
+
+      <section className="seo-section">
+        <h2>Chat with any of them</h2>
+        <ul>
+          {d.turns.map((t, i) => (
+            <li key={i}>
+              <Link href={`/mind/${encodeURIComponent(ref(t.mind_id))}`}>
+                {t.mind_name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </SeoColumn>
+  );
+}

--- a/web/app/debates/page.tsx
+++ b/web/app/debates/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import SeoColumn from "@/components/seo/SeoColumn";
+import JsonLd from "@/components/seo/JsonLd";
+import { SITE_URL, abs, breadcrumbJsonLd, fetchDebatesList } from "@/lib/seo-mind";
+
+// The debates index — the discovery surface for Type-4 multi-mind symposia
+// (the philosophie.ai-style feed). Question-led entries: a sharp question pulls
+// far harder than an entity name.
+
+export const revalidate = 3600;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const canonical = abs("/debates");
+  return {
+    title: "Debates — history's great minds argue today's questions | Feynman",
+    description:
+      "Multi-mind debates on Feynman: 2-4 great thinkers argue one question, each in their own voice, engaging the others. Read the symposium, then join the conversation.",
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      title: "Debates — great minds argue today's questions",
+      description:
+        "2-4 great thinkers argue one question, each in their own voice. Read the symposium, then chat with any of them.",
+      url: canonical,
+      siteName: "Feynman",
+    },
+  };
+}
+
+export default async function DebatesIndexPage() {
+  const debates = await fetchDebatesList();
+  const canonical = abs("/debates");
+
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Debates on Feynman",
+    url: canonical,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: debates.length,
+      itemListElement: debates.map((d, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: abs(`/debate/${d.slug}`),
+        name: d.question,
+      })),
+    },
+  };
+  const breadcrumbLd = breadcrumbJsonLd([
+    ["Feynman", SITE_URL],
+    ["Debates", canonical],
+  ]);
+
+  return (
+    <SeoColumn>
+      <JsonLd data={itemListLd} />
+      <JsonLd data={breadcrumbLd} />
+
+      <h1>Debates</h1>
+      <p className="seo-meta">
+        History&apos;s great minds argue today&apos;s questions — 2-4 thinkers
+        per question, each in their own voice, engaging the others. Read the
+        symposium, then join the conversation.
+      </p>
+
+      {debates.length ? (
+        <section className="seo-section">
+          <ul>
+            {debates.map((d) => (
+              <li key={d.slug}>
+                <Link href={`/debate/${d.slug}`}>{d.question}</Link>
+                {d.topic ? <span className="seo-meta"> · {d.topic}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <section className="seo-section">
+          <p>No debates yet — check back soon.</p>
+        </section>
+      )}
+    </SeoColumn>
+  );
+}

--- a/web/app/mind/[id]/dialogues/page.tsx
+++ b/web/app/mind/[id]/dialogues/page.tsx
@@ -11,6 +11,7 @@ import {
   dialoguesArticleJsonLd,
   fetchMind,
   fetchMindDialogues,
+  fetchMindDebates,
   metaDescription,
 } from "@/lib/seo-mind";
 
@@ -74,7 +75,10 @@ export default async function MindDialoguesPage({
   // not the multi-mind home composer), so a cold visitor can start talking.
   const chatHref = `/mind/${encodeURIComponent(params.id)}/chat`;
 
-  const dialogues = await fetchMindDialogues(params.id, 10);
+  const [dialogues, debates] = await Promise.all([
+    fetchMindDialogues(params.id, 10),
+    fetchMindDebates(params.id),
+  ]);
 
   const articleLd = dialoguesArticleJsonLd({
     headline: `AI dialogues with ${mind.name}`,
@@ -159,6 +163,19 @@ export default async function MindDialoguesPage({
           </p>
         </section>
       )}
+
+      {debates.length ? (
+        <section className="seo-section">
+          <h2>Debates {mind.name} joined</h2>
+          <ul>
+            {debates.map((d) => (
+              <li key={d.slug}>
+                <Link href={`/debate/${d.slug}`}>{d.question}</Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
     </EntityLayout>
   );
 }

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -391,6 +391,102 @@ export function dialoguesArticleJsonLd(opts: {
   });
 }
 
+// ─── Multi-mind debates (Type 4) ───
+
+export interface DebateTurn {
+  mind_id: string;
+  mind_name: string;
+  turn_index: number;
+  content: string;
+}
+
+export interface Debate {
+  id: string;
+  slug: string;
+  question: string;
+  topic?: string;
+  created_at?: string;
+  turns: DebateTurn[];
+  mind_slugs?: Record<string, string>;
+}
+
+export interface MindDebateItem {
+  slug: string;
+  question: string;
+  created_at?: string;
+}
+
+export interface DebateListItem {
+  slug: string;
+  question: string;
+  topic?: string;
+  created_at?: string;
+}
+
+/** A debate + its ordered turns (GET /api/debates/{slug}); null if absent. */
+export async function fetchDebate(slug: string): Promise<Debate | null> {
+  try {
+    const res = await get<Debate>(`/api/debates/${encodeURIComponent(slug)}`, {
+      next: { revalidate: 600 },
+    });
+    if (!res || !Array.isArray(res.turns) || res.turns.length === 0) return null;
+    return res;
+  } catch {
+    return null;
+  }
+}
+
+/** All published debates — the /debates index feed. */
+export async function fetchDebatesList(): Promise<DebateListItem[]> {
+  try {
+    const res = await get<{ debates?: DebateListItem[] }>(`/api/debates`, {
+      next: { revalidate: 600 },
+    });
+    return Array.isArray(res?.debates) ? res.debates : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Debates a mind argued in — the 'Recent debates' rail on /mind/{id}. */
+export async function fetchMindDebates(id: string): Promise<MindDebateItem[]> {
+  try {
+    const res = await get<{ debates?: MindDebateItem[] }>(
+      `/api/minds/${encodeURIComponent(id)}/debates`,
+      { next: { revalidate: 600 } },
+    );
+    return Array.isArray(res?.debates) ? res.debates : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Debate page schema. DiscussionForumPosting with each mind's turn as a
+ * Comment authored by that thinker (Person) — the multi-author structure
+ * Google understands for a symposium, and the citation hook for LLMs.
+ */
+export function debateJsonLd(opts: {
+  question: string;
+  url: string;
+  created?: string;
+  turns: Array<{ name: string; text: string; url: string }>;
+}): Json {
+  return dropNulls({
+    "@context": "https://schema.org",
+    "@type": "DiscussionForumPosting",
+    headline: opts.question,
+    url: opts.url,
+    datePublished: opts.created || "",
+    author: { "@type": "Organization", name: "Feynman", url: SITE_URL },
+    comment: opts.turns.map((t) => ({
+      "@type": "Comment",
+      text: t.text,
+      author: { "@type": "Person", name: t.name, url: t.url },
+    })),
+  });
+}
+
 /** Truncate to ~N chars on a word boundary with an ellipsis (matches seo.py). */
 export function truncate(text: string, maxChars: number): string {
   const t = (text || "").trim();


### PR DESCRIPTION
## Why
Our most unique content type — **Type 4 (emergent AI dialogue)** — was code-shipped but **empty**: it mined real chat sessions, and chat volume is ~0 (125 sessions, 0 messages). Meanwhile we've been pouring effort into Type 1/2 (`/q`, `/on` — programmatic, templated, scaled-abuse-adjacent).

[book.philosophie.ai](https://book.philosophie.ai) proved the missing move: don't wait for real chats — **let the minds debate each other**. This adds that engine, on top of our advantages they lack (books axis, 1.2K-mind breadth, SEO depth).

## What it produces
2-4 great minds argue ONE question; each speaker (after the first) sees the running transcript and **engages the others by name** — sharpening, extending, rebutting. The emergent cross-referencing is the unique citable artifact, and being multi-perspective it's far **less templated** than `/q`/`/on`, so it reads as real applied dialogue.

**Local quality check** — Socrates × Marcus Aurelius × Epicurus on *"Should we fear death?"*:
- Marcus: *"Socrates speaks wisely… **Yet I would sharpen this**: the fear of death arises not from ignorance… but from a false judgment about what is good and evil."*
- Epicurus: *"Socrates and Marcus Aurelius both speak well, **yet they miss the root**… death is nothing to us."*

Each held a distinct voice, grounded in their ideas — clearly above a single `/q` answer.

## Changes
**Backend**
- `db.py`: `debates` + `debate_turns` tables — plain `CREATE TABLE IF NOT EXISTS` at the **end** of `init_db` (no ALTER → never blocks cold start, per the zombie-lock incident) + 7 CRUD fns.
- `debates.py`: orchestration — voice-dense prompt (persona + typical_phrases + running transcript), round-robin `generate_debate`, **15 curated seeds** (contrasting thinkers per question), idempotent `run_debate_batch`. `bulk_chat`→DeepSeek (local, not geoblocked).
- `main.py`: `GET /api/debates`, `/api/debates/{slug}`, `/api/minds/{id}/debates`; sitemap advertises `/debate/{slug}` (high-uniqueness → **not** frozen like the editorial layer).

**Frontend**
- `/debate/[slug]` — the symposium, `DiscussionForumPosting` JSON-LD (each turn a `Comment` by its thinker-`Person`) + per-mind chat funnel.
- `/debates` — question-led discovery index (`CollectionPage`/`ItemList`).
- `/mind/[id]/dialogues` — now aggregates *'Debates {mind} joined'*, filling the previously-empty Type-4 page.

## Scope / safety
- New tables only, no migration. Backend-additive (no existing route touched).
- Data generated separately into prod (~15 debates from the curated seeds); idempotent.
- Gate on a green feynman-web Vercel build (web/ can't typecheck locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)