### PR TITLE
fix(symposium): debate turns lead with their own idea, not a mechanical reply

### DIFF
--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -38,10 +38,14 @@ _DEBATE_SYSTEM = (
     "You are simulating one of history's great thinkers speaking in their own "
     "first-person voice in a written symposium with other great minds. Stay true "
     "to the thinker's documented ideas and characteristic way of reasoning — no "
-    "invented quotes, dates, or biography. When prior remarks are provided, ENGAGE "
-    "them: name a previous speaker and sharpen, extend, or rebut them, then advance "
-    "your own distinct position. This is a debate of ideas, never a personal attack. "
-    "Write tight, substantive prose — no greetings, no sign-offs, no stage directions."
+    "invented quotes, dates, or biography. Lead with YOUR own position and "
+    "reasoning. The other remarks are there for friction, not a script: when a "
+    "specific point genuinely sharpens or collides with your view, engage it by "
+    "name — but do NOT open every turn by restating someone else, and never force "
+    "a reference where the argument doesn't need one. Sometimes you build on a "
+    "point, sometimes you cut against it, sometimes you simply take the question "
+    "somewhere new. This is a debate of ideas, never a personal attack. Write "
+    "tight, substantive prose — no greetings, no sign-offs, no stage directions."
 )
 
 
@@ -78,17 +82,19 @@ def _debate_prompt(question: str, m: dict[str, Any], transcript: str, is_first: 
         # actual symposium with depth.
         body = (
             f"The symposium so far:\n{transcript}\n\n"
-            f"As {m['name']}, the discussion has developed — now go deeper. Pick the "
-            "single strongest challenge another speaker has raised to your view and "
-            "meet it head-on, OR pinpoint exactly where you and another speaker "
-            "fundamentally diverge and why it matters. Name them. Do NOT restate your "
-            "opening — advance it with a concrete distinction, example, or consequence."
+            f"As {m['name']}, go deeper — advance your position with a concrete "
+            "distinction, example, or consequence; don't restate your opening. Where a "
+            "real disagreement has surfaced you may meet it or sharpen it, naming who "
+            "you mean — but lead with the idea, don't mechanically open by summarizing "
+            "another speaker."
         )
     else:
         body = (
             f"Remarks already made:\n{transcript}\n\n"
-            f"Now respond as {m['name']}. Reference at least one prior speaker by name "
-            "where you agree or disagree, then advance your own position."
+            f"Now speak as {m['name']}. Make YOUR argument the focus — lead with your "
+            "own claim or angle, not a recap of who said what. Engage a specific point "
+            "someone raised only where it genuinely sharpens your case (name them when "
+            "you do); not every turn needs to open by responding. Vary how you enter."
         )
     return head + body + "\n\nFirst person, 110-170 words, concrete and specific. No greetings or sign-offs."
 


### PR DESCRIPTION
## User feedback
Every turn opened by responding to the one above ("X rightly points to … but I …") — too formulaic, reads like a template.

## Cause
The prompt forced it:
- `_DEBATE_SYSTEM`: "name a previous speaker and sharpen/extend/rebut them, THEN advance"
- round-1 branch: "Reference at least one prior speaker by name … then advance"
- round-2 branch: "Pick the single strongest challenge … Name them"

## Fix
Lead with your OWN position; the others' remarks are friction, not a script — engage a specific point by name **only where it genuinely sharpens your case**, don't open every turn by restating someone, vary how you enter. Round 2 still goes deeper and may meet/sharpen a real disagreement, but **leads with the idea**.

The cross-reference *emergence* (what makes a symposium ≠ isolated /q answers) is **kept** — it just isn't mechanical anymore.

## Verified (dry-run, same cast, not written to DB)
Jobs/Bezos/Christensen/Victor on "data or vision?":
- Round 1 — each states their own claim directly ("This is a false dichotomy…", "…relentless obsession with the customer…")
- Round 2 — engages naturally (Jobs picks up Bret's point, Christensen names Jobs) with no "X said…" openings

## Scope
Affects **future** generation. The existing 72 symposiums keep the old formulaic text until regenerated — that's a separate, cost-gated step (≈576 LLM calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)