### PR TITLE
feat(pro): list "Join any symposium and continue the debate live" as a Pro perk

### DIFF
--- a/web/components/subscription/PlanCards.tsx
+++ b/web/components/subscription/PlanCards.tsx
@@ -30,6 +30,7 @@ export const PRO_FEATURES = [
   "Write the book you need — on-demand, on any topic",
   "Great minds continuously join chats",
   "Invite great minds into your chats",
+  "Join any symposium and continue the debate live",
   "Upload your own minds or from any source",
   "Discover & expand the minds network",
   "Higher daily usage limits",


### PR DESCRIPTION
The Pro-gated **"Join this discussion"** feature (symposium → live multi-mind chat, `useProGate` signin→Pro) wasn't reflected on the plan card. Added it to the minds-chat group of `PRO_FEATURES` so the paywall sells what it actually gates:

> ✓ Join any symposium and continue the debate live

🤖 Generated with [Claude Code](https://claude.com/claude-code)