### PR TITLE
fix(symposium): capitalize question titles + lighten feed font

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3527,8 +3527,15 @@ def get_mind_by_name(name: str) -> dict[str, Any] | None:
 
 
 def create_debate(question: str, topic: str, mind_ids: list[str]) -> dict[str, Any]:
-    """Insert a debate shell (turns added separately). Returns {id, slug}."""
+    """Insert a debate shell (turns added separately). Returns {id, slug}.
+
+    Capitalize the question's first letter so the title reads correctly in
+    every surface it renders — feed, <h1>, <title>, OG card, JSON-LD, sitemap.
+    CSS can't reach the SEO surfaces, so normalize once at the data layer."""
     did = str(uuid.uuid4())
+    question = (question or "").strip()
+    if question:
+        question = question[0].upper() + question[1:]
     with get_conn() as conn:
         slug = _unique_slug(conn, "debates", question[:60]) or did[:8]
         _execute(conn, _q(
@@ -3550,7 +3557,7 @@ def delete_debate_by_question(question: str) -> None:
     """Remove a debate + its turns by question (no FK, so cascade by hand).
     Lets the generator re-run a seed with deeper/longer rounds (force mode)."""
     with get_conn() as conn:
-        rows = _fetchall(conn, _q("SELECT id FROM debates WHERE question = ?"), (question,))
+        rows = _fetchall(conn, _q("SELECT id FROM debates WHERE LOWER(question) = LOWER(?)"), (question,))
         for r in rows:
             _execute(conn, _q("DELETE FROM debate_turns WHERE debate_id = ?"), (r["id"],))
             _execute(conn, _q("DELETE FROM debates WHERE id = ?"), (r["id"],))
@@ -3622,7 +3629,9 @@ def list_debates_for_mind(mind_id: str, limit: int = 10) -> list[dict[str, Any]]
 def debate_question_exists(question: str) -> bool:
     """Idempotency guard for the generator — skip a question already debated."""
     with get_conn() as conn:
-        row = _fetchone(conn, _q("SELECT 1 AS hit FROM debates WHERE question = ?"), (question,))
+        # Case-insensitive: create_debate stores a capitalized question, but the
+        # generator checks idempotency with the raw (often lowercase) candidate.
+        row = _fetchone(conn, _q("SELECT 1 AS hit FROM debates WHERE LOWER(question) = LOWER(?)"), (question,))
         return bool(row)
 
 

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -634,7 +634,7 @@ body { background-color: var(--bg-home); }
   transition: opacity 0.12s ease;
 }
 .seo-content a.symposium-row:hover .symposium-row-q { color: var(--accent); }
-.symposium-row-q { font-size: 20px; font-weight: 500; line-height: 1.38; color: var(--text); transition: color 0.12s ease; }
+.symposium-row-q { font-size: 18px; font-weight: 500; line-height: 1.4; color: var(--text); transition: color 0.12s ease; }
 .symposium-row-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .symposium-row-avatars { display: flex; flex-shrink: 0; }
 .symposium-row-avatar {


### PR DESCRIPTION
## What
Two small symposium-title fixes from Steve's review.

**1. Titles were lowercase-leading** ("is morality discovered or invented?"). The question text was stored lowercase and rendered verbatim, so *every* surface showed a lowercase title — feed, `<h1>`, `<title>`, OG card, JSON-LD, sitemap. CSS (`::first-letter`) can't reach the SEO surfaces, so this is fixed at the **data layer**:
- `create_debate` capitalizes the first letter on write.
- `debate_question_exists` + `delete_debate_by_question` are now **case-insensitive** (`LOWER(question) = LOWER(?)`), so a lowercase candidate still dedupes against the capitalized stored row — no duplicate generation.
- Backfilled the **33** lowercase-leading rows in prod (the other 27 seeds were already capitalized).

**2. Feed question font 20px → 18px.** In the single-column `/symposiums` stream the question is a *list item*, and 20px was oversized. Weight stays **500** (not heavier — keeps the "big but not heavy" intent). The detail-page `<h1>` stays 34px since it's that page's main title.

## Surfaces fixed by the data normalization
Feed · detail `<h1>` · `<title>` · OG share card · JSON-LD · sitemap — all now read with a capitalized title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)