### PR TITLE
feat(symposiums): topic-grouped card feed

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3579,14 +3579,31 @@ def get_debate_by_slug(slug: str) -> dict[str, Any] | None:
 
 
 def list_debates(limit: int = 200) -> list[dict[str, Any]]:
-    """All published debates (slug + question + recency) — the sitemap + index."""
+    """All published debates (slug + question + topic + participant names) — the
+    /symposiums index + sitemap. Participants come from one batched query over
+    debate_turns (names only, no content), ordered by first appearance."""
     with get_conn() as conn:
         rows = _fetchall(conn, _q(
-            "SELECT slug, question, topic, created_at FROM debates "
+            "SELECT id, slug, question, topic, created_at FROM debates "
             "WHERE status = 'published' AND slug IS NOT NULL "
             "ORDER BY created_at DESC LIMIT ?"
         ), (limit,))
-        return [dict(r) for r in rows]
+        debates = [dict(r) for r in rows]
+        if not debates:
+            return []
+        ids = [d["id"] for d in debates]
+        ph = ",".join(["?"] * len(ids))
+        trows = _fetchall(conn, _q(
+            f"SELECT debate_id, mind_name, MIN(turn_index) AS ord FROM debate_turns "  # noqa: S608 — ph is ?-placeholders
+            f"WHERE debate_id IN ({ph}) GROUP BY debate_id, mind_name ORDER BY ord ASC"
+        ), tuple(ids))
+        by_debate: dict[str, list[str]] = {}
+        for t in trows:
+            by_debate.setdefault(t["debate_id"], []).append(t["mind_name"])
+        for d in debates:
+            d["participants"] = by_debate.get(d["id"], [])
+            d.pop("id", None)  # internal — don't leak into the API payload
+        return debates
 
 
 def list_debates_for_mind(mind_id: str, limit: int = 10) -> list[dict[str, Any]]:

--- a/web/app/symposiums/page.tsx
+++ b/web/app/symposiums/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import SeoColumn from "@/components/seo/SeoColumn";
 import JsonLd from "@/components/seo/JsonLd";
-import { SITE_URL, abs, breadcrumbJsonLd, fetchDebatesList } from "@/lib/seo-mind";
+import { SITE_URL, abs, breadcrumbJsonLd, fetchDebatesList, type DebateListItem } from "@/lib/seo-mind";
+import { mindColor, mindInitials } from "@/lib/minds";
 
 // The symposiums index — the discovery surface for Type-4 multi-mind symposia
 // (the philosophie.ai-style feed). Question-led entries: a sharp question pulls
@@ -66,16 +67,36 @@ export default async function SymposiumsIndexPage() {
       </p>
 
       {debates.length ? (
-        <section className="seo-section">
-          <ul>
-            {debates.map((d) => (
-              <li key={d.slug}>
-                <Link href={`/symposium/${d.slug}`}>{d.question}</Link>
-                {d.topic ? <span className="seo-meta"> · {d.topic}</span> : null}
-              </li>
-            ))}
-          </ul>
-        </section>
+        groupByTopic(debates).map(([topic, items]) => (
+          <section key={topic} className="seo-section">
+            <h2>{topic}</h2>
+            <div className="symposium-grid">
+              {items.map((d) => (
+                <Link key={d.slug} href={`/symposium/${d.slug}`} className="symposium-card">
+                  <div className="symposium-card-q">{d.question}</div>
+                  {d.participants && d.participants.length ? (
+                    <div className="symposium-card-minds">
+                      <span className="symposium-card-avatars">
+                        {d.participants.slice(0, 5).map((name, i) => (
+                          <span
+                            key={i}
+                            className="symposium-card-avatar"
+                            style={{ background: mindColor(name) }}
+                          >
+                            {mindInitials(name)}
+                          </span>
+                        ))}
+                      </span>
+                      <span className="symposium-card-names">
+                        {d.participants.join(", ")}
+                      </span>
+                    </div>
+                  ) : null}
+                </Link>
+              ))}
+            </div>
+          </section>
+        ))
       ) : (
         <section className="seo-section">
           <p>No symposiums yet — check back soon.</p>
@@ -83,4 +104,19 @@ export default async function SymposiumsIndexPage() {
       )}
     </SeoColumn>
   );
+}
+
+/** Group symposiums by topic, preserving first-seen topic order. */
+function groupByTopic(debates: DebateListItem[]): [string, DebateListItem[]][] {
+  const order: string[] = [];
+  const map = new Map<string, DebateListItem[]>();
+  for (const d of debates) {
+    const t = d.topic || "Other";
+    if (!map.has(t)) {
+      map.set(t, []);
+      order.push(t);
+    }
+    map.get(t)!.push(d);
+  }
+  return order.map((t) => [t, map.get(t)!]);
 }

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -421,6 +421,7 @@ export interface DebateListItem {
   question: string;
   topic?: string;
   created_at?: string;
+  participants?: string[];
 }
 
 /** A debate + its ordered turns (GET /api/debates/{slug}); null if absent. */

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -616,6 +616,37 @@ body { background-color: var(--bg-home); }
 .symposium-turn-actions .seo-action { font-size: 12px; padding: 2px 4px; }
 .symposium-hero-actions { margin-top: 16px; }
 
+/* ── /symposiums index — a card feed grouped by topic, not a wall of links. ── */
+.symposium-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 14px; margin-top: 10px;
+}
+.seo-content a.symposium-card {
+  display: flex; flex-direction: column; gap: 14px;
+  padding: 18px 20px; border: 1px solid var(--border); border-radius: 14px;
+  background: var(--bg-chat); text-decoration: none; color: var(--text);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+.seo-content a.symposium-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
+}
+.symposium-card-q { font-size: 17px; font-weight: 650; line-height: 1.36; color: var(--text); }
+.symposium-card-minds { display: flex; align-items: center; gap: 10px; margin-top: auto; }
+.symposium-card-avatars { display: flex; flex-shrink: 0; }
+.symposium-card-avatar {
+  width: 24px; height: 24px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: #fff; font-size: 9px; font-weight: 700; user-select: none;
+  border: 2px solid var(--bg-chat); margin-left: -6px;
+}
+.symposium-card-avatar:first-child { margin-left: 0; }
+.symposium-card-names {
+  font-size: 12px; color: var(--text-muted); line-height: 1.3;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
 /* ── Notable quotes — anchored, indexable quote blocks; each one can be asked
    about directly (quote → prefilled chat), the living-entry differentiator. ── */
 .notable-quotes { list-style: none; padding: 0; margin: 10px 0 0; display: flex; flex-direction: column; gap: 18px; }


### PR DESCRIPTION
The /symposiums index was a flat `<ul>` of blue underlined links — monotonous, no structure. Redesigned:

- **Grouped by topic** (Ethics, Art & Design, …) with a heading per group — domains are scannable, not one long list.
- **Each symposium is a card**: the question (no underline) + participant minds as overlapping colored avatars + names — the multi-voice roster shows what it IS at a glance (philosophie.ai-style feed).
- **Backend**: `list_debates` returns participant names via one batched `debate_turns` query (names only, no content) → cards render avatars with zero extra round-trips.

Frontend + a thin backend field. Gate on green build; post-deploy: /symposiums shows topic groups + avatar cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)