### PR TITLE
feat(symposium): 2-round depth + avatars + transcript styling

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3546,6 +3546,16 @@ def add_debate_turn(debate_id: str, mind_id: str, mind_name: str, turn_index: in
         ), (str(uuid.uuid4()), debate_id, mind_id, mind_name, turn_index, content, _utcnow()))
 
 
+def delete_debate_by_question(question: str) -> None:
+    """Remove a debate + its turns by question (no FK, so cascade by hand).
+    Lets the generator re-run a seed with deeper/longer rounds (force mode)."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q("SELECT id FROM debates WHERE question = ?"), (question,))
+        for r in rows:
+            _execute(conn, _q("DELETE FROM debate_turns WHERE debate_id = ?"), (r["id"],))
+            _execute(conn, _q("DELETE FROM debates WHERE id = ?"), (r["id"],))
+
+
 def get_debate_by_slug(slug: str) -> dict[str, Any] | None:
     """A debate + its ordered turns, by slug (the /debate/{slug} render)."""
     with get_conn() as conn:

--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -27,6 +27,7 @@ from .db import (
     add_debate_turn,
     create_debate,
     debate_question_exists,
+    delete_debate_by_question,
     get_mind_by_name,
 )
 from .providers import bulk_chat
@@ -56,7 +57,7 @@ def _voice_bits(m: dict[str, Any]) -> tuple[str, str]:
     return phrases, works
 
 
-def _debate_prompt(question: str, m: dict[str, Any], transcript: str, is_first: bool) -> str:
+def _debate_prompt(question: str, m: dict[str, Any], transcript: str, is_first: bool, is_later_round: bool = False) -> str:
     phrases, works = _voice_bits(m)
     head = (
         f"You are {m['name']} ({m.get('era') or ''}; {m.get('domain') or ''}).\n"
@@ -70,6 +71,18 @@ def _debate_prompt(question: str, m: dict[str, Any], transcript: str, is_first: 
         body = (
             f"You open the symposium. State your position as {m['name']} — the core "
             "claim and the reasoning that makes it unmistakably yours."
+        )
+    elif is_later_round:
+        # Second pass: the discussion exists, so push it forward instead of
+        # restating an opening — this is what turns 3-4 isolated takes into an
+        # actual symposium with depth.
+        body = (
+            f"The symposium so far:\n{transcript}\n\n"
+            f"As {m['name']}, the discussion has developed — now go deeper. Pick the "
+            "single strongest challenge another speaker has raised to your view and "
+            "meet it head-on, OR pinpoint exactly where you and another speaker "
+            "fundamentally diverge and why it matters. Name them. Do NOT restate your "
+            "opening — advance it with a concrete distinction, example, or consequence."
         )
     else:
         body = (
@@ -88,16 +101,23 @@ def _clean(text: str) -> str:
     return t.strip()
 
 
-def generate_debate(question: str, minds: list[dict[str, Any]], rounds: int = 1) -> list[dict[str, Any]]:
+def generate_debate(question: str, minds: list[dict[str, Any]], rounds: int = 2) -> list[dict[str, Any]]:
     """Round-robin generation. Each speaker sees the running transcript. Returns
-    a list of {mind, turn_index, content}. A failed/short turn is skipped."""
+    a list of {mind, turn_index, content}. A failed/short turn is skipped.
+
+    rounds=2 (default) gives a real symposium, not 3-4 isolated takes: round 1 =
+    opening positions that reference each other; round 2 = each speaker goes
+    deeper, meeting the strongest challenge or sharpening a true disagreement."""
     turns: list[dict[str, Any]] = []
     transcript = ""
     idx = 0
-    for _r in range(rounds):
+    for r in range(rounds):
         for m in minds:
             try:
-                res, _ = bulk_chat(system=_DEBATE_SYSTEM, user=_debate_prompt(question, m, transcript, idx == 0))
+                res, _ = bulk_chat(
+                    system=_DEBATE_SYSTEM,
+                    user=_debate_prompt(question, m, transcript, idx == 0, is_later_round=(r >= 1)),
+                )
             except Exception as exc:
                 log.warning("debate turn failed for %s: %s", m.get("name"), exc)
                 continue
