### PR TITLE
feat(symposium): embed in topic hubs + book pages

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -27,7 +27,7 @@ import {
   bookJsonld,
   breadcrumbJsonld,
 } from "@/lib/seo-book";
-import { fetchTopics } from "@/lib/seo-mind";
+import { fetchTopics, fetchDebatesList } from "@/lib/seo-mind";
 
 // ISR. The EMPTY generateStaticParams() is load-bearing: it opts this dynamic
 // route into the static/ISR path — prerender NONE at build (there are thousands
@@ -115,13 +115,14 @@ export default async function BookLandingPage({ params }: PageProps) {
   if (!data) notFound();
 
   // Enrichment — all independent, all degrade to empty on failure.
-  const [questions, passages, related, overview, topics, readMeta] = await Promise.all([
+  const [questions, passages, related, overview, topics, readMeta, allDebates] = await Promise.all([
     getQuestions(id),
     getSamplePassages(id, 3),
     getRelatedForBook(id),
     getBookOverview(id),
     fetchTopics(),
     getBookReadMeta(id),
+    fetchDebatesList(),
   ]);
   // Author + subtitle for AI books live in the ai_books row (the /read endpoint),
   // NOT the agent meta_json — so they must come from readMeta to match what the
@@ -134,6 +135,11 @@ export default async function BookLandingPage({ params }: PageProps) {
   // "Topic" rail links to a real /topic/{slug} instead of 404'ing on ad-hoc
   // categories like "Business" (→ "Business & Strategy") or junk values.
   const canonicalTopic = canonicalTopicForCategory(data.category, topics);
+  // Symposiums in the book's topic — surfaced as "Related debates" (a topic-
+  // level tie-in, NOT claimed to be about this book), the least-forced link.
+  const relatedDebates = canonicalTopic
+    ? allDebates.filter((d) => d.topic === canonicalTopic).slice(0, 4)
+    : [];
   // Only surface the category in display chrome when it's a real category, not
   // a leaked chat query stored as the category by topic-discovery.
   const cleanCategory = isCleanCategory(data.category) ? data.category : "";
@@ -263,6 +269,18 @@ export default async function BookLandingPage({ params }: PageProps) {
                     {" "}● {m.activity.count} {m.activity.count === 1 ? "chat" : "chats"}
                   </span>
                 ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {relatedDebates.length ? (
+        <div className="seo-rail-card">
+          <h3>Related debates</h3>
+          <ul>
+            {relatedDebates.map((d) => (
+              <li key={d.slug}>
+                <Link href={`/symposium/${d.slug}`}>{d.question}</Link>
               </li>
             ))}
           </ul>

--- a/web/app/topic/[slug]/page.tsx
+++ b/web/app/topic/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import EntityLayout from "@/components/seo/EntityLayout";
 import EntityActions from "@/components/seo/EntityActions";
 import JsonLd from "@/components/seo/JsonLd";
+import SymposiumLinks from "@/components/seo/SymposiumLinks";
 import { ExploreFooter } from "@/components/seo/mind/MindSections";
 import {
   SITE_URL,
@@ -15,6 +16,7 @@ import {
   fetchMinds,
   fetchTopics,
   fetchTopicOverview,
+  fetchDebatesList,
   filterBooksByTopic,
   filterMindsByTopic,
   metaDescription,
@@ -84,15 +86,19 @@ export default async function TopicPage({
   const topic = await resolveTopicSlug(params.slug);
   if (!topic) notFound();
 
-  const [agents, minds, topics, overview] = await Promise.all([
+  const [agents, minds, topics, overview, allDebates] = await Promise.all([
     fetchAgents(),
     fetchMinds(),
     fetchTopics(),
     fetchTopicOverview(params.slug),
+    fetchDebatesList(),
   ]);
 
   const books = filterBooksByTopic(agents, topic, 30);
   const topicMinds = filterMindsByTopic(minds, topic, 12);
+  // Symposiums belonging to this topic — a natural fit (the symposium's topic
+  // IS this hub), unlike the weaker book-page tie-in.
+  const topicDebates = allDebates.filter((d) => d.topic === topic);
 
   const canonical = abs(`/topic/${params.slug}`);
 
@@ -194,6 +200,13 @@ export default async function TopicPage({
               </li>
             ))}
           </ul>
+        </section>
+      ) : null}
+
+      {topicDebates.length ? (
+        <section className="seo-section">
+          <h2>Great minds debate {topic}</h2>
+          <SymposiumLinks debates={topicDebates} limit={8} />
         </section>
       ) : null}
 

--- a/web/components/seo/SymposiumLinks.tsx
+++ b/web/components/seo/SymposiumLinks.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { mindColor, mindInitials } from "@/lib/minds";
+import type { DebateListItem } from "@/lib/seo-mind";
+
+/**
+ * Compact symposium list for embedding in other entity pages (topic hub, book
+ * detail). Each row: the question + a few participant avatars. Server component
+ * (pure render) — the host page fetches + filters the debates by topic.
+ */
+export default function SymposiumLinks({
+  debates,
+  limit = 6,
+}: {
+  debates: DebateListItem[];
+  limit?: number;
+}) {
+  const items = debates.slice(0, limit);
+  if (!items.length) return null;
+  return (
+    <ul className="symposium-links">
+      {items.map((d) => (
+        <li key={d.slug}>
+          <Link href={`/symposium/${d.slug}`} className="symposium-link">
+            <span className="symposium-link-q">{d.question}</span>
+            {d.participants && d.participants.length ? (
+              <span className="symposium-link-avatars">
+                {d.participants.slice(0, 4).map((n, i) => (
+                  <span
+                    key={i}
+                    className="symposium-link-avatar"
+                    style={{ background: mindColor(n) }}
+                  >
+                    {mindInitials(n)}
+                  </span>
+                ))}
+              </span>
+            ) : null}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -653,6 +653,25 @@ body { background-color: var(--bg-home); }
   padding: 3px 10px; border-radius: 999px; background: var(--bg-sidebar);
 }
 
+/* ── Compact symposium list embedded in topic / book pages. ── */
+.symposium-links { list-style: none; padding: 0; margin: 8px 0 0; }
+.seo-content a.symposium-link {
+  display: flex; align-items: center; justify-content: space-between; gap: 14px;
+  padding: 13px 4px; border-bottom: 1px solid var(--border);
+  text-decoration: none; color: var(--text);
+}
+.symposium-links li:last-child .symposium-link { border-bottom: none; }
+.symposium-link-q { font-size: 15px; font-weight: 500; line-height: 1.35; }
+.seo-content a.symposium-link:hover .symposium-link-q { color: var(--accent); }
+.symposium-link-avatars { display: flex; flex-shrink: 0; }
+.symposium-link-avatar {
+  width: 22px; height: 22px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: #fff; font-size: 9px; font-weight: 700; user-select: none;
+  border: 2px solid var(--bg-chat); margin-left: -6px;
+}
+.symposium-link-avatar:first-child { margin-left: 0; }
+
 /* ── Notable quotes — anchored, indexable quote blocks; each one can be asked
    about directly (quote → prefilled chat), the living-entry differentiator. ── */
 .notable-quotes { list-style: none; padding: 0; margin: 10px 0 0; display: flex; flex-direction: column; gap: 18px; }


### PR DESCRIPTION
Per the decision (topic + book, with book honestly framed as 'related'):

- **Topic page** — a **'Great minds debate {topic}'** section listing symposiums whose topic IS this hub (natural fit), with participant avatars via a new shared `SymposiumLinks` component. Strengthens the topic↔symposium graph.
- **Book page** — a rail **'Related debates'** card = symposiums in the book's canonical topic. Framed as topic-level *related*, NOT 'about this book' (the only honest link is shared topic). Simple link list in the narrow rail, matching its siblings.

Both reuse `fetchDebatesList` (already returns topic + participants), filtered in-page. Frontend-only. Gate on green build; post-deploy: a topic hub with symposiums shows the section; a book in that topic shows the rail card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)