### PR TITLE
fix(symposiums): question titles big (20px) but light (500)

### DIFF
--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -634,7 +634,7 @@ body { background-color: var(--bg-home); }
   transition: opacity 0.12s ease;
 }
 .seo-content a.symposium-row:hover .symposium-row-q { color: var(--accent); }
-.symposium-row-q { font-size: 18px; font-weight: 500; line-height: 1.4; color: var(--text); transition: color 0.12s ease; }
+.symposium-row-q { font-size: 20px; font-weight: 500; line-height: 1.38; color: var(--text); transition: color 0.12s ease; }
 .symposium-row-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .symposium-row-avatars { display: flex; flex-shrink: 0; }
 .symposium-row-avatar {


### PR DESCRIPTION
The earlier 'too heavy' fix over-corrected — it shrank the font (20→18px) as well as lightening the weight. But 'heavy' = the **weight** (bold), not the size; the question is the page's hook and should stay prominent. Restored **20px**, kept **weight 500** — big but not heavy. One CSS line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)