### PR TITLE
fix(og): CDN-cache share cards so social scrapers don't time out to blank

### DIFF
--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -78,13 +78,24 @@ export async function GET(req: Request) {
   const kind = searchParams.get("kind") || "";
 
   const fonts = await loadOgFonts();
-  const opts = { ...OG_SIZE, fonts, headers: { "Cache-Control": CACHE } };
+  const opts = { ...OG_SIZE, fonts };
 
+  // @vercel/og's ImageResponse injects its own "immutable, max-age=31536000"
+  // Cache-Control and the `headers` option doesn't reliably override it — the
+  // result drops our s-maxage. WITHOUT s-maxage the Vercel CDN won't cache the
+  // image (x-vercel-cache: MISS), so every social scrape cold-renders it (Satori
+  // + remote portrait fetch ≈ 2s) and slow scrapers (X/Twitter) time out to a
+  // BLANK card. Set it explicitly on the response so the CDN caches it and
+  // re-scrapes are instant. Applies to every card type (book/mind/symposium/…).
   try {
     const el = await build(type, id, slug, kind);
-    return new ImageResponse(el, opts);
+    const img = new ImageResponse(el, opts);
+    img.headers.set("Cache-Control", CACHE);
+    return img;
   } catch {
-    return new ImageResponse(<FallbackCard />, opts);
+    const img = new ImageResponse(<FallbackCard />, opts);
+    img.headers.set("Cache-Control", CACHE);
+    return img;
   }
 }
 


### PR DESCRIPTION
## Symptom
A symposium shared to X rendered a **blank image** + downgraded to a small summary card.

## Diagnosis (not what it looked like)
- Page OG meta is **correct**: `og:image` + `twitter:card=summary_large_image` + `twitter:image` all present.
- The `/og` PNG **renders fine**: HTTP 200, image/png, ~50KB.
- **But** `x-vercel-cache: MISS` on every hit, and Cache-Control came back as `public, immutable, max-age=31536000, public, max-age=3600` — **no `s-maxage`**.

## Root cause
`@vercel/og`'s `ImageResponse` injects its own immutable `Cache-Control`, and the `headers` option doesn't reliably override it — so our `s-maxage` was dropped. Without `s-maxage` the Vercel CDN never caches the image, so **every social scrape cold-renders it** (Satori + remote Wikimedia portrait fetch ≈ 2s). A slow scraper (X) times out → blank card.

## Fix
Set `Cache-Control` **explicitly on the ImageResponse** (`public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800`). The CDN now caches each card; re-scrapes are instant. Applies to **every card type** (book/mind/symposium/discussion/qa/essay/topic/agg).

## Verify (post-deploy, in the watcher)
`curl -sI /og?type=symposium&slug=…` → `x-vercel-cache: HIT` + Cache-Control contains `s-maxage=86400`.

## Note on the already-posted tweet
X cached the blank card. After this deploys (and the card is primed in the CDN), **delete + re-post** the link so X re-scrapes and picks up the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)