### PR TITLE
feat(symposium): share — whole + per-turn, with matching OG cards

### DIFF
--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -38,9 +38,12 @@ import {
   FallbackCard,
   OgAvatar,
   OgMiniCover,
+  SymposiumCard,
+  SymposiumTurnCard,
 } from "@/lib/og/cards";
 import {
   fetchMind,
+  fetchDebate,
   fetchPublicAnswer,
   fetchPublicDiscussion,
   fetchMindOnTopic,
@@ -301,6 +304,51 @@ async function build(type: string, id: string, slug: string, kind: string) {
           glyph={<OgMiniCover bg={bookAccent(data.title, isAi)} initials={bookInitials(data.title)} />}
           name={data.title}
           label={data.author ? clip(data.author, 44) : isInsights ? "Reader insights" : "Reader discussions"}
+        />
+      );
+    }
+
+    case "symposium": {
+      const d = await fetchDebate(slug);
+      if (!d) return <HomeCard />;
+      const seen = new Set<string>();
+      const parts: { accent: string; initials: string }[] = [];
+      const names: string[] = [];
+      for (const t of d.turns) {
+        if (seen.has(t.mind_id)) continue;
+        seen.add(t.mind_id);
+        parts.push({ accent: mindAccent(t.mind_name), initials: mindInitials(t.mind_name) });
+        names.push(t.mind_name);
+      }
+      const rosterLabel =
+        names.length <= 1
+          ? names[0] || ""
+          : names.slice(0, -1).join(", ") + " and " + names[names.length - 1];
+      return (
+        <SymposiumCard
+          question={d.question}
+          topic={d.topic}
+          participants={parts}
+          rosterLabel={rosterLabel}
+        />
+      );
+    }
+
+    case "symposium-turn": {
+      const d = await fetchDebate(slug);
+      if (!d) return <HomeCard />;
+      const i = Math.max(0, parseInt(kind || "0", 10) || 0);
+      const turn = d.turns[i] || d.turns[0];
+      if (!turn) return <HomeCard />;
+      const portrait = await mindPortraitDataUri({ name: turn.mind_name });
+      return (
+        <SymposiumTurnCard
+          question={d.question}
+          speakerName={turn.mind_name}
+          snippet={(turn.content || "").replace(/\s+/g, " ").trim()}
+          portrait={portrait}
+          accent={mindAccent(turn.mind_name)}
+          initials={mindInitials(turn.mind_name)}
         />
       );
     }

--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import EntityLayout from "@/components/seo/EntityLayout";
 import JsonLd from "@/components/seo/JsonLd";
