### PR TITLE
fix(minds-graph): persist positions on unmount (no re-flow on return)

### DIFF
--- a/web/components/minds/MindsGraph.tsx
+++ b/web/components/minds/MindsGraph.tsx
@@ -660,6 +660,12 @@ export default function MindsGraph() {
     // ── Cleanup (fixes the legacy listener leak) ───────────────────────────
     return () => {
       disposed = true;
+      // Persist current positions on unmount (switching menus) — NOT only on the
+      // sim's 'end' (which takes ~8s and never fires if you leave sooner). This
+      // is what makes a return visit restore instead of replaying the entrance.
+      // Guard on alpha so a quick bounce during the initial flow doesn't freeze a
+      // half-formed (still-clustered-at-origin) graph for next time.
+      if (!sim || sim.alpha() < 0.4) savePositions();
       if (raf) cancelAnimationFrame(raf);
       sim?.stop();
       sim = null;


### PR DESCRIPTION
The /minds entrance still replayed on **every** menu switch. Root cause: positions were saved only on the sim's `'end'` (~8s decay) or after a drag — if you leave before that, nothing is saved, `savedPositions` stays null, and the next visit reruns the first-time flow.

Fix: also `savePositions()` on **unmount** (menu switch), guarded by `alpha < 0.4` so a quick bounce during the initial flow doesn't freeze a half-formed (still origin-clustered) graph. Return visits then restore + `sim.stop()` → no re-animation.

Frontend, single file. Post-deploy: load /minds (flows in), switch away after a couple seconds + back = instant restore, no flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)