### PR TITLE
fix(symposium): sensitive-figure blacklist + on-domain casting guard

### DIFF
--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -286,32 +286,33 @@ def _topic_questions(topic: str, n: int) -> list[str]:
     return _json_list(res.content or "")[:n]
 
 
-def _topic_match_strict(domain: str, topic: str) -> bool:
-    """WHOLE-WORD topic↔domain match (vs is_mind_topic_relevant's substring,
-    which lets 'Art' match 'Artificial Intelligence' → AI folks polluting the Art
-    casting pool). Casting wants precision over recall, so: a topic word (≥4
-    chars) must appear as a whole word (or simple plural) in the domain."""
-    domain = (domain or "").lower()
-    if not domain:
-        return False
-    dwords = set(re.split(r"[,\s&/;()]+", domain))
-    for tw in re.split(r"[,\s&]+", topic.lower()):
-        if len(tw) < 4 or tw == "design":
-            continue
-        if tw in dwords or (tw + "s") in dwords or tw.rstrip("s") in dwords:
-            return True
-    return False
+# Cross-domain false matches from is_mind_topic_relevant's substring matching:
+# 'Art' (in 'Art & Design') matches 'Artificial Intelligence', dragging every AI
+# researcher into the Art pool. Keep the loose match's recall (painter/sculptor/
+# etc. lack a literal 'art' token), but exclude these specific collisions.
+_TOPIC_EXCLUDE_DOMAINS: dict[str, tuple[str, ...]] = {
+    "art & design": ("artificial", "computer", "machine learning", "neural"),
+}
 
 
 def _candidates_for_topic(topic: str, limit: int = 24) -> list[dict[str, Any]]:
     """Famous, topic-relevant minds as the casting pool (name + domain suffice;
-    persona is fetched per-pick later). Whole-word match + sensitive filter."""
+    persona is fetched per-pick later). Loose topic match for recall, minus the
+    sensitive list and known cross-domain substring collisions."""
     from .db import list_minds
+    from .qa import is_mind_topic_relevant
     minds = list_minds(limit=5000, lite=True)
-    rel = [
-        m for m in minds
-        if _topic_match_strict(m.get("domain", ""), topic) and not _is_sensitive(m.get("name", ""))
-    ]
+    bad = _TOPIC_EXCLUDE_DOMAINS.get(topic.lower(), ())
+
+    def ok(m: dict[str, Any]) -> bool:
+        if _is_sensitive(m.get("name", "")):
+            return False
+        if not is_mind_topic_relevant(m, topic):
+            return False
+        dom = (m.get("domain") or "").lower()
+        return not (bad and any(b in dom for b in bad))
+
+    rel = [m for m in minds if ok(m)]
     rel.sort(key=lambda m: -(m.get("chat_count") or 0))
     return rel[:limit]
 

--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -232,10 +232,31 @@ def _qgen_prompt(topic: str, n: int) -> str:
     )
 
 
+# Never cast as a debater — figures known mainly for political power or for
+# atrocities make "what would X argue" read as apologia, not philosophy (cf. the
+# mind /q guard). Matched case-insensitively as a substring of the name.
+_SENSITIVE_DEBATERS = {
+    "mao zedong", "adolf hitler", "joseph stalin", "vladimir lenin",
+    "benito mussolini", "pol pot", "kim il-sung", "kim jong", "saddam hussein",
+    "muammar gaddafi", "ruhollah khomeini", "yasser arafat", "francisco franco",
+    "augusto pinochet", "idi amin", "hirohito", "hideki tojo", "che guevara",
+    "fidel castro", "slobodan milosevic",
+}
+
+
+def _is_sensitive(name: str) -> bool:
+    low = (name or "").lower()
+    return any(s in low for s in _SENSITIVE_DEBATERS)
+
+
 _CAST_SYSTEM = (
     "You cast participants for a symposium. You pick the thinkers who will produce a "
     "genuine intellectual CLASH — opposing schools or positions, each with a real "
-    "stake — never four who'd just nod along."
+    "stake — never four who'd just nod along. Two hard rules: (1) every pick's OWN "
+    "field must genuinely cover the question — exclude anyone whose tie is tangential "
+    "(e.g. a scientist on an art question, a politician on a metaphysics question); "
+    "(2) never pick a figure known mainly for wielding political power or for "
+    "historical atrocities."
 )
 
 
@@ -243,8 +264,10 @@ def _cast_prompt(question: str, roster: str, n: int) -> str:
     return (
         f'Question: "{question}"\n\n'
         f"Candidate thinkers (name — domain):\n{roster}\n\n"
-        f"Pick the {n} who would produce the deepest, most genuine disagreement on "
-        "THIS question — opposing positions, not allies. Use names EXACTLY as listed.\n"
+        f"Pick the {n} whose OWN expertise genuinely covers this question and who "
+        "would produce the deepest, most genuine disagreement — opposing positions, "
+        "not allies. Drop anyone whose connection is tangential. Use names EXACTLY as "
+        "listed.\n"
         'Return STRICT JSON only: ["Name", ...]'
     )
 
@@ -269,7 +292,7 @@ def _candidates_for_topic(topic: str, limit: int = 24) -> list[dict[str, Any]]:
     from .db import list_minds
     from .qa import is_mind_topic_relevant
     minds = list_minds(limit=5000, lite=True)
-    rel = [m for m in minds if is_mind_topic_relevant(m, topic)]
+    rel = [m for m in minds if is_mind_topic_relevant(m, topic) and not _is_sensitive(m.get("name", ""))]
     rel.sort(key=lambda m: -(m.get("chat_count") or 0))
     return rel[:limit]
 
@@ -277,7 +300,37 @@ def _candidates_for_topic(topic: str, limit: int = 24) -> list[dict[str, Any]]:
 def _pick_debaters(question: str, candidates: list[dict[str, Any]], n: int = 4) -> list[str]:
     roster = "\n".join(f"- {m['name']} — {(m.get('domain') or '')[:48]}" for m in candidates)
     res, _ = bulk_chat(system=_CAST_SYSTEM, user=_cast_prompt(question, roster, n))
-    return _json_list(res.content or "")[:n]
+    # Belt-and-suspenders: drop any sensitive figure the model still returned.
+    return [p for p in _json_list(res.content or "") if not _is_sensitive(p)][:n]
+
+
+def regenerate_debate(slug: str, rounds: int = 2) -> str | None:
+    """Re-cast + re-generate one existing symposium in place (same question +
+    topic + slug), e.g. to replace a tangential or sensitive debater. Deletes the
+    old turns only after the new ones generate. Returns the slug or None."""
+    from .db import get_debate_by_slug
+    d = get_debate_by_slug(slug)
+    if not d:
+        return None
+    q, topic = d["question"], d.get("topic") or ""
+    cands = _candidates_for_topic(topic)
+    minds, seen = [], set()
+    for nm in _pick_debaters(q, cands, 4):
+        m = get_mind_by_name(nm)
+        if m and m.get("persona") and m["id"] not in seen:
+            minds.append(m)
+            seen.add(m["id"])
+    if len(minds) < 2:
+        return None
+    turns = generate_debate(q, minds, rounds=rounds)
+    if len(turns) < 2:
+        return None
+    delete_debate_by_question(q)
+    nd = create_debate(q, topic, [t["mind"]["id"] for t in turns])
+    for t in turns:
+        add_debate_turn(nd["id"], t["mind"]["id"], t["mind"]["name"], t["turn_index"], t["content"])
+    log.info("regenerated symposium %r → %s (%d turns)", q, nd["slug"], len(turns))
+    return nd["slug"]
 
 
 def expand_symposiums(

--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -286,33 +286,41 @@ def _topic_questions(topic: str, n: int) -> list[str]:
     return _json_list(res.content or "")[:n]
 
 
-# Cross-domain false matches from is_mind_topic_relevant's substring matching:
-# 'Art' (in 'Art & Design') matches 'Artificial Intelligence', dragging every AI
-# researcher into the Art pool. Keep the loose match's recall (painter/sculptor/
-# etc. lack a literal 'art' token), but exclude these specific collisions.
-_TOPIC_EXCLUDE_DOMAINS: dict[str, tuple[str, ...]] = {
-    "art & design": ("artificial", "computer", "machine learning", "neural"),
+# Casting must use WHOLE-WORD topic↔domain matching: the substring match in
+# is_mind_topic_relevant let 'art' (from 'Art & Design') hit 'artificial',
+# 'startup', 'wartime' — flooding the Art pool with AI/VC/politics people.
+# Artists' domains rarely contain the literal word 'art', so Art & Design gets a
+# curated synonym set on top of whole-word matching.
+_TOPIC_EXTRA_WORDS: dict[str, set[str]] = {
+    "art & design": {
+        "art", "arts", "artist", "artistic", "painting", "painter", "sculpture",
+        "sculptor", "aesthetics", "aesthetic", "visual", "architecture", "architect",
+    },
 }
+
+
+def _topic_match(domain: str, topic: str) -> bool:
+    dwords = set(re.split(r"[,\s&/;()\-]+", (domain or "").lower()))
+    if not dwords:
+        return False
+    words = {w for w in re.split(r"[,\s&]+", topic.lower()) if len(w) >= 4 and w != "design"}
+    words |= _TOPIC_EXTRA_WORDS.get(topic.lower(), set())
+    for tw in words:
+        if tw in dwords or (tw + "s") in dwords or tw.rstrip("s") in dwords:
+            return True
+    return False
 
 
 def _candidates_for_topic(topic: str, limit: int = 24) -> list[dict[str, Any]]:
     """Famous, topic-relevant minds as the casting pool (name + domain suffice;
-    persona is fetched per-pick later). Loose topic match for recall, minus the
-    sensitive list and known cross-domain substring collisions."""
+    persona is fetched per-pick later). Whole-word match (no substring
+    collisions) + sensitive filter."""
     from .db import list_minds
