### PR TITLE
feat(symposium): "Join this discussion" — symposium → live multi-mind chat

### DIFF
--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import EntityLayout from "@/components/seo/EntityLayout";
 import JsonLd from "@/components/seo/JsonLd";
 import ShareButton from "@/components/share/ShareButton";
+import JoinDiscussionButton from "@/components/symposium/JoinDiscussionButton";
 import {
   SITE_URL,
   abs,
@@ -146,6 +147,11 @@ export default async function SymposiumPage({
         any of them yourself.
       </p>
       <div className="symposium-hero-actions">
+        <JoinDiscussionButton
+          question={d.question}
+          participants={participants}
+          turns={d.turns}
+        />
         <ShareButton
           url={canonical}
           title={d.question}

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -75,6 +75,9 @@ interface PendingChat {
   message: string;
   books?: SelectedBook[];
   minds?: SelectedMind[];
+  // Symposium "join": the prior debate, replayed into the first panel round's
+  // history so the invited minds continue it (consumed once; see seedHistoryRef).
+  seedHistory?: { role: string; content: string }[];
 }
 
 /** True if a first-message handoff for this session is waiting (without
@@ -222,6 +225,9 @@ export default function ChatView({
   // effect below. Pro / open-source users are unaffected (the gate only reads
   // it when !isProUser).
   const invitedOnceRef = useRef(false);
+  // Symposium "join" handoff: the prior debate, injected into the FIRST panel
+  // round's history (consumed once) so the minds pick up where it left off.
+  const seedHistoryRef = useRef<{ role: string; content: string }[] | null>(null);
   const [sending, setSending] = useState(false);
   const [mindsBusy, setMindsBusy] = useState(false);
   const [consent, setConsent] = useState<ConsentState>(null);
@@ -495,6 +501,10 @@ export default function ChatView({
         return m && joinedNames.includes(m.name);
       });
       let responses: MindResponse[] = [];
+      // Symposium "join" replays the prior debate into the FIRST round's history
+      // (consumed once); later rounds carry context via baseMsgs as usual.
+      const seed = seedHistoryRef.current;
+      if (seed) seedHistoryRef.current = null;
       try {
         responses = await panelChat({
           message,
@@ -502,7 +512,7 @@ export default function ChatView({
           invitedMindIds: invitedIds.length ? invitedIds : undefined,
           bookContext: bookCtx.length ? bookCtx : undefined,
           agentIds: agentIds.length ? agentIds : undefined,
-          history: buildPanelHistory(baseMsgs),
+          history: seed ? [...seed, ...buildPanelHistory(baseMsgs)] : buildPanelHistory(baseMsgs),
           targetMinds: targetMinds?.length ? targetMinds : undefined,
         });
       } catch (e) {
@@ -976,6 +986,8 @@ export default function ChatView({
     const seededMinds = new Map((pending.minds || []).map((m) => [m.id, m]));
     if (seededBooks.size) setBooks(seededBooks);
     if (seededMinds.size) setMinds(seededMinds);
+    // Symposium "join": stash the prior debate so the first panel round carries it.
+    if (pending.seedHistory?.length) seedHistoryRef.current = pending.seedHistory;
     // …and pass them as overrides so the send uses them without waiting for the
     // setBooks/setMinds state updates to commit.
     handleSend(pending.message, { books: seededBooks, minds: seededMinds });

--- a/web/components/symposium/JoinDiscussionButton.tsx
+++ b/web/components/symposium/JoinDiscussionButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * "Join this discussion" — the symposium → live multi-mind chat bridge.
+ *
+ * Turns a read-only symposium into the core minds-join experience: creates a
+ * chat session, pre-selects the symposium's participants as mind chips, and
+ * replays the prior debate as panel-chat history (seedHistory) so the minds pick
+ * up where the page left off. Reuses the home-composer handoff channel
+ * (feynman:pendingChat) — ChatView reads it on mount, seeds the chips + history,
+ * and sends the question. Gated by the signin→Pro double wall (useProGate), like
+ * every minds chat.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createSession } from "@/lib/chat";
+import { useProGate } from "@/components/pro/ProOverlay";
+
+const PENDING_KEY = "feynman:pendingChat";
+
+interface Participant {
+  mind_id: string;
+  mind_name: string;
+}
+interface Turn {
+  mind_name: string;
+  content: string;
+}
+
+export default function JoinDiscussionButton({
+  question,
+  participants,
+  turns,
+}: {
+  question: string;
+  participants: Participant[];
+  turns: Turn[];
+}) {
+  const router = useRouter();
+  const { requirePro } = useProGate();
+  const [busy, setBusy] = useState(false);
+
+  async function join() {
+    if (busy) return;
+    // signin→Pro double wall (by design): anon → /login, free → upgrade overlay,
+    // pro → proceed. requirePro() with no action returns true only for pro users.
+    if (!requirePro()) return;
+    setBusy(true);
+    try {
+      const minds = participants
+        .filter((p) => p.mind_id)
+        .map((p) => ({ id: p.mind_id, name: p.mind_name }));
+      // The prior debate, in the same "[Name]: …" shape buildPanelHistory emits,
+      // so the minds continue the symposium instead of starting cold.
+      const seedHistory = turns
+        .filter((t) => t.content)
+        .map((t) => ({ role: "assistant", content: `[${t.mind_name}]: ${t.content}` }));
+      const session = await createSession({ title: question, sessionType: "chat" });
+      sessionStorage.setItem(
+        PENDING_KEY,
+        JSON.stringify({ sessionId: session.id, message: question, minds, seedHistory }),
+      );
+      router.push(`/chat/${session.id}`);
+    } catch {
+      setBusy(false); // stay on the page; the user can retry
+    }
+  }
+
+  return (
+    <button type="button" className="symposium-join-cta" onClick={join} disabled={busy}>
+      {busy ? "Opening…" : "Join this discussion"}
+    </button>
+  );
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -614,7 +614,20 @@ body { background-color: var(--bg-home); }
 .seo-content a.symposium-chat-link:hover { opacity: 0.8; }
 /* Compact share button inside a turn (override the default seo-action sizing). */
 .symposium-turn-actions .seo-action { font-size: 12px; padding: 2px 4px; }
-.symposium-hero-actions { margin-top: 16px; }
+.symposium-hero-actions { margin-top: 16px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+/* Primary CTA — "Join this discussion" (symposium → live multi-mind chat). Black
+   solid like the site's primary button + .topic-tag.active, so it reads as THE
+   action; Share sits beside it as secondary. */
+.symposium-join-cta {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 9px 18px; border-radius: 999px;
+  background: var(--btn-solid-bg); color: var(--btn-solid-color);
+  border: 1px solid var(--btn-solid-bg);
+  font-size: 14px; font-weight: 600; font-family: inherit; cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+.symposium-join-cta:hover { opacity: 0.88; }
+.symposium-join-cta:disabled { opacity: 0.55; cursor: default; }
 
 /* ── /symposiums index — a single-column question stream (the question is the
    hook), with topic chips to filter. Not grouped, not a grid. ── */


### PR DESCRIPTION
## Phase 1 of user-initiated discussions
Turns a read-only symposium into the core **minds-join** experience. The detail page gets a primary CTA **"Join this discussion"** that:
1. creates a chat session,
2. pre-selects the symposium's participants as mind **chips**,
3. replays the prior debate as panel-chat **history** (so the minds continue where the page left off),

then the reader asks their own follow-ups and can invite more minds (the existing `MindsPopover` + consent flow).

## Maximally reuses existing machinery (no new backend)
- **`pendingChat` handoff** (`feynman:pendingChat`) already pre-seeds chips + sends the first message — added an optional `seedHistory` field carrying the debate.
- **`ChatView.runPanel`** injects `seedHistory` into the FIRST panel round's history (consumed once); later rounds carry context via the transcript as usual.
- **Pro double wall** via `useProGate` (anon → `/login`, free → upgrade overlay) — the minds-chat gate is unchanged **by design**.
- CTA uses the site's solid primary button (matches `.topic-tag.active`).

Matches the user's choices: multi-mind continue + debate summary as context.

## Verification
`tsc --noEmit` clean on changed files. End-to-end (click → chat → minds reply) needs a Pro-signed-in session (manual).

## Follow-ups (separate PRs)
- Home-composer "start a discussion" entry point (create-topic-from-scratch).
- **Phase 2**: publish a user's live discussion as a public symposium page (UGC + review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)