### PR TITLE
fix(symposium): align /symposiums filter chips with Library

### DIFF
--- a/web/components/seo/SymposiumsFeed.tsx
+++ b/web/components/seo/SymposiumsFeed.tsx
@@ -33,7 +33,7 @@ export default function SymposiumsFeed({ debates }: { debates: DebateListItem[] 
             <button
               key={t}
               type="button"
-              className={`symposium-filter${active === t ? " active" : ""}`}
+              className={`topic-tag${active === t ? " active" : ""}`}
               aria-selected={active === t}
               onClick={() => setActive(t)}
             >

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -619,14 +619,9 @@ body { background-color: var(--bg-home); }
 /* ── /symposiums index — a single-column question stream (the question is the
    hook), with topic chips to filter. Not grouped, not a grid. ── */
 .symposium-filters { display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 6px; }
-.symposium-filter {
-  padding: 6px 14px; border-radius: 999px; border: 1px solid var(--border);
-  background: transparent; color: var(--text-secondary);
-  font-size: 13px; font-weight: 500; font-family: inherit; cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-}
-.symposium-filter:hover { color: var(--text); border-color: var(--border-strong); }
-.symposium-filter.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+/* Chips reuse Library's .topic-tag verbatim (same pill, same BLACK active state)
+   so the two filter bars stay identical — only the container layout above is
+   symposium-specific. Don't reintroduce a .symposium-filter class; it drifts. */
 .symposium-feed { display: flex; flex-direction: column; }
 .seo-content a.symposium-row {
   display: flex; flex-direction: column; gap: 12px; padding: 22px 4px;


### PR DESCRIPTION
## Symptom (Steve's screenshots)
The topic-filter chips on **/symposiums** have a **blue** active state, while **Library**'s filter chips have a **black** active state — the two filter bars don't match.

## Root cause
`/symposiums` maintained its own `.symposium-filter` class:
- active: `var(--accent)` (blue) vs Library `.topic-tag.active` → `var(--btn-solid-bg)` (black)
- plus drift in padding (6/14 vs 7/16), border color, base text color

Two classes for the same UI element → guaranteed drift (same root cause as the earlier sidebar-link mismatch).

## Fix
Reuse Library's `.topic-tag` **verbatim** for the chips (identical pill + **black** active state). Keep only the symposium-specific container `.symposium-filters` for layout. Deleted the `.symposium-filter` rules so they can't drift again.

One source of truth: if Library's chip style changes, /symposiums follows automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)