### PR TITLE
feat(symposiums): single-column question stream + topic filter

### DIFF
--- a/web/app/symposiums/page.tsx
+++ b/web/app/symposiums/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import SeoColumn from "@/components/seo/SeoColumn";
 import JsonLd from "@/components/seo/JsonLd";
-import { SITE_URL, abs, breadcrumbJsonLd, fetchDebatesList, type DebateListItem } from "@/lib/seo-mind";
-import { mindColor, mindInitials } from "@/lib/minds";
+import SymposiumsFeed from "@/components/seo/SymposiumsFeed";
+import { SITE_URL, abs, breadcrumbJsonLd, fetchDebatesList } from "@/lib/seo-mind";
 
 // The symposiums index — the discovery surface for Type-4 multi-mind symposia
 // (the philosophie.ai-style feed). Question-led entries: a sharp question pulls
@@ -67,36 +66,7 @@ export default async function SymposiumsIndexPage() {
       </p>
 
       {debates.length ? (
-        groupByTopic(debates).map(([topic, items]) => (
-          <section key={topic} className="seo-section">
-            <h2>{topic}</h2>
-            <div className="symposium-grid">
-              {items.map((d) => (
-                <Link key={d.slug} href={`/symposium/${d.slug}`} className="symposium-card">
-                  <div className="symposium-card-q">{d.question}</div>
-                  {d.participants && d.participants.length ? (
-                    <div className="symposium-card-minds">
-                      <span className="symposium-card-avatars">
-                        {d.participants.slice(0, 5).map((name, i) => (
-                          <span
-                            key={i}
-                            className="symposium-card-avatar"
-                            style={{ background: mindColor(name) }}
-                          >
-                            {mindInitials(name)}
-                          </span>
-                        ))}
-                      </span>
-                      <span className="symposium-card-names">
-                        {d.participants.join(", ")}
-                      </span>
-                    </div>
-                  ) : null}
-                </Link>
-              ))}
-            </div>
-          </section>
-        ))
+        <SymposiumsFeed debates={debates} />
       ) : (
         <section className="seo-section">
           <p>No symposiums yet — check back soon.</p>
@@ -104,19 +74,4 @@ export default async function SymposiumsIndexPage() {
       )}
     </SeoColumn>
   );
-}
-
-/** Group symposiums by topic, preserving first-seen topic order. */
-function groupByTopic(debates: DebateListItem[]): [string, DebateListItem[]][] {
-  const order: string[] = [];
-  const map = new Map<string, DebateListItem[]>();
-  for (const d of debates) {
-    const t = d.topic || "Other";
-    if (!map.has(t)) {
-      map.set(t, []);
-      order.push(t);
-    }
-    map.get(t)!.push(d);
-  }
-  return order.map((t) => [t, map.get(t)!]);
 }

