### PR TITLE
feat(symposium): turn permalink shows the full symposium, shared turn highlighted

### DIFF
--- a/web/app/symposium/[slug]/t/[turn]/page.tsx
+++ b/web/app/symposium/[slug]/t/[turn]/page.tsx
@@ -87,6 +87,20 @@ export default async function SymposiumTurnPage({
   if (!turn) notFound();
   const base = `/symposium/${d.slug}`;
   const ref = (mindId: string) => d.mind_slugs?.[mindId] || mindId;
+  // Distinct participants (roster strip) in first-appearance order.
+  const participants: typeof d.turns = [];
+  const seenP = new Set<string>();
+  for (const t of d.turns) {
+    if (!seenP.has(t.mind_id)) {
+      seenP.add(t.mind_id);
+      participants.push(t);
+    }
+  }
+  const pNames = participants.map((t) => t.mind_name);
+  const joinLabel =
+    pNames.length <= 1
+      ? pNames[0] || ""
+      : pNames.slice(0, -1).join(", ") + " and " + pNames[pNames.length - 1];
   const breadcrumbLd = breadcrumbJsonLd([
     ["Feynman", SITE_URL],
     ["Symposiums", abs("/symposiums")],
@@ -94,33 +108,68 @@ export default async function SymposiumTurnPage({
     [turn.mind_name, abs(`${base}/t/${i}`)],
   ]);
 
+  // Share-landing view: the visitor arrives from a tweet of ONE turn, but we
+  // render the WHOLE symposium with that turn highlighted — so it's instantly
+  // clear this is one moment in a multi-mind debate, and the full thing is right
+  // here (no easy-to-miss "read more" link needed).
   return (
     <SeoColumn>
       <JsonLd data={breadcrumbLd} />
-      <p className="seo-meta">In a symposium on</p>
+      <p className="seo-meta">{d.topic ? `${d.topic} · Symposium` : "Symposium"}</p>
       <h1 className="discussion-symposium-h1">
         <Link href={base}>{d.question}</Link>
       </h1>
-      {/* The shared remark — the SAME mind-message row as the live chat. */}
-      <div className="symposium-thread" style={{ marginTop: 18 }}>
-        <div className="chat-message mind-message">
-          <div className="mind-msg-avatar" style={{ background: mindColor(turn.mind_name) }}>
-            {mindInitials(turn.mind_name)}
-          </div>
-          <div className="mind-msg-body">
-            <div className="mind-msg-name">{turn.mind_name}</div>
-            <div className="mind-msg-content">
-              {turn.content
-                .split(/\n\n+/)
-                .map((p) => p.trim())
-                .filter(Boolean)
-                .map((p, j) => (
-                  <p key={j}>{p}</p>
-                ))}
-            </div>
-          </div>
+      <div className="chat-system-notice mind-join-notice symposium-join">
+        <div className="join-notice-inner">
+          {participants.map((t) => (
+            <span
+              key={t.mind_id}
+              className="join-avatar"
+              style={{ background: mindColor(t.mind_name) }}
+            >
+              {mindInitials(t.mind_name)}
+            </span>
+          ))}
+          <span>{joinLabel} in conversation</span>
         </div>
       </div>
+      <p className="symposium-lede">
+        You followed <strong>{turn.mind_name}</strong>&apos;s point — here&apos;s the
+        full {participants.length}-mind symposium it belongs to, their turn
+        highlighted below.
+      </p>
+
+      {/* Full thread — same mind-message rows as the live chat; the shared turn
+          is highlighted + tagged so it's obvious which moment was linked. */}
+      <div className="symposium-thread" style={{ marginTop: 18 }}>
+        {d.turns.map((t, j) => (
+          <div
+            key={j}
+            id={j === i ? "shared-turn" : undefined}
+            className={`chat-message mind-message${j === i ? " symposium-turn-shared" : ""}`}
+          >
+            <div className="mind-msg-avatar" style={{ background: mindColor(t.mind_name) }}>
+              {mindInitials(t.mind_name)}
+            </div>
+            <div className="mind-msg-body">
+              <div className="mind-msg-name symposium-turn-head">
+                <span>{t.mind_name}</span>
+                {j === i ? <span className="symposium-shared-tag">Shared</span> : null}
+              </div>
+              <div className="mind-msg-content">
+                {t.content
+                  .split(/\n\n+/)
+                  .map((p) => p.trim())
+                  .filter(Boolean)
+                  .map((p, k) => (
+                    <p key={k}>{p}</p>
+                  ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
       <div className="symposium-hero-actions" style={{ marginTop: 22 }}>
         <Link
           className="symposium-join-cta"
@@ -137,11 +186,6 @@ export default async function SymposiumTurnPage({
           variant="secondary"
         />
       </div>
-      <p className="shared-cta-foot" style={{ marginTop: 20 }}>
-        <Link className="shared-cta-alt" href={base}>
-          ← Read the full symposium
-        </Link>
-      </p>
     </SeoColumn>
   );
 }

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -598,6 +598,21 @@ body { background-color: var(--bg-home); }
   font-size: 28px; font-weight: 700; letter-spacing: -0.01em; line-height: 1.2;
   margin: 2px 0 4px; color: var(--text);
 }
+/* The shared turn on a /symposium/{slug}/t/{i} permalink — the whole symposium
+   renders, this one moment is highlighted + tagged so the linked turn stands out. */
+.symposium-thread .mind-message.symposium-turn-shared {
+  background: rgba(127, 127, 127, 0.07);
+  border-radius: 14px;
+  padding: 14px 16px;
+  box-shadow: inset 3px 0 0 0 var(--accent);
+  scroll-margin-top: 80px;
+}
+.symposium-shared-tag {
+  margin-left: 10px;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+  color: var(--accent); border: 1px solid var(--accent);
+  padding: 1px 8px; border-radius: 999px; vertical-align: middle;
+}
 .symposium-join { justify-content: flex-start; margin: 14px 0 12px; }
 .symposium-lede { font-size: 15px; line-height: 1.6; color: var(--text-secondary); max-width: 620px; margin: 0; }
 .symposium-lede strong { color: var(--text); font-weight: 650; }


### PR DESCRIPTION
## User feedback
Landing on a tweeted turn (`/symposium/{slug}/t/{i}`) showed only **that one remark** + an easy-to-miss "← Read the full symposium" link — not obvious it's one moment in a multi-mind debate.

## Change
The permalink now renders the **WHOLE symposium**: topic eyebrow + question + participant **roster strip** + the **full thread**, with the shared turn **highlighted** (tinted row + accent bar + a "Shared" tag) and a lede ("you followed X's point — here's the full N-mind symposium it belongs to").

So a visitor immediately sees this is a full debate and reads it in place — no buried link needed.

## Unchanged
- `og:image` still the **per-turn card** (`type=symposium-turn`) — X/Twitter still shows the turn
- `canonical` → the full symposium, **noindex** (share entry, not a separate indexable page)

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)