### PR TITLE
feat(home): surface the multi-mind debate path in the composer

### DIFF
--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -366,9 +366,11 @@ export default function HomeComposer() {
 
   const hasContext = books.size > 0 || minds.size > 0;
   const placeholder = hasContext
-    ? minds.size
-      ? "Ask your question... Type @ to mention a mind"
-      : "Ask your question..."
+    ? minds.size >= 2
+      ? "Pose a question — they'll debate it. Type @ to mention a mind"
+      : minds.size
+        ? "Ask your question... Type @ to mention a mind"
+        : "Ask your question..."
     : "Ask about books or topics — great minds will join in...";
 
   return (
@@ -500,6 +502,20 @@ export default function HomeComposer() {
       </div>
 
       <div className="home-starters" id="home-starters">
+        {/* Surface the multi-mind path explicitly: a debate is just this composer
+            with 2+ minds invited, but most people won't discover that. From the
+            empty state, this pill opens the invite popover; the placeholder then
+            nudges "pose a question — they'll debate it". */}
+        {!hasContext ? (
+          <button
+            type="button"
+            className="starter-pill starter-pill-debate"
+            onClick={() => setMindsOpen(true)}
+            title="Invite 2+ great minds and they'll debate your question"
+          >
+            Start a debate between great minds
+          </button>
+        ) : null}
         {starters.map((q) => (
           <button key={q} type="button" className="starter-pill" onClick={() => pickStarter(q)}>
             {q}

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -691,6 +691,11 @@ body {
   border-color: var(--accent); color: var(--accent);
   box-shadow: var(--shadow-sm);
 }
+/* "Start a debate" — surfaces the multi-mind path from the empty state. Accent
+   outline so it reads as the lead suggestion; fills in on hover. Opens the
+   invite-minds popover (not a prefilled prompt). */
+.starter-pill-debate { border-color: var(--accent); color: var(--accent); font-weight: 600; }
+.starter-pill-debate:hover { background: var(--accent); color: #fff; box-shadow: var(--shadow-sm); }
 
 .home-hint {
   margin-top: 16px; font-size: 13px; color: var(--text-muted);


### PR DESCRIPTION
## Phase 1b — "create a topic from scratch"
A debate is just the home composer with 2+ minds invited, but nobody discovers that. Two **light** nudges (matches your choice: reuse the composer + make it explicit; no restructuring of the core input):

- **Empty-state starter pill** "Start a debate between great minds" → opens the invite-minds popover (accent outline, fills on hover). It's a discovery affordance for the multi-mind path, not a prefilled prompt.
- **Placeholder gains a 2+-minds state**: "Pose a question — they'll debate it", so once minds are invited the user knows what's about to happen.

Reuses the existing minds popover + send flow; no new mechanics. `tsc --noEmit` clean.

This completes **Phase 1** (continue an existing symposium [#178] + start a new debate from the composer). Remaining: **Phase 2** — publish a user's live discussion as a public symposium page (UGC + review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)