--- a/web/components/seo/SymposiumsFeed.tsx
+++ b/web/components/seo/SymposiumsFeed.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * /symposiums discovery feed. A SINGLE-COLUMN question stream (the question is
+ * the hook → click → read → chat), with top topic chips to filter by interest.
+ * NOT topic-grouped (grouping breaks the "scan questions" flow) and NOT a dense
+ * grid (a grid makes you skim a block instead of reading each question).
+ *
+ * Rendered by a server page that passes all debates in, so the full list is in
+ * the SSR HTML (SEO); the chip filter is the only client concern.
+ */
+import { useState } from "react";
+import Link from "next/link";
+import type { DebateListItem } from "@/lib/seo-mind";
+import { mindColor, mindInitials } from "@/lib/minds";
+
+export default function SymposiumsFeed({ debates }: { debates: DebateListItem[] }) {
+  // Topic chips in first-seen order, "All" first.
+  const topics: string[] = ["All"];
+  for (const d of debates) {
+    const t = d.topic || "Other";
+    if (!topics.includes(t)) topics.push(t);
+  }
+  const [active, setActive] = useState("All");
+  const shown =
+    active === "All" ? debates : debates.filter((d) => (d.topic || "Other") === active);
+
+  return (
+    <>
+      {topics.length > 2 ? (
+        <div className="symposium-filters" role="tablist" aria-label="Filter by topic">
+          {topics.map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`symposium-filter${active === t ? " active" : ""}`}
+              aria-selected={active === t}
+              onClick={() => setActive(t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="symposium-feed">
+        {shown.map((d) => (
+          <Link key={d.slug} href={`/symposium/${d.slug}`} className="symposium-row">
+            <div className="symposium-row-q">{d.question}</div>
+            <div className="symposium-row-meta">
+              {d.participants && d.participants.length ? (
+                <>
+                  <span className="symposium-row-avatars">
+                    {d.participants.slice(0, 5).map((name, i) => (
+                      <span
+                        key={i}
+                        className="symposium-row-avatar"
+                        style={{ background: mindColor(name) }}
+                      >
+                        {mindInitials(name)}
+                      </span>
+                    ))}
+                  </span>
+                  <span className="symposium-row-names">{d.participants.join(", ")}</span>
+                </>
+              ) : null}
+              {d.topic ? <span className="symposium-row-topic">{d.topic}</span> : null}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -616,35 +616,41 @@ body { background-color: var(--bg-home); }
 .symposium-turn-actions .seo-action { font-size: 12px; padding: 2px 4px; }
 .symposium-hero-actions { margin-top: 16px; }
 
-/* ── /symposiums index — a card feed grouped by topic, not a wall of links. ── */
-.symposium-grid {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 14px; margin-top: 10px;
+/* ── /symposiums index — a single-column question stream (the question is the
+   hook), with topic chips to filter. Not grouped, not a grid. ── */
+.symposium-filters { display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 6px; }
+.symposium-filter {
+  padding: 6px 14px; border-radius: 999px; border: 1px solid var(--border);
+  background: transparent; color: var(--text-secondary);
+  font-size: 13px; font-weight: 500; font-family: inherit; cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
-.seo-content a.symposium-card {
-  display: flex; flex-direction: column; gap: 14px;
-  padding: 18px 20px; border: 1px solid var(--border); border-radius: 14px;
-  background: var(--bg-chat); text-decoration: none; color: var(--text);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+.symposium-filter:hover { color: var(--text); border-color: var(--border-strong); }
+.symposium-filter.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.symposium-feed { display: flex; flex-direction: column; }
+.seo-content a.symposium-row {
+  display: flex; flex-direction: column; gap: 12px; padding: 22px 4px;
+  border-bottom: 1px solid var(--border); text-decoration: none; color: var(--text);
+  transition: opacity 0.12s ease;
 }
-.seo-content a.symposium-card:hover {
-  border-color: var(--accent);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
-  transform: translateY(-1px);
-}
-.symposium-card-q { font-size: 17px; font-weight: 650; line-height: 1.36; color: var(--text); }
-.symposium-card-minds { display: flex; align-items: center; gap: 10px; margin-top: auto; }
-.symposium-card-avatars { display: flex; flex-shrink: 0; }
-.symposium-card-avatar {
-  width: 24px; height: 24px; border-radius: 50%;
+.seo-content a.symposium-row:hover .symposium-row-q { color: var(--accent); }
+.symposium-row-q { font-size: 20px; font-weight: 650; line-height: 1.32; color: var(--text); transition: color 0.12s ease; }
+.symposium-row-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.symposium-row-avatars { display: flex; flex-shrink: 0; }
+.symposium-row-avatar {
+  width: 26px; height: 26px; border-radius: 50%;
   display: inline-flex; align-items: center; justify-content: center;
-  color: #fff; font-size: 9px; font-weight: 700; user-select: none;
-  border: 2px solid var(--bg-chat); margin-left: -6px;
+  color: #fff; font-size: 10px; font-weight: 700; user-select: none;
+  border: 2px solid var(--bg-chat); margin-left: -7px;
 }
-.symposium-card-avatar:first-child { margin-left: 0; }
-.symposium-card-names {
-  font-size: 12px; color: var(--text-muted); line-height: 1.3;
+.symposium-row-avatar:first-child { margin-left: 0; }
+.symposium-row-names {
+  font-size: 13px; color: var(--text-secondary); line-height: 1.3; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.symposium-row-topic {
+  flex-shrink: 0; margin-left: auto; font-size: 11px; color: var(--text-muted);
+  padding: 3px 10px; border-radius: 999px; background: var(--bg-sidebar);
 }
 
 /* ── Notable quotes — anchored, indexable quote blocks; each one can be asked


### PR DESCRIPTION
Revisited against the page's core job: /symposiums is a **discovery** surface — a sharp question should hook you → click → read → chat. The previous topic-grouped card **grid** worked against that: grouping broke the scan-questions flow into academic sections, and a multi-column grid makes you skim a block instead of reading each question.

**Now a single-column question stream** (the question is the headline + hook) with **top topic chips** to filter by interest (philosophie.ai-style feed, no grouping). New client `SymposiumsFeed` does only the chip filter; the server page passes all debates so the full list stays in the SSR HTML (SEO intact). Each row = big question + participant avatars/names + a topic pill.

Gate on green build; post-deploy: /symposiums is one readable column of questions with working topic chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)