### PR TITLE
feat(symposium): chat-UI redesign — participants header + lighter thread

### DIFF
--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -78,16 +78,16 @@ export default async function DebatePage({
   const canonical = abs(`/symposium/${d.slug}`);
   const names = uniqueNames(d.turns);
   const ref = (mindId: string) => d.mind_slugs?.[mindId] || mindId;
-  // Where the deeper round begins = the first time a speaker takes a second
-  // turn. Used to drop a "the discussion deepens" divider between movements.
-  const secondRoundAt = (() => {
-    const seen = new Set<string>();
-    for (let i = 0; i < d.turns.length; i++) {
-      if (seen.has(d.turns[i].mind_id)) return i;
-      seen.add(d.turns[i].mind_id);
+  // Distinct participants in first-appearance order — the group-chat header row
+  // (and the footer chat funnel). One entry per mind even though they speak twice.
+  const participants: typeof d.turns = [];
+  const seenP = new Set<string>();
+  for (const t of d.turns) {
+    if (!seenP.has(t.mind_id)) {
+      seenP.add(t.mind_id);
+      participants.push(t);
     }
-    return -1;
-  })();
+  }
 
   const ld = debateJsonLd({
     question: d.question,
@@ -110,71 +110,83 @@ export default async function DebatePage({
       <JsonLd data={ld} />
       <JsonLd data={breadcrumbLd} />
 
-      {d.topic ? <p className="seo-meta">{d.topic} · Symposium</p> : <p className="seo-meta">Symposium</p>}
+      <p className="seo-meta">{d.topic ? `${d.topic} · Symposium` : "Symposium"}</p>
       <h1>{d.question}</h1>
-      <p className="seo-meta">
-        {names.length} great minds in conversation — each argues in their own
-        voice, grounded in their documented ideas, engaging the others by name.
-        An AI-mediated symposium you can join.
-      </p>
 
-      <div className="symposium-thread">
-        {d.turns.map((t, i) => {
-          const href = `/mind/${encodeURIComponent(ref(t.mind_id))}`;
-          return (
-            <div key={i}>
-              {i === secondRoundAt ? (
-                <div className="symposium-round-break">The discussion deepens</div>
-              ) : null}
-              <article className="symposium-turn">
-                <Link
-                  href={href}
-                  className="symposium-avatar"
-                  style={{ background: mindColor(t.mind_name) }}
-                  aria-hidden="true"
-                  tabIndex={-1}
-                >
-                  {mindInitials(t.mind_name)}
-                </Link>
-                <div className="symposium-turn-body">
-                  <Link href={href} className="symposium-turn-author">
-                    {t.mind_name}
-                  </Link>
-                  {t.content
-                    .split(/\n\n+/)
-                    .map((p) => p.trim())
-                    .filter(Boolean)
-                    .map((p, j) => (
-                      <p key={j}>{p}</p>
-                    ))}
-                </div>
-              </article>
-            </div>
-          );
-        })}
+      {/* Group-chat header: the minds in the room, each a chat entry point. */}
+      <div className="symposium-participants">
+        {participants.map((t) => (
+          <Link
+            key={t.mind_id}
+            href={`/mind/${encodeURIComponent(ref(t.mind_id))}`}
+            className="symposium-participant"
+          >
+            <span
+              className="symposium-pill-avatar"
+              style={{ background: mindColor(t.mind_name) }}
+            >
+              {mindInitials(t.mind_name)}
+            </span>
+            <span className="symposium-pill-name">{t.mind_name}</span>
+          </Link>
+        ))}
       </div>
-
-      <p className="seo-cta-row">
-        <a
-          className="primary"
-          href={`/mind/${encodeURIComponent(ref(d.turns[0].mind_id))}/chat`}
-        >
-          Chat with {d.turns[0].mind_name} →
-        </a>
+      <p className="seo-meta symposium-intro">
+        {names.length} great minds on this question — each in their own voice,
+        engaging the others. Tap anyone to chat.
       </p>
 
-      <section className="seo-section">
-        <h2>Chat with any of them</h2>
-        <ul>
-          {d.turns.map((t, i) => (
-            <li key={i}>
-              <Link href={`/mind/${encodeURIComponent(ref(t.mind_id))}`}>
+      {/* The conversation, read as a thread (one bubble per turn). */}
+      <div className="symposium-thread">
+        {d.turns.map((t, i) => (
+          <article key={i} className="symposium-turn">
+            <span
+              className="symposium-avatar"
+              style={{ background: mindColor(t.mind_name) }}
+              aria-hidden="true"
+            >
+              {mindInitials(t.mind_name)}
+            </span>
+            <div className="symposium-turn-body">
+              <Link
+                href={`/mind/${encodeURIComponent(ref(t.mind_id))}`}
+                className="symposium-turn-author"
+              >
                 {t.mind_name}
               </Link>
-            </li>
+              {t.content
+                .split(/\n\n+/)
+                .map((p) => p.trim())
+                .filter(Boolean)
+                .map((p, j) => (
+                  <p key={j}>{p}</p>
+                ))}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {/* Footer funnel: continue with any voice in the room (no single pick). */}
+      <div className="symposium-footer">
+        <p className="seo-meta">Continue the conversation — chat with any of them:</p>
+        <div className="symposium-participants">
+          {participants.map((t) => (
+            <Link
+              key={t.mind_id}
+              href={`/mind/${encodeURIComponent(ref(t.mind_id))}/chat`}
+              className="symposium-participant"
+            >
+              <span
+                className="symposium-pill-avatar"
+                style={{ background: mindColor(t.mind_name) }}
+              >
+                {mindInitials(t.mind_name)}
+              </span>
+              <span className="symposium-pill-name">{t.mind_name}</span>
+            </Link>
           ))}
-        </ul>
-      </section>
+        </div>
+      </div>
     </SeoColumn>
   );
 }

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -587,39 +587,44 @@ body { background-color: var(--bg-home); }
 .insight-card-who { display: block; font-size: 12px; font-weight: 600; color: var(--accent); margin-bottom: 5px; }
 .insight-card p { margin: 0; line-height: 1.6; color: var(--text); }
 
-/* ── Symposium thread — a multi-mind debate read as a real conversation:
-   colored initials avatar + speaker + remark, separated like a transcript. ── */
-.symposium-thread { display: flex; flex-direction: column; margin-top: 6px; max-width: 720px; }
-.symposium-turn {
-  display: flex; gap: 14px; padding: 20px 0;
-  border-bottom: 1px solid var(--border);
+/* ── Symposium — a multi-mind conversation, styled like the chat UI: a
+   participants header (the minds in the room) + a light message thread. The
+   .seo-content overrides kill the inherited SEO-prose link underline/blue so
+   avatars and names read as chat, not hyperlinks. ── */
+.symposium-participants { display: flex; flex-wrap: wrap; gap: 8px; margin: 16px 0 10px; }
+.seo-content a.symposium-participant {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 4px 12px 4px 4px; border-radius: 999px;
+  background: var(--bg-sidebar); border: 1px solid var(--border);
+  text-decoration: none; color: var(--text);
+  transition: border-color 0.15s ease, background 0.15s ease;
 }
-.symposium-turn:last-child { border-bottom: none; }
-.symposium-avatar {
-  width: 46px; height: 46px; border-radius: 50%; flex-shrink: 0;
+.seo-content a.symposium-participant:hover { border-color: var(--accent); background: var(--accent-light); }
+.symposium-pill-avatar {
+  width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0;
   display: flex; align-items: center; justify-content: center;
-  color: #fff; font-weight: 700; font-size: 16px; letter-spacing: 0.5px;
-  text-decoration: none; user-select: none;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  color: #fff; font-weight: 700; font-size: 11px; user-select: none;
 }
-.symposium-avatar:hover { transform: scale(1.05); box-shadow: 0 0 0 3px var(--accent-light); }
+.symposium-pill-name { font-size: 13px; font-weight: 600; color: var(--text); }
+.symposium-intro { margin-bottom: 4px; }
+
+.symposium-thread { display: flex; flex-direction: column; gap: 2px; margin-top: 20px; max-width: 720px; }
+.symposium-turn { display: flex; gap: 12px; padding: 14px 0; }
+.symposium-avatar {
+  width: 36px; height: 36px; border-radius: 50%; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  color: #fff; font-weight: 700; font-size: 13px; user-select: none;
+}
 .symposium-turn-body { flex: 1; min-width: 0; }
-.symposium-turn-author {
-  display: inline-block; font-size: 15px; font-weight: 650;
-  color: var(--text); text-decoration: none; margin-bottom: 2px;
+.seo-content a.symposium-turn-author {
+  display: inline-block; font-size: 14px; font-weight: 650;
+  color: var(--text); text-decoration: none; margin-bottom: 1px;
 }
-.symposium-turn-author:hover { color: var(--accent); }
-.symposium-turn-body p { margin: 8px 0 0; line-height: 1.72; color: var(--text); }
-/* Round divider — marks where the opening round ends and the deeper exchange
-   begins, so a long symposium reads as two movements not one wall. */
-.symposium-round-break {
-  display: flex; align-items: center; gap: 12px;
-  margin: 26px 0 6px; color: var(--text-muted);
-  font-size: 12px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase;
-}
-.symposium-round-break::before, .symposium-round-break::after {
-  content: ""; flex: 1; height: 1px; background: var(--border);
-}
+.seo-content a.symposium-turn-author:hover { color: var(--accent); }
+.symposium-turn-body p { margin: 6px 0 0; line-height: 1.7; color: var(--text); }
+
+.symposium-footer { margin-top: 30px; padding-top: 20px; border-top: 1px solid var(--border); }
+.symposium-footer .seo-meta { margin-bottom: 10px; }
 
 /* ── Notable quotes — anchored, indexable quote blocks; each one can be asked
    about directly (quote → prefilled chat), the living-entry differentiator. ── */


### PR DESCRIPTION
Review fixes on the symposium page:

1. **Blue underline on avatars/names** — they inherited `.seo-content a` (SEO prose links). Overridden with `.seo-content a.symposium-*` → reads as chat, not hyperlinks. Avatars also lightened (46→36px thread, 26px pills).
2. **Arbitrary 'Chat with {first speaker}'** — it was just `turns[0]`. Replaced with a **participant row**: every mind in the room, each → its own chat. No single pick.
3. **Cryptic 'The discussion deepens' divider** — removed; one continuous thread (a mind speaking twice is natural in group chat).
4. **Chat-UI structure** — topic eyebrow + question, then a **group-chat participants header** (minds as tappable avatar+name pills → chat entry points), then the message thread.

Frontend-only (page + liquid.css); data unchanged. Gate on green feynman-web build; post-deploy spot-check /symposium/what-makes-a-life-meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)