+import ShareButton from "@/components/share/ShareButton";
 import {
   SITE_URL,
   abs,
@@ -143,6 +144,16 @@ export default async function SymposiumPage({
         a living exchange you won&apos;t find anywhere else — read it, then chat with
         any of them yourself.
       </p>
+      <div className="symposium-hero-actions">
+        <ShareButton
+          url={canonical}
+          title={d.question}
+          subject="Symposium"
+          previewImage={abs(`/og?type=symposium&slug=${encodeURIComponent(d.slug)}`)}
+          label="Share this symposium"
+          variant="secondary"
+        />
+      </div>
     </>
   );
 
@@ -195,12 +206,24 @@ export default async function SymposiumPage({
             <div className="mind-msg-body">
               <div className="mind-msg-name symposium-turn-head">
                 <span>{t.mind_name}</span>
-                <Link
-                  href={`/mind/${encodeURIComponent(ref(t.mind_id))}/chat`}
-                  className="symposium-chat-link"
-                >
-                  Chat →
-                </Link>
+                <span className="symposium-turn-actions">
+                  <ShareButton
+                    url={`${canonical}#turn-${i}`}
+                    title={`${t.mind_name} on “${d.question}”`}
+                    subject="From a symposium"
+                    previewImage={abs(
+                      `/og?type=symposium-turn&slug=${encodeURIComponent(d.slug)}&kind=${i}`,
+                    )}
+                    label="Share"
+                    variant="ghost"
+                  />
+                  <Link
+                    href={`/mind/${encodeURIComponent(ref(t.mind_id))}/chat`}
+                    className="symposium-chat-link"
+                  >
+                    Chat →
+                  </Link>
+                </span>
               </div>
               <div className="mind-msg-content">
                 {t.content

--- a/web/components/share/ShareButton.tsx
+++ b/web/components/share/ShareButton.tsx
@@ -11,6 +11,7 @@ export default function ShareButton({
   url,
   subject,
   title,
+  previewImage,
   defaultText,
   label = "Share",
   variant = "ghost",
@@ -18,6 +19,8 @@ export default function ShareButton({
   url: string;
   subject?: string;
   title?: string;
+  /** og:image to preview; when omitted ShareDialog reads the page's meta. */
+  previewImage?: string;
   defaultText?: string;
   label?: string;
   variant?: "ghost" | "secondary";
@@ -34,7 +37,7 @@ export default function ShareButton({
         {label}
       </button>
       {open ? (
-        <ShareDialog url={url} subject={subject} title={title} defaultText={defaultText} onClose={() => setOpen(false)} />
+        <ShareDialog url={url} subject={subject} title={title} previewImage={previewImage} defaultText={defaultText} onClose={() => setOpen(false)} />
       ) : null}
     </>
   );

--- a/web/lib/og/cards.tsx
+++ b/web/lib/og/cards.tsx
@@ -460,6 +460,95 @@ export function AggCard({ title, sub, glyph, name, label }: { title: string; sub
   );
 }
 
+// Whole-symposium card: the question as the headline + the roster of minds in
+// the room (overlapping avatars, like MindsCue but named). The multi-voice
+// roster IS the unique thing — no single book/mind, a conversation between many.
+export function SymposiumCard({
+  question,
+  topic,
+  participants,
+  rosterLabel,
+}: {
+  question: string;
+  topic?: string;
+  participants: { accent: string; initials: string }[];
+  rosterLabel: string;
+}) {
+  return (
+    <Frame
+      body={
+        <div style={{ display: "flex", flexDirection: "column", flexGrow: 1, justifyContent: "center" }}>
+          <div style={{ display: "flex", fontSize: 17, letterSpacing: 2, color: INK_MUTE, marginBottom: 18, fontFamily: FONT }}>
+            {topic ? `SYMPOSIUM · ${clip(topic.toUpperCase(), 28)}` : "SYMPOSIUM"}
+          </div>
+          <div style={{ display: "flex", fontSize: 46, fontWeight: 700, color: INK, lineHeight: 1.16, marginBottom: 30 }}>
+            {clip(question, 108)}
+          </div>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <div style={{ display: "flex" }}>
+              {participants.slice(0, 5).map((p, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 56, height: 56, borderRadius: 56, background: p.accent, color: "#fff", fontSize: 19, fontWeight: 700, fontFamily: FONT, border: "3px solid #faf8f4", marginLeft: i === 0 ? 0 : -14 }}>
+                  {p.initials}
+                </div>
+              ))}
+            </div>
+            <div style={{ display: "flex", fontSize: 24, color: INK_SOFT, marginLeft: 20, fontFamily: FONT, maxWidth: 760 }}>
+              {clip(rosterLabel, 64)}
+            </div>
+          </div>
+          <ChatPill label="Read the symposium" />
+        </div>
+      }
+      footer={<FooterSimple />}
+    />
+  );
+}
+
+// Single-turn card: one mind's contribution within a symposium. The question is
+// the context strip; the remark is the bubble; the CTA chats with that mind.
+export function SymposiumTurnCard({
+  question,
+  speakerName,
+  snippet,
+  portrait,
+  accent,
+  initials,
+}: {
+  question: string;
+  speakerName: string;
+  snippet: string;
+  portrait: string | null;
+  accent: string;
+  initials: string;
+}) {
+  return (
+    <Frame
+      body={
+        <div style={{ display: "flex", flexDirection: "column", flexGrow: 1, justifyContent: "center" }}>
+          <div style={{ display: "flex", flexDirection: "column", marginBottom: 26 }}>
+            <div style={{ display: "flex", fontSize: 16, letterSpacing: 2, color: INK_MUTE, fontFamily: FONT }}>IN A SYMPOSIUM ON</div>
+            <div style={{ display: "flex", fontSize: 30, fontWeight: 700, color: INK, lineHeight: 1.2, marginTop: 8, maxWidth: 980 }}>
+              {clip(question, 88)}
+            </div>
+          </div>
+          <div style={{ display: "flex", alignItems: "flex-start" }}>
+            <Avatar src={portrait} initials={initials} accent={accent} size={90} />
+            <div style={{ display: "flex", flexDirection: "column", marginLeft: 24, flexGrow: 1, minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "baseline", marginBottom: 12 }}>
+                <div style={{ display: "flex", fontSize: 28, fontWeight: 700, color: INK, fontFamily: FONT }}>{clip(speakerName, 26)}</div>
+                <div style={{ display: "flex", fontSize: 19, color: INK_MUTE, marginLeft: 13, fontFamily: FONT, fontStyle: "italic" }}>argued</div>
+              </div>
+              <Bubble text={`“${clip(snippet, 200)}”`} accent={accent} fontSize={28} />
+            </div>
+          </div>
+          <ChatPill label={`Chat with ${clip(speakerName, 20)}`} />
+        </div>
+      }
+      footer={<FooterSimple />}
+    />
+  );
+}
+
 export function HomeCard() {
   return (
     <Frame

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -598,15 +598,23 @@ body { background-color: var(--bg-home); }
 .symposium-thread .mind-msg-content p { margin: 0 0 10px; }
 .symposium-thread .mind-msg-content p:last-child { margin-bottom: 0; }
 /* Per-turn chat entry on the name line (right) — replaces the footer link row. */
-.symposium-turn-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.symposium-turn-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+/* Per-turn actions (Share + Chat) — hover-revealed on desktop, always-on for
+   touch — so each turn carries its own share + chat entry without clutter. */
+.symposium-turn-actions {
+  display: flex; align-items: center; gap: 10px; flex-shrink: 0;
+  opacity: 0; transition: opacity 0.15s ease;
+}
+.mind-message:hover .symposium-turn-actions { opacity: 1; }
+@media (hover: none) { .symposium-turn-actions { opacity: 1; } }
 .seo-content a.symposium-chat-link {
   font-size: 12px; font-weight: 500; color: var(--accent); text-decoration: none;
-  white-space: nowrap; flex-shrink: 0; opacity: 0; transition: opacity 0.15s ease;
+  white-space: nowrap;
 }
-.mind-message:hover .symposium-chat-link { opacity: 0.9; }
-.seo-content a.symposium-chat-link:hover { opacity: 1; }
-/* Touch / no-hover: always show the chat entry (no hover to reveal it). */
-@media (hover: none) { .seo-content a.symposium-chat-link { opacity: 0.9; } }
+.seo-content a.symposium-chat-link:hover { opacity: 0.8; }
+/* Compact share button inside a turn (override the default seo-action sizing). */
+.symposium-turn-actions .seo-action { font-size: 12px; padding: 2px 4px; }
+.symposium-hero-actions { margin-top: 16px; }
 
 /* ── Notable quotes — anchored, indexable quote blocks; each one can be asked
    about directly (quote → prefilled chat), the living-entry differentiator. ── */


### PR DESCRIPTION
Symposiums had no share affordance. Added both levels requested, reusing the unified `/og` card system + ShareDialog preview:

**OG cards** (`lib/og/cards`, matching the existing Frame/Bubble/ChatPill language):
- `SymposiumCard` — question headline + the **roster of minds** as overlapping avatars (the multi-voice room is the unique thing).
- `SymposiumTurnCard` — question context + one mind's avatar + remark bubble + 'Chat with {mind}' pill.

**Route:** `type=symposium` (roster) and `type=symposium-turn` (`slug` + `kind`=turn index), via `fetchDebate`.

**UI:**
- `ShareButton` gains optional `previewImage` (per-turn previews its own card; whole-page reads the page's meta og:image = `type=symposium`).
- Page: 'Share this symposium' under the lede + a per-turn **Share** beside each speaker's **Chat →** (hover desktop / always-on touch), the link carrying `#turn-{i}`.

Symposium content is public → a turn share is a deep link + its card, no `shared_answers`/UGC gating (that's for private chat turns). Frontend-only. Gate on green build; post-deploy: `/og?type=symposium&slug=…` and `…&type=symposium-turn&kind=2` render; Share buttons open the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)