@@ -147,13 +167,16 @@ SEED_DEBATES: list[dict[str, Any]] = [
 ]
 
 
-def run_debate_batch(limit: int | None = None, rounds: int = 1) -> tuple[int, int]:
-    """Generate + store debates from the seed list. Idempotent (skips questions
-    already debated). Returns (created, remaining). Drives a local script."""
+def run_debate_batch(limit: int | None = None, rounds: int = 2, force: bool = False) -> tuple[int, int]:
+    """Generate + store debates from the seed list. Idempotent: skips questions
+    already debated UNLESS force=True, which regenerates them (delete old turns
+    first) — used to re-run the seeds at a deeper round count. Returns
+    (created, remaining). Drives a local script."""
     created = 0
     remaining = 0
     for seed in SEED_DEBATES:
-        if debate_question_exists(seed["q"]):
+        exists = debate_question_exists(seed["q"])
+        if exists and not force:
             continue
         remaining += 1
         if limit is not None and created >= limit:
@@ -172,6 +195,10 @@ def run_debate_batch(limit: int | None = None, rounds: int = 1) -> tuple[int, in
         if len(turns) < 2:
             log.warning("debate %r: only %d turns generated, skipping", seed["q"], len(turns))
             continue
+        # Only delete the old version AFTER a successful regeneration, so a
+        # mid-run failure never leaves a question with no symposium at all.
+        if exists and force:
+            delete_debate_by_question(seed["q"])
         d = create_debate(seed["q"], seed["topic"], [t["mind"]["id"] for t in turns])
         for t in turns:
             add_debate_turn(d["id"], t["mind"]["id"], t["mind"]["name"], t["turn_index"], t["content"])

--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   fetchDebate,
   metaDescription,
 } from "@/lib/seo-mind";
+import { mindColor, mindInitials } from "@/lib/minds";
 
 // Symposium (Type-4): 2-4 great minds argue ONE question, each engaging the
 // prior speakers by name. The emergent cross-referencing transcript is the
