### PR TITLE
feat(symposium): publish a multi-mind discussion as a symposium-style page

### DIFF
--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -13,6 +13,7 @@ import MessageList from "@/components/chat/MessageList";
 import ContinueComposer from "@/components/chat/ContinueComposer";
 import ShareButton from "@/components/share/ShareButton";
 import type { Message } from "@/lib/chat";
+import { mindColor, mindInitials } from "@/lib/minds";
 
 // A single approved, PII-scrubbed public discussion. Data comes from
 // GET /api/public-discussions/{id} (mirrors the legacy public_session_page:
@@ -153,20 +154,59 @@ export default async function PublicDiscussionPage({
       disc.messages.filter((m) => m.role === "mind").map((m) => m.speaker || ""),
     ),
   ].filter(Boolean) as string[];
+  // A multi-mind discussion (2+ minds spoke) is a user-made symposium — give it
+  // the same header as the curated /symposium pages (question title + a
+  // participant roster strip) instead of the generic "shared conversation"
+  // banner. Single-mind / book chats keep the plain banner.
+  const isSymposium = knownMindNames.length >= 2;
+  const roster =
+    knownMindNames.length <= 1
+      ? knownMindNames[0] || ""
+      : knownMindNames.slice(0, -1).join(", ") +
+        " and " +
+        knownMindNames[knownMindNames.length - 1];
 
   return (
     <SeoColumn>
       <JsonLd data={forumLd} />
       <JsonLd data={breadcrumbLd} />
 
-      {/* h1 kept for SEO but visually hidden — the chat itself has no big title;
-          the question is the first turn of the transcript below. */}
-      <h1 className="sr-only">{title}</h1>
-      <div className="shared-banner">
-        <span className="shared-banner-label">Shared conversation on Feynman</span>
-        <span className="shared-banner-by">Shared by {disc.handle || "Anonymous"}</span>
-        <ShareButton url={canonical} subject="Shared conversation" title={title} variant="ghost" />
-      </div>
+      {isSymposium ? (
+        // User-made symposium: question as the visible title + a participant
+        // roster strip (the same .mind-join-notice treatment as /symposium).
+        <>
+          <p className="seo-meta">Symposium · shared by {disc.handle || "Anonymous"}</p>
+          <h1 className="discussion-symposium-h1">{title}</h1>
+          <div className="chat-system-notice mind-join-notice symposium-join">
+            <div className="join-notice-inner">
+              {knownMindNames.map((name) => (
+                <span
+                  key={name}
+                  className="join-avatar"
+                  style={{ background: mindColor(name) }}
+                >
+                  {mindInitials(name)}
+                </span>
+              ))}
+              <span>{roster} in conversation</span>
+            </div>
+          </div>
+          <div className="symposium-hero-actions">
+            <ShareButton url={canonical} subject="Symposium" title={title} variant="secondary" />
+          </div>
+        </>
+      ) : (
+        <>
+          {/* h1 kept for SEO but visually hidden — the chat itself has no big
+              title; the question is the first turn of the transcript below. */}
+          <h1 className="sr-only">{title}</h1>
+          <div className="shared-banner">
+            <span className="shared-banner-label">Shared conversation on Feynman</span>
+            <span className="shared-banner-by">Shared by {disc.handle || "Anonymous"}</span>
+            <ShareButton url={canonical} subject="Shared conversation" title={title} variant="ghost" />
+          </div>
+        </>
+      )}
 
       <div className="shared-transcript">
         <MessageList messages={transcript} knownMindNames={knownMindNames} />

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -591,6 +591,13 @@ body { background-color: var(--bg-home); }
    participants strip + .mind-message rows (32px avatar + name + content) for the
    thread, so it reads identically to a real chat room. Only layout tweaks here:
    left-align the notice and add paragraph spacing for multi-para remarks. ── */
+/* User-made symposium (a published multi-mind discussion) reuses the curated
+   symposium header treatment on /discussions/[id]. */
+.discussion-symposium-h1 {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 28px; font-weight: 700; letter-spacing: -0.01em; line-height: 1.2;
+  margin: 2px 0 4px; color: var(--text);
+}
 .symposium-join { justify-content: flex-start; margin: 14px 0 12px; }
 .symposium-lede { font-size: 15px; line-height: 1.6; color: var(--text-secondary); max-width: 620px; margin: 0; }
 .symposium-lede strong { color: var(--text); font-weight: 650; }


### PR DESCRIPTION
## Phase 2 — "publish to a public page"
**Surprise: the machinery already existed.** Any chat session publishes via the share button → `/discussions/{id}` (auto-publish, PII-scrubbed, JSON-LD `DiscussionForumPosting` + OG, indexable with a thin-content guard), and that page **already renders `role:"mind"` turns**. The only gap was *presentation* — a multi-mind discussion looked like a generic "shared conversation".

## Change (presentation only)
When **2+ minds spoke** (`knownMindNames.length >= 2`), `/discussions/[id]` now uses the curated `/symposium` header treatment instead of the plain banner:
- eyebrow `Symposium · shared by {handle}`
- the question as a visible serif `h1` (`.discussion-symposium-h1`)
- a participant **roster strip** (`.mind-join-notice` + `mindColor`/`mindInitials`, identical to `/symposium`)

Single-mind / book chats keep the existing banner untouched.

## Per the chosen scope
- **Not aggregated** — stays out of the sitemap / discovery lists; reachable via its share link + its own indexable page (matches the editorial-sitemap-freeze policy).
- **Existing moderation** — auto-publish + PII scrub + daily cap + admin veto, unchanged.
- **No new backend, no schema change** — mind turns already serialize with `meta.mindName`.

`tsc --noEmit` clean. End-to-end (Pro user: start multi-mind chat → share → see symposium-style public page) is a manual check.

This completes the user-initiated-discussions feature: **continue** an existing symposium (#178), **start** a new debate from the composer (#179), and **publish** it as a public symposium-style page (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)