### PR TITLE
feat(symposium): sidebar entry + mind-detail interlink

### DIFF
--- a/web/app/mind/[id]/page.tsx
+++ b/web/app/mind/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   fetchMindLibrary,
   fetchMindThemes,
   fetchMindDialogues,
+  fetchMindDebates,
   fetchMindQuestions,
   isMindTopicRelevant,
   mindSameAs,
@@ -272,12 +273,28 @@ export default async function MindPage({
 
 async function MindRail({ id, mind }: { id: string; mind: MindDetail }) {
   try {
-    const [agents, related] = await Promise.all([fetchAgents(), fetchRelatedMinds(mind)]);
+    const [agents, related, symposiums] = await Promise.all([
+      fetchAgents(),
+      fetchRelatedMinds(mind),
+      fetchMindDebates(id),
+    ]);
     const hasWorks = (mind.works || []).filter(Boolean).length > 0;
-    if (!hasWorks && !related.length) return null;
+    if (!hasWorks && !related.length && !symposiums.length) return null;
     return (
       <>
         <MindWorks works={mind.works} agents={agents} variant="rail" />
+        {symposiums.length ? (
+          <div className="seo-rail-card">
+            <h3>Symposiums</h3>
+            <ul>
+              {symposiums.slice(0, 6).map((s) => (
+                <li key={s.slug}>
+                  <Link href={`/symposium/${s.slug}`}>{s.question}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
         {related.length ? (
           <div className="seo-rail-card">
             <h3>Related minds</h3>

--- a/web/components/shell/Sidebar.tsx
+++ b/web/components/shell/Sidebar.tsx
@@ -69,6 +69,20 @@ const NAV = [
       </>
     ),
   },
+  {
+    href: "/symposiums",
+    label: "Symposiums",
+    cls: "sidebar-symposiums-link",
+    icon: (
+      <>
+        {/* speech bubble with three voices — a multi-mind conversation */}
+        <path d="M4 5h16v10H9l-4 4V5z" />
+        <circle cx="9" cy="10" r="1" />
+        <circle cx="13" cy="10" r="1" />
+        <circle cx="17" cy="10" r="1" />
+      </>
+    ),
+  },
 ];
 
 export default function Sidebar() {
@@ -158,7 +172,11 @@ export default function Sidebar() {
       </Link>
 
       {NAV.map((item) => {
-        const active = pathname === item.href || pathname.startsWith(item.href + "/");
+        const active =
+          pathname === item.href ||
+          pathname.startsWith(item.href + "/") ||
+          // /symposiums (index) should also light up on /symposium/{slug} (detail).
+          (item.href === "/symposiums" && pathname.startsWith("/symposium/"));
         return (
           <Link
             key={item.href}


### PR DESCRIPTION
Symposiums were an island — reachable only by direct URL, and mind detail pages didn't point to the symposiums a mind argued in (only Notable works + Related minds). Two links close the loop, per the question:

- **Sidebar**: first-class **Symposiums** nav item (after Great Minds, speech-bubble icon), active on `/symposiums` and `/symposium/{slug}`.
- **Mind detail rail**: a **Symposiums** card listing the symposiums this mind joined (reuses `fetchMindDebates`/`list_debates_for_mind`), each → the thread.

Now fully cross-linked both directions: sidebar/graph → symposiums → participant minds → their symposiums. Discovery + internal-link equity. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)