@@ -77,6 +78,16 @@ export default async function DebatePage({
   const canonical = abs(`/symposium/${d.slug}`);
   const names = uniqueNames(d.turns);
   const ref = (mindId: string) => d.mind_slugs?.[mindId] || mindId;
+  // Where the deeper round begins = the first time a speaker takes a second
+  // turn. Used to drop a "the discussion deepens" divider between movements.
+  const secondRoundAt = (() => {
+    const seen = new Set<string>();
+    for (let i = 0; i < d.turns.length; i++) {
+      if (seen.has(d.turns[i].mind_id)) return i;
+      seen.add(d.turns[i].mind_id);
+    }
+    return -1;
+  })();
 
   const ld = debateJsonLd({
     question: d.question,
@@ -107,25 +118,41 @@ export default async function DebatePage({
         An AI-mediated symposium you can join.
       </p>
 
-      <section className="seo-section insights">
-        {d.turns.map((t, i) => (
-          <article key={i} className="insight-card">
-            <Link
-              href={`/mind/${encodeURIComponent(ref(t.mind_id))}`}
-              className="insight-card-who"
-            >
-              {t.mind_name}
-            </Link>
-            {t.content
-              .split(/\n\n+/)
-              .map((p) => p.trim())
-              .filter(Boolean)
-              .map((p, j) => (
-                <p key={j}>{p}</p>
-              ))}
-          </article>
-        ))}
-      </section>
+      <div className="symposium-thread">
+        {d.turns.map((t, i) => {
+          const href = `/mind/${encodeURIComponent(ref(t.mind_id))}`;
+          return (
+            <div key={i}>
+              {i === secondRoundAt ? (
+                <div className="symposium-round-break">The discussion deepens</div>
+              ) : null}
+              <article className="symposium-turn">
+                <Link
+                  href={href}
+                  className="symposium-avatar"
+                  style={{ background: mindColor(t.mind_name) }}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                >
+                  {mindInitials(t.mind_name)}
+                </Link>
+                <div className="symposium-turn-body">
+                  <Link href={href} className="symposium-turn-author">
+                    {t.mind_name}
+                  </Link>
+                  {t.content
+                    .split(/\n\n+/)
+                    .map((p) => p.trim())
+                    .filter(Boolean)
+                    .map((p, j) => (
+                      <p key={j}>{p}</p>
+                    ))}
+                </div>
+              </article>
+            </div>
+          );
+        })}
+      </div>
 
       <p className="seo-cta-row">
         <a

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -587,6 +587,40 @@ body { background-color: var(--bg-home); }
 .insight-card-who { display: block; font-size: 12px; font-weight: 600; color: var(--accent); margin-bottom: 5px; }
 .insight-card p { margin: 0; line-height: 1.6; color: var(--text); }
 
+/* ── Symposium thread — a multi-mind debate read as a real conversation:
+   colored initials avatar + speaker + remark, separated like a transcript. ── */
+.symposium-thread { display: flex; flex-direction: column; margin-top: 6px; max-width: 720px; }
+.symposium-turn {
+  display: flex; gap: 14px; padding: 20px 0;
+  border-bottom: 1px solid var(--border);
+}
+.symposium-turn:last-child { border-bottom: none; }
+.symposium-avatar {
+  width: 46px; height: 46px; border-radius: 50%; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  color: #fff; font-weight: 700; font-size: 16px; letter-spacing: 0.5px;
+  text-decoration: none; user-select: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.symposium-avatar:hover { transform: scale(1.05); box-shadow: 0 0 0 3px var(--accent-light); }
+.symposium-turn-body { flex: 1; min-width: 0; }
+.symposium-turn-author {
+  display: inline-block; font-size: 15px; font-weight: 650;
+  color: var(--text); text-decoration: none; margin-bottom: 2px;
+}
+.symposium-turn-author:hover { color: var(--accent); }
+.symposium-turn-body p { margin: 8px 0 0; line-height: 1.72; color: var(--text); }
+/* Round divider — marks where the opening round ends and the deeper exchange
+   begins, so a long symposium reads as two movements not one wall. */
+.symposium-round-break {
+  display: flex; align-items: center; gap: 12px;
+  margin: 26px 0 6px; color: var(--text-muted);
+  font-size: 12px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase;
+}
+.symposium-round-break::before, .symposium-round-break::after {
+  content: ""; flex: 1; height: 1px; background: var(--border);
+}
+
 /* ── Notable quotes — anchored, indexable quote blocks; each one can be asked
    about directly (quote → prefilled chat), the living-entry differentiator. ── */
 .notable-quotes { list-style: none; padding: 0; margin: 10px 0 0; display: flex; flex-direction: column; gap: 18px; }


### PR DESCRIPTION
Follow-up to the rename, addressing two gaps:

## 1. Depth — a symposium needs more than 3-4 takes
- `generate_debate` now defaults to **rounds=2**. Round 1 = opening positions (cross-referencing); round 2 = each speaker **goes deeper** via a new `is_later_round` prompt branch (meet the strongest challenge to your view, or pinpoint a true divergence — advance, don't restate). A 4-mind seed → **~8 turns / ~1,000-1,400 words**.
- `run_debate_batch(force=True)` regenerates the existing seeds at the deeper round count; `delete_debate_by_question` removes old turns **after** the new ones generate (mid-run failure never orphans a question). Slugs are stable (question unchanged).

## 2. Styling — read it as a conversation, not text links
- Each turn leads with a **colored initials avatar** (reuses site-wide `mindColor`/`mindInitials`) + speaker + remark, as a real transcript (`.symposium-thread`/`.symposium-turn`, theme vars → dark-mode correct).
- A **"The discussion deepens"** divider marks where round 2 begins, so a long symposium reads as two movements.

(Avatars use initials, the site-wide convention; real Wikimedia portraits are a separate follow-up — SSR-resolving P18 per speaker is slow and not all minds have one.)

## Verify
- green feynman-web build
- regenerate data locally (`force=True, rounds=2`, DeepSeek — no geoblock); post-deploy spot-check a symposium for ~8 turns + avatars + divider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)