-    from .qa import is_mind_topic_relevant
     minds = list_minds(limit=5000, lite=True)
-    bad = _TOPIC_EXCLUDE_DOMAINS.get(topic.lower(), ())
-
-    def ok(m: dict[str, Any]) -> bool:
-        if _is_sensitive(m.get("name", "")):
-            return False
-        if not is_mind_topic_relevant(m, topic):
-            return False
-        dom = (m.get("domain") or "").lower()
-        return not (bad and any(b in dom for b in bad))
-
-    rel = [m for m in minds if ok(m)]
+    rel = [
+        m for m in minds
+        if _topic_match(m.get("domain", ""), topic) and not _is_sensitive(m.get("name", ""))
+    ]
     rel.sort(key=lambda m: -(m.get("chat_count") or 0))
     return rel[:limit]
 

--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -286,13 +286,32 @@ def _topic_questions(topic: str, n: int) -> list[str]:
     return _json_list(res.content or "")[:n]
 
 
+def _topic_match_strict(domain: str, topic: str) -> bool:
+    """WHOLE-WORD topic↔domain match (vs is_mind_topic_relevant's substring,
+    which lets 'Art' match 'Artificial Intelligence' → AI folks polluting the Art
+    casting pool). Casting wants precision over recall, so: a topic word (≥4
+    chars) must appear as a whole word (or simple plural) in the domain."""
+    domain = (domain or "").lower()
+    if not domain:
+        return False
+    dwords = set(re.split(r"[,\s&/;()]+", domain))
+    for tw in re.split(r"[,\s&]+", topic.lower()):
+        if len(tw) < 4 or tw == "design":
+            continue
+        if tw in dwords or (tw + "s") in dwords or tw.rstrip("s") in dwords:
+            return True
+    return False
+
+
 def _candidates_for_topic(topic: str, limit: int = 24) -> list[dict[str, Any]]:
     """Famous, topic-relevant minds as the casting pool (name + domain suffice;
-    persona is fetched per-pick later)."""
+    persona is fetched per-pick later). Whole-word match + sensitive filter."""
     from .db import list_minds
-    from .qa import is_mind_topic_relevant
     minds = list_minds(limit=5000, lite=True)
-    rel = [m for m in minds if is_mind_topic_relevant(m, topic) and not _is_sensitive(m.get("name", ""))]
+    rel = [
+        m for m in minds
+        if _topic_match_strict(m.get("domain", ""), topic) and not _is_sensitive(m.get("name", ""))
+    ]
     rel.sort(key=lambda m: -(m.get("chat_count") or 0))
     return rel[:limit]
 


### PR DESCRIPTION
The audit surfaced bad LLM casts: **Mao Zedong** in an ethics symposium (power/atrocity figure → apologia), and **Hinton in aesthetics / Churchill in 'art's role' / Beethoven in literature** (tangential domains — in the pool because `is_mind_topic_relevant` matches loosely + fame sorts them up). The casting had no guards. Fixes:

- **`_SENSITIVE_DEBATERS` blacklist** — filtered from the candidate pool AND a second pass on the LLM's picks (belt-and-suspenders); power/atrocity figures never cast.
- **`_CAST_SYSTEM`/`_cast_prompt`** now hard-require each pick's OWN field to cover the question (drop tangential ties).
- **`regenerate_debate(slug)`** — re-cast + re-generate one symposium in place; used to fix the 6 flagged existing ones in prod.

Backend-only. Gate on green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)