### PR TITLE
refactor(symposium): trim detail-page lede

### DIFF
--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -137,11 +137,12 @@ export default async function SymposiumPage({
           <span>{joinLabel} in conversation</span>
         </div>
       </div>
-      {/* Lede — tells a cold visitor exactly what this page is + why it's unique. */}
+      {/* Lede — tells a cold visitor what this page is + invites them to chat.
+          Boilerplate-light (no "A symposium:" prefix — the eyebrow already says
+          it; no marketing line) since it repeats across every symposium page. */}
       <p className="symposium-lede">
-        A <strong>symposium</strong>: {participants.length} great minds take up one
-        question — each argues in their own voice and answers the others. It&apos;s
-        a living exchange you won&apos;t find anywhere else — read it, then chat with
+        {participants.length} great minds take up one question — each argues in
+        their own voice and answers the others. Read the exchange, then chat with
         any of them yourself.
       </p>
       <div className="symposium-hero-actions">


### PR DESCRIPTION
## Why
The detail-page lede was **identical across all 60 symposium pages**:

> A **symposium**: 4 great minds take up one question — each argues in their own voice and answers the others. It's a living exchange you won't find anywhere else — read it, then chat with any of them yourself.

That kind of word-for-word repeated block is precisely the templated-content signal we've been removing everywhere else (de-templated /q). It also led with a marketing line ("you won't find anywhere else").

## Change
- Drop the redundant **"A symposium:"** prefix — the eyebrow already reads `{Topic} · Symposium`.
- Drop the **marketing line**.
- Keep a single boilerplate-light line that still orients a cold visitor + invites the chat:

> 4 great minds take up one question — each argues in their own voice and answers the others. Read the exchange, then chat with any of them yourself.

The page's real unique content is the cross-referencing transcript below — the lede is just orientation, so it stays short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)