### PR TITLE
fix: sidebar Symposiums alignment + graph restores last view (no re-animation)

### DIFF
--- a/web/components/minds/MindsGraph.tsx
+++ b/web/components/minds/MindsGraph.tsx
@@ -134,14 +134,22 @@ export default function MindsGraph() {
     let W = container.clientWidth || 900;
     let H = container.clientHeight || 600;
 
-    // Play the top-left "flow" entrance only on the FIRST visit; afterwards drop
-    // the visitor straight into a settled graph and restore their last pan/zoom.
-    const SEEN_KEY = "feynman:minds-graph-seen";
+    // First visit: play the original top-left flow-in entrance, then save the
+    // SETTLED node positions + view. Every later visit: seat nodes at those
+    // saved positions and keep the sim STOPPED (zero animation — no re-flow, no
+    // center "explosion"), restoring the exact last view. Saving the final
+    // positions (not just pan/zoom, and NOT the raw PCA targets) is what makes a
+    // return visit show precisely where things settled last time.
+    const POS_KEY = "feynman:minds-graph-pos";
     const VIEW_KEY = "feynman:minds-graph-view";
-    let seenIntro = false;
+    let savedPositions: Record<string, [number, number]> | null = null;
     let savedView: { x: number; y: number; k: number } | null = null;
     try {
-      seenIntro = localStorage.getItem(SEEN_KEY) === "1";
+      const rawPos = localStorage.getItem(POS_KEY);
+      if (rawPos) {
+        const p = JSON.parse(rawPos);
+        if (p && typeof p === "object" && Object.keys(p).length) savedPositions = p;
+      }
       const raw = localStorage.getItem(VIEW_KEY);
       if (raw) {
         const v = JSON.parse(raw);
@@ -150,6 +158,18 @@ export default function MindsGraph() {
     } catch {
       /* private mode / disabled storage — just play the default entrance */
     }
+    const savePositions = () => {
+      if (!nodes.length) return;
+      try {
+        const out: Record<string, [number, number]> = {};
+        for (const n of nodes) {
+          if (n.x != null && n.y != null) out[n.id] = [Math.round(n.x), Math.round(n.y)];
+        }
+        localStorage.setItem(POS_KEY, JSON.stringify(out));
+      } catch {
+        /* ignore */
+      }
+    };
 
     const canvas = document.createElement("canvas");
     canvas.className = styles.canvas;
@@ -218,6 +238,12 @@ export default function MindsGraph() {
         .alphaDecay(0.015)
         .on("tick", () => {
           /* draw loop reads positions; nothing to do here */
+        })
+        .on("end", () => {
+          // Sim settled (the first-visit entrance finished, or a drag came to
+          // rest) → persist the final positions so the next visit restores them
+          // with no animation.
+          savePositions();
         });
     }
 
@@ -234,14 +260,16 @@ export default function MindsGraph() {
       const built = buildGraphData(minds, simLinks, layout);
       nodes = built.nodes;
       links = built.links;
-      // Returning visitor: seat nodes AT their PCA targets so the graph appears
-      // already settled (no flow-in from the origin). First-timer: leave x/y
-      // unset so the embedding force does its one-time top-left entrance.
-      if (seenIntro) {
+      // Returning visitor: restore the EXACT last settled positions (saved on
+      // 'end'), so the graph appears exactly as they left it. First-timer:
+      // leave x/y unset so the embedding force does its one-time top-left
+      // entrance from the origin.
+      if (savedPositions) {
         for (const n of nodes) {
-          if (n.layoutPos) {
-            n.x = n.layoutPos.rx * W;
-            n.y = n.layoutPos.ry * H;
+          const p = savedPositions[n.id];
+          if (p) {
+            n.x = p[0];
+            n.y = p[1];
           }
         }
       }
@@ -259,20 +287,16 @@ export default function MindsGraph() {
           });
         }
       }
-      sim = buildSimulation(); // auto-starts at alpha 1, like production
-      if (seenIntro) {
-        // Already seated at targets — run a low-alpha pass so collision/charge
-        // gently de-overlap without a visible flow, instead of a full entrance.
-        sim.alpha(0.25);
-      } else {
-        // First visit: let the entrance play, then remember it so we never
-        // replay it on this device.
-        try {
-          localStorage.setItem(SEEN_KEY, "1");
-        } catch {
-          /* ignore */
-        }
+      sim = buildSimulation();
+      if (savedPositions) {
+        // Return visit: nodes are already at their last settled spots — freeze
+        // the sim so there is ZERO motion (no flow-in, no charge "explosion").
+        // A drag restarts it, and on('end') re-saves the new positions.
+        sim.stop();
       }
+      // First visit: leave the sim running (auto-started at alpha 1) so the
+      // top-left flow-in entrance plays; on('end') then saves the settled
+      // positions for next time.
     })();
 
     // ── Zoom / pan ─────────────────────────────────────────────────────────

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -218,6 +218,9 @@ body {
 .app-layout.sidebar-collapsed .sidebar-minds-link {
   justify-content: center; padding: 8px; margin: 0 8px 4px;
 }
+.app-layout.sidebar-collapsed .sidebar-symposiums-link {
+  justify-content: center; padding: 8px; margin: 0 8px 4px;
+}
 .app-layout.sidebar-collapsed .sidebar-profile .sidebar-label {
   display: none;
 }
@@ -303,6 +306,16 @@ body {
 }
 .sidebar-minds-link:hover { color: var(--text); background: rgba(128,128,128,0.08); }
 .sidebar-minds-link svg { flex-shrink: 0; }
+.sidebar-symposiums-link {
+  margin: 0 12px 8px; padding: 8px 12px;
+  border-radius: 8px;
+  display: flex; align-items: center; gap: 8px;
+  color: var(--text-muted); text-decoration: none;
+  font-size: 13px; font-weight: 500; font-family: 'Libre Baskerville', Georgia, serif;
+  transition: all 0.15s; white-space: nowrap;
+}
+.sidebar-symposiums-link:hover { color: var(--text); background: rgba(128,128,128,0.08); }
+.sidebar-symposiums-link svg { flex-shrink: 0; }
 
 .profile-info {
   display: flex; flex-direction: column; min-width: 0;


### PR DESCRIPTION
Two regressions from my earlier work — fixed:

**1. Sidebar 'Symposiums' was a bare blue link.** Each nav item's styling lives in its own class (`.sidebar-minds-link` etc.); I added the NAV entry without the matching CSS. Added `.sidebar-symposiums-link` + collapsed variant as an exact copy of `.sidebar-minds-link` → aligns with the rest.

**2. The /minds graph exploded from center on every return.** My prior attempt seeded nodes at raw PCA targets then ran the sim at alpha 0.25 — the charge force (-600) shoved them apart = the 'explosion'. Correct model:
- **First visit**: original top-left flow-in entrance; on `'end'` save the **settled** node positions.
- **Every later visit**: restore those exact positions + `sim.stop()` → **zero motion**, exactly where they left it, with the restored pan/zoom. A drag restarts the sim and re-saves on rest.

Frontend-only. Gate on green build; post-deploy: sidebar Symposiums matches the other items; first /minds load flows in, switch away + back = instant, no explosion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)