### PR TITLE
rename: user-facing 'debate' → 'symposium'

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -995,17 +995,18 @@ def sitemap_xml():
     <priority>0.8</priority>
   </url>
 """
-        # Multi-mind debates (Type 4) — emergent symposium transcripts. High
-        # uniqueness + low template-risk (multi-perspective, cross-referencing),
-        # so these ARE advertised, unlike the frozen /q /on editorial layer. The
-        # curated seed set keeps the count small, so no scaled-content footprint.
+        # Multi-mind symposiums (Type 4) — emergent transcripts. High uniqueness
+        # + low template-risk (multi-perspective, cross-referencing), so these
+        # ARE advertised, unlike the frozen /q /on editorial layer. The curated
+        # seed set keeps the count small, so no scaled-content footprint.
+        # (User-facing path is /symposium; the table/fns keep the "debate" name.)
         from .core.db import list_debates as _list_debates
         for _d in _list_debates(limit=500):
             _dslug = _d.get("slug")
             if not _dslug:
                 continue
             urls += f"""  <url>
-    <loc>{_SITE_URL}/debate/{_dslug}</loc>{_lastmod(_d.get("created_at"))}
+    <loc>{_SITE_URL}/symposium/{_dslug}</loc>{_lastmod(_d.get("created_at"))}
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/web/app/mind/[id]/dialogues/page.tsx
+++ b/web/app/mind/[id]/dialogues/page.tsx
@@ -166,11 +166,11 @@ export default async function MindDialoguesPage({
 
       {debates.length ? (
         <section className="seo-section">
-          <h2>Debates {mind.name} joined</h2>
+          <h2>Symposiums {mind.name} joined</h2>
           <ul>
             {debates.map((d) => (
               <li key={d.slug}>
-                <Link href={`/debate/${d.slug}`}>{d.question}</Link>
+                <Link href={`/symposium/${d.slug}`}>{d.question}</Link>
               </li>
             ))}
           </ul>

--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -12,11 +12,12 @@ import {
   metaDescription,
 } from "@/lib/seo-mind";
 
-// Type-4 multi-mind debate: 2-4 great minds argue ONE question, each engaging
-// the prior speakers by name. The emergent cross-referencing transcript is the
+// Symposium (Type-4): 2-4 great minds argue ONE question, each engaging the
+// prior speakers by name. The emergent cross-referencing transcript is the
 // unique citable artifact — it exists nowhere else (Wikipedia is dead bio,
 // Wikiquote is isolated quotes). Curated + generated, so it's advertised in the
-// sitemap (unlike the frozen /q /on editorial layer).
+// sitemap (unlike the frozen /q /on editorial layer). User-facing name is
+// "symposium"; internal API/table/fn names stay "debate(s)" as implementation.
 
 export const revalidate = 86400;
 export const dynamicParams = true;
@@ -35,14 +36,14 @@ export async function generateMetadata({
   params: { slug: string };
 }): Promise<Metadata> {
   const d = await fetchDebate(params.slug);
-  if (!d) return { title: "Debate not found — Feynman" };
+  if (!d) return { title: "Symposium not found — Feynman" };
   const names = uniqueNames(d.turns);
-  const canonical = abs(`/debate/${d.slug}`);
-  const title = `${d.question} — ${names.slice(0, 3).join(", ")} debate | Feynman`;
+  const canonical = abs(`/symposium/${d.slug}`);
+  const title = `${d.question} — a symposium with ${names.slice(0, 3).join(", ")} | Feynman`;
   const desc = metaDescription(
-    `${names.join(", ")} debate the question "${d.question}" — each argues in their own voice, engaging the others, then you can join the conversation. A living symposium, not a static page.`,
+    `${names.join(", ")} in symposium on "${d.question}" — each argues in their own voice, engaging the others, then you can join the conversation. A living symposium, not a static page.`,
   );
-  const ogImage = abs(`/og?type=debate&slug=${encodeURIComponent(d.slug)}`);
+  const ogImage = abs(`/og?type=symposium&slug=${encodeURIComponent(d.slug)}`);
   return {
     title,
     description: desc,
@@ -73,7 +74,7 @@ export default async function DebatePage({
   const d = await fetchDebate(params.slug);
   if (!d) notFound();
 
-  const canonical = abs(`/debate/${d.slug}`);
+  const canonical = abs(`/symposium/${d.slug}`);
   const names = uniqueNames(d.turns);
   const ref = (mindId: string) => d.mind_slugs?.[mindId] || mindId;
 
@@ -89,7 +90,7 @@ export default async function DebatePage({
   });
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
-    ["Debates", abs("/debates")],
+    ["Symposiums", abs("/symposiums")],
     [d.question, canonical],
   ]);
 
@@ -98,7 +99,7 @@ export default async function DebatePage({
       <JsonLd data={ld} />
       <JsonLd data={breadcrumbLd} />
 
-      {d.topic ? <p className="seo-meta">{d.topic} · Debate</p> : <p className="seo-meta">Debate</p>}
+      {d.topic ? <p className="seo-meta">{d.topic} · Symposium</p> : <p className="seo-meta">Symposium</p>}
       <h1>{d.question}</h1>
       <p className="seo-meta">
         {names.length} great minds in conversation — each argues in their own

--- a/web/app/symposiums/page.tsx
+++ b/web/app/symposiums/page.tsx
@@ -4,38 +4,38 @@ import SeoColumn from "@/components/seo/SeoColumn";
 import JsonLd from "@/components/seo/JsonLd";
 import { SITE_URL, abs, breadcrumbJsonLd, fetchDebatesList } from "@/lib/seo-mind";
 
-// The debates index — the discovery surface for Type-4 multi-mind symposia
+// The symposiums index — the discovery surface for Type-4 multi-mind symposia
 // (the philosophie.ai-style feed). Question-led entries: a sharp question pulls
-// far harder than an entity name.
+// far harder than an entity name. (Internal data/fns keep the "debate" name.)
 
 export const revalidate = 3600;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const canonical = abs("/debates");
+  const canonical = abs("/symposiums");
   return {
-    title: "Debates — history's great minds argue today's questions | Feynman",
+    title: "Symposiums — history's great minds on today's questions | Feynman",
     description:
-      "Multi-mind debates on Feynman: 2-4 great thinkers argue one question, each in their own voice, engaging the others. Read the symposium, then join the conversation.",
+      "Symposiums on Feynman: 2-4 great thinkers take up one question, each in their own voice, engaging the others. Read the symposium, then join the conversation.",
     alternates: { canonical },
     openGraph: {
       type: "website",
-      title: "Debates — great minds argue today's questions",
+      title: "Symposiums — great minds on today's questions",
       description:
-        "2-4 great thinkers argue one question, each in their own voice. Read the symposium, then chat with any of them.",
+        "2-4 great thinkers take up one question, each in their own voice. Read the symposium, then chat with any of them.",
       url: canonical,
       siteName: "Feynman",
     },
   };
 }
 
-export default async function DebatesIndexPage() {
+export default async function SymposiumsIndexPage() {
   const debates = await fetchDebatesList();
-  const canonical = abs("/debates");
+  const canonical = abs("/symposiums");
 
   const itemListLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    name: "Debates on Feynman",
+    name: "Symposiums on Feynman",
     url: canonical,
     mainEntity: {
       "@type": "ItemList",
@@ -43,14 +43,14 @@ export default async function DebatesIndexPage() {
       itemListElement: debates.map((d, i) => ({
         "@type": "ListItem",
         position: i + 1,
-        url: abs(`/debate/${d.slug}`),
+        url: abs(`/symposium/${d.slug}`),
         name: d.question,
       })),
     },
   };
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
-    ["Debates", canonical],
+    ["Symposiums", canonical],
   ]);
 
   return (
@@ -58,10 +58,10 @@ export default async function DebatesIndexPage() {
       <JsonLd data={itemListLd} />
       <JsonLd data={breadcrumbLd} />
 
-      <h1>Debates</h1>
+      <h1>Symposiums</h1>
       <p className="seo-meta">
-        History&apos;s great minds argue today&apos;s questions — 2-4 thinkers
-        per question, each in their own voice, engaging the others. Read the
+        History&apos;s great minds on today&apos;s questions — 2-4 thinkers per
+        question, each in their own voice, engaging the others. Read the
         symposium, then join the conversation.
       </p>
 
@@ -70,7 +70,7 @@ export default async function DebatesIndexPage() {
           <ul>
             {debates.map((d) => (
               <li key={d.slug}>
-                <Link href={`/debate/${d.slug}`}>{d.question}</Link>
+                <Link href={`/symposium/${d.slug}`}>{d.question}</Link>
                 {d.topic ? <span className="seo-meta"> · {d.topic}</span> : null}
               </li>
             ))}
@@ -78,7 +78,7 @@ export default async function DebatesIndexPage() {
         </section>
       ) : (
         <section className="seo-section">
-          <p>No debates yet — check back soon.</p>
+          <p>No symposiums yet — check back soon.</p>
         </section>
       )}
     </SeoColumn>

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -18,6 +18,15 @@ const API_BASE =
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    // The feature shipped briefly at /debate(s) before being renamed to
+    // /symposium(s). Those URLs were in one sitemap render, so 301 them so any
+    // early crawl consolidates onto the new path instead of 404-ing.
+    return [
+      { source: "/debate/:slug", destination: "/symposium/:slug", permanent: true },
+      { source: "/debates", destination: "/symposiums", permanent: true },
+    ];
+  },
   async rewrites() {
     // Local-dev proxy so the browser talks same-origin to the FastAPI on :8001.
     // PRODUCTION rewrites (incl. SEO/OG/share → the Python backend) live in


### PR DESCRIPTION
## Why
`debate` over-framed the content as adversarial. It's really *great minds taking up one question* — agreeing, sharpening, rebutting (Marcus Aurelius **builds on** Socrates before adding his twist; it's not a fight). **Symposium** (Plato's *Symposium* = great minds in discourse) fits the 'chat with great minds' brand, is ownable as a product term, and reads as thoughtful, not combative. Renaming now — before Google indexes `/debate` — makes it ~free.

## Scope
**User-facing only:**
- URLs: `/debate/{slug}`→`/symposium/{slug}`, `/debates`→`/symposiums` (route folders renamed)
- Copy, breadcrumbs, page titles, meta, sitemap `<loc>`
- 301 redirects `/debate/:slug`→`/symposium/:slug` + `/debates`→`/symposiums` (next.config) so the single sitemap render that briefly carried `/debate` consolidates instead of 404-ing

**Internal stays `debate`** (implementation detail, commented): `debates`/`debate_turns` tables, `create_debate`/etc, `/api/debates` routes, `fetchDebate`/`debateJsonLd`. Churning them would double the change surface for zero user benefit.

## Verify
- green feynman-web build (web/ can't typecheck locally)
- post-deploy: `/symposium/should-we-fear-death` → 200, `/debate/should-we-fear-death` → 301 → /symposium/…, `/symposiums` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)