### PR TITLE
feat(og): dedicated share card for /symposiums (was the home fallback)

### DIFF
--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -40,10 +40,12 @@ import {
   OgMiniCover,
   SymposiumCard,
   SymposiumTurnCard,
+  SymposiumsIndexCard,
 } from "@/lib/og/cards";
 import {
   fetchMind,
   fetchDebate,
+  fetchDebatesList,
   fetchPublicAnswer,
   fetchPublicDiscussion,
   fetchMindOnTopic,
@@ -317,6 +319,11 @@ async function build(type: string, id: string, slug: string, kind: string) {
           label={data.author ? clip(data.author, 44) : isInsights ? "Reader insights" : "Reader discussions"}
         />
       );
+    }
+
+    case "symposiums": {
+      const list = await fetchDebatesList();
+      return <SymposiumsIndexCard questions={list.map((d) => d.question)} />;
     }
 
     case "symposium": {

--- a/web/app/symposiums/page.tsx
+++ b/web/app/symposiums/page.tsx
@@ -24,6 +24,15 @@ export async function generateMetadata(): Promise<Metadata> {
         "2-4 great thinkers take up one question, each in their own voice. Read the symposium, then chat with any of them.",
       url: canonical,
       siteName: "Feynman",
+      images: [abs("/og?type=symposiums")],
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: "@steve_yeow",
+      title: "Symposiums — great minds on today's questions",
+      description:
+        "2-4 great thinkers take up one question, each in their own voice. Read the symposium, then chat with any of them.",
+      images: [abs("/og?type=symposiums")],
     },
   };
 }

--- a/web/lib/og/cards.tsx
+++ b/web/lib/og/cards.tsx
@@ -504,6 +504,36 @@ export function SymposiumCard({
   );
 }
 
+// The /symposiums index card — the discovery surface IS a collection of live
+// debates. Leads with a few REAL questions (a sharp question pulls far harder
+// than the generic home "knowledge network" tagline it used to fall back to).
+export function SymposiumsIndexCard({ questions }: { questions: string[] }) {
+  return (
+    <Frame
+      body={
+        <div style={{ display: "flex", flexDirection: "column", flexGrow: 1, justifyContent: "center" }}>
+          <div style={{ display: "flex", fontSize: 17, letterSpacing: 2, color: INK_MUTE, marginBottom: 14, fontFamily: FONT }}>
+            SYMPOSIUMS
+          </div>
+          <div style={{ display: "flex", fontSize: 46, fontWeight: 700, color: INK, lineHeight: 1.14, marginBottom: 28, maxWidth: 1000 }}>
+            Great minds debate the big questions
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {questions.slice(0, 3).map((q, i) => (
+              <div key={i} style={{ display: "flex", alignItems: "center", fontSize: 27, color: INK_SOFT, fontFamily: FONT, marginBottom: 13 }}>
+                <div style={{ display: "flex", color: INK_MUTE, marginRight: 14 }}>—</div>
+                <div style={{ display: "flex" }}>{clip(q, 60)}</div>
+              </div>
+            ))}
+          </div>
+          <ChatPill label="Browse the symposiums" />
+        </div>
+      }
+      footer={<FooterSimple />}
+    />
+  );
+}
+
 // Single-turn card: one mind's contribution within a symposium. The question is
 // the context strip; the remark is the bubble; the CTA chats with that mind.
 export function SymposiumTurnCard({


### PR DESCRIPTION
## Symptom
Sharing **/symposiums** to X showed the generic **home card** ("Chat with books. Great minds join in.") instead of a symposiums-specific card.

## Cause
`/symposiums` `generateMetadata` set `openGraph` but **no `images`** → fell back to the root layout's default og:image (the home card).

## Fix
- **New `SymposiumsIndexCard`** (`web/lib/og/cards.tsx`): `SYMPOSIUMS` eyebrow + "Great minds debate the big questions" + **3 real questions** pulled from the feed (a sharp question pulls far harder than a generic tagline) + ChatPill.
- **`/og` route**: new `case "symposiums"` → `fetchDebatesList` → `SymposiumsIndexCard`.
- **`/symposiums` metadata**: add `openGraph.images` + a `twitter` `summary_large_image` card, both → `/og?type=symposiums`.

Reuses existing card primitives (`Frame`/`ChatPill`/`FooterSimple`/`INK`/`clip`); benefits from the #181 CDN-cache fix. `tsc --noEmit` clean.

## Verify (post-deploy, in watcher)
`/og?type=symposiums` → 200 image/png; `/symposiums` HTML `og:image` now points to `/og?type=symposiums` (not the home fallback); prime the CDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)