### PR TITLE
fix(symposium): turn permalink redirects to the full symposium, not a near-dup

### DIFF
--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -203,7 +203,7 @@ export default async function SymposiumPage({
           the name line (right) instead of a footer link list. */}
       <div className="symposium-thread">
         {d.turns.map((t, i) => (
-          <div key={i} className="chat-message mind-message">
+          <div key={i} id={`turn-${i}`} className="chat-message mind-message">
             <div
               className="mind-msg-avatar"
               style={{ background: mindColor(t.mind_name) }}

--- a/web/app/symposium/[slug]/t/[turn]/page.tsx
+++ b/web/app/symposium/[slug]/t/[turn]/page.tsx
@@ -1,26 +1,15 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Link from "next/link";
-import EntityLayout from "@/components/seo/EntityLayout";
-import JsonLd from "@/components/seo/JsonLd";
-import ShareButton from "@/components/share/ShareButton";
-import {
-  SITE_URL,
-  abs,
-  breadcrumbJsonLd,
-  fetchDebate,
-  fetchDebatesList,
-  metaDescription,
-} from "@/lib/seo-mind";
-import { mindColor, mindInitials } from "@/lib/minds";
+import TurnRedirect from "@/components/symposium/TurnRedirect";
+import { abs, fetchDebate, metaDescription } from "@/lib/seo-mind";
 
-// Per-turn share permalink: a visitor arrives from a tweet of ONE turn. The page
-// renders the WHOLE symposium (identical to /symposium/[slug] — EntityLayout +
-// hero + rail + thread) with the shared turn highlighted, so it's instantly a
-// full multi-mind debate, not an orphan quote. Exists so a social scrape resolves
-// to THAT turn's OG card (the in-page `#turn-{i}` fragment a crawler never sees).
-// canonical → the full symposium, noindex (a share entry, not a separate page).
-// ISR by params (slug + turn) — does NOT touch the /symposium/[slug] cache.
+// Per-turn share permalink. Purpose: a social scrape (X/Twitter) of one mind's
+// remark resolves to THAT turn's OG card (an in-page `#turn-{i}` fragment is
+// invisible to crawlers). A human who clicks through is redirected to the full
+// symposium, anchored to that turn — so there's exactly ONE symposium content
+// page (the detail page), never a confusing near-duplicate. The route still
+// serves 200 + the turn OG in <head> for the crawler; canonical → the full
+// symposium; noindex. ISR by params — doesn't touch the /symposium/[slug] cache.
 
 export const revalidate = 86400;
 export const dynamicParams = true;
@@ -35,10 +24,6 @@ function turnOf(
   const i = parseInt(turnStr, 10);
   const turn = Number.isInteger(i) && i >= 0 ? d.turns[i] : undefined;
   return { i, turn };
-}
-
-function ogImageFor(slug: string, i: number) {
-  return abs(`/og?type=symposium-turn&slug=${encodeURIComponent(slug)}&kind=${i}`);
 }
 
 export async function generateMetadata({
@@ -56,10 +41,13 @@ export async function generateMetadata({
   const desc = metaDescription(
     `${turn.mind_name} in a symposium on "${d.question}": ${turn.content}`,
   );
-  const ogImage = ogImageFor(d.slug, i);
+  const ogImage = abs(
+    `/og?type=symposium-turn&slug=${encodeURIComponent(d.slug)}&kind=${i}`,
+  );
   return {
     title,
     description: desc,
+    // Canonical = the full symposium (this is a share entry, not a separate page).
     alternates: { canonical: base },
     robots: { index: false, follow: true },
     openGraph: {
@@ -89,138 +77,11 @@ export default async function SymposiumTurnPage({
   if (!d) notFound();
   const { i, turn } = turnOf(d, params.turn);
   if (!turn) notFound();
-  const base = `/symposium/${d.slug}`;
-  const canonical = abs(base);
-  const ref = (mindId: string) => d.mind_slugs?.[mindId] || mindId;
-
-  // Distinct participants (roster strip + rail) in first-appearance order.
-  const participants: typeof d.turns = [];
-  const seenP = new Set<string>();
-  for (const t of d.turns) {
-    if (!seenP.has(t.mind_id)) {
-      seenP.add(t.mind_id);
-      participants.push(t);
-    }
-  }
-  const pNames = participants.map((t) => t.mind_name);
-  const joinLabel =
-    pNames.length <= 1
-      ? pNames[0] || ""
-      : pNames.slice(0, -1).join(", ") + " and " + pNames[pNames.length - 1];
-
-  const more = (await fetchDebatesList()).filter((x) => x.slug !== d.slug).slice(0, 6);
-
-  const breadcrumbLd = breadcrumbJsonLd([
-    ["Feynman", SITE_URL],
-    ["Symposiums", abs("/symposiums")],
-    [d.question, canonical],
-    [turn.mind_name, abs(`${base}/t/${i}`)],
-  ]);
-
-  const hero = (
-    <>
-      <p className="seo-meta">{d.topic ? `${d.topic} · Symposium` : "Symposium"}</p>
-      <h1>{d.question}</h1>
-      <div className="chat-system-notice mind-join-notice symposium-join">
-        <div className="join-notice-inner">
-          {participants.map((t) => (
-            <span
-              key={t.mind_id}
-              className="join-avatar"
-              style={{ background: mindColor(t.mind_name) }}
-            >
-              {mindInitials(t.mind_name)}
-            </span>
-          ))}
-          <span>{joinLabel} in conversation</span>
-        </div>
-      </div>
-      <p className="symposium-lede">
-        You followed <strong>{turn.mind_name}</strong>&apos;s point — here&apos;s the
-        full {participants.length}-mind symposium it belongs to, their turn
-        highlighted below.
-      </p>
-      <div className="symposium-hero-actions">
-        <Link
-          className="symposium-join-cta"
-          href={`/mind/${encodeURIComponent(ref(turn.mind_id))}/chat`}
-        >
-          Chat with {turn.mind_name}
-        </Link>
-        <ShareButton
-          url={abs(`${base}/t/${i}`)}
-          title={`${turn.mind_name} on “${d.question}”`}
-          subject="From a symposium"
-          previewImage={ogImageFor(d.slug, i)}
-          label="Share"
-          variant="secondary"
-        />
-      </div>
-    </>
-  );
-
-  const rail = (
-    <>
-      <div className="seo-rail-card">
-        <h3>Chat with a participant</h3>
-        <ul>
-          {participants.map((t) => (
-            <li key={t.mind_id}>
-              <Link href={`/mind/${encodeURIComponent(ref(t.mind_id))}/chat`}>
-                {t.mind_name}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-      {more.length ? (
-        <div className="seo-rail-card">
-          <h3>More symposiums</h3>
-          <ul>
-            {more.map((x) => (
-              <li key={x.slug}>
-                <Link href={`/symposium/${x.slug}`}>{x.question}</Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </>
-  );
-
+  // Send the human to the full symposium, scrolled to this turn.
   return (
-    <EntityLayout hero={hero} rail={rail}>
-      <JsonLd data={breadcrumbLd} />
-      {/* Full thread — same mind-message rows as the live chat; the shared turn
-          is highlighted + tagged so it's obvious which moment was linked. */}
-      <div className="symposium-thread">
-        {d.turns.map((t, j) => (
-          <div
-            key={j}
-            id={j === i ? "shared-turn" : undefined}
-            className={`chat-message mind-message${j === i ? " symposium-turn-shared" : ""}`}
-          >
-            <div className="mind-msg-avatar" style={{ background: mindColor(t.mind_name) }}>
-              {mindInitials(t.mind_name)}
-            </div>
-            <div className="mind-msg-body">
-              <div className="mind-msg-name symposium-turn-head">
-                <span>{t.mind_name}</span>
-                {j === i ? <span className="symposium-shared-tag">Shared</span> : null}
-              </div>
-              <div className="mind-msg-content">
-                {t.content
-                  .split(/\n\n+/)
-                  .map((p) => p.trim())
-                  .filter(Boolean)
-                  .map((p, k) => (
-                    <p key={k}>{p}</p>
-                  ))}
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </EntityLayout>
+    <TurnRedirect
+      href={`/symposium/${d.slug}#turn-${i}`}
+      label={`Open “${d.question}”`}
+    />
   );
 }

--- a/web/components/symposium/TurnRedirect.tsx
+++ b/web/components/symposium/TurnRedirect.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * A per-turn share permalink (/symposium/{slug}/t/{i}) exists ONLY so a social
+ * scrape resolves to that turn's OG card. A human who clicks through should land
+ * on the full symposium — one canonical page, no confusing near-duplicate. We
+ * can't SSR-redirect (a 3xx carries no OG meta for the crawler), so the route
+ * serves 200 + the turn's OG in <head>, then this client component redirects to
+ * the symposium, anchored to that turn.
+ */
+export default function TurnRedirect({ href, label }: { href: string; label: string }) {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace(href);
+  }, [href, router]);
+  return (
+    <div className="turn-redirect">
+      <p className="turn-redirect-note">Opening the symposium…</p>
+      <a className="turn-redirect-link" href={href}>
+        {label}
+      </a>
+    </div>
+  );
+}

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -613,6 +613,13 @@ body { background-color: var(--bg-home); }
   color: var(--accent); border: 1px solid var(--accent);
   padding: 1px 8px; border-radius: 999px; vertical-align: middle;
 }
+/* #turn-{i} anchor target on the detail page — a per-turn share permalink
+   redirects here and scrolls to the turn; leave room under the sticky top. */
+.symposium-thread .mind-message { scroll-margin-top: 84px; }
+/* Brief splash on the per-turn permalink before the client redirect fires. */
+.turn-redirect { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 80px 20px; text-align: center; }
+.turn-redirect-note { color: var(--text-muted); font-size: 15px; margin: 0; }
+.turn-redirect-link { color: var(--accent); font-size: 15px; }
 .symposium-join { justify-content: flex-start; margin: 14px 0 12px; }
 .symposium-lede { font-size: 15px; line-height: 1.6; color: var(--text-secondary); max-width: 620px; margin: 0; }
 .symposium-lede strong { color: var(--text); font-weight: 650; }


### PR DESCRIPTION
## User: "很 confuse"
The per-turn page rendered a **near-duplicate of the detail page** but layered conflicting single-turn semantics on top (a "you followed X's point" lede, a single "Chat with X" CTA, a highlighted turn) over the full 4-mind thread. So it read as *both* the symposium detail page **and** a single-remark page — and it was unclear why two near-identical pages exist.

## Fix
The per-turn permalink is now a **thin OG entry that client-redirects to the full symposium**, anchored to that turn (`/symposium/{slug}#turn-{i}`).

- **One** symposium content page (the detail page); the permalink exists only so a social scrape gets the per-turn OG card.
- Can't SSR-redirect (a 3xx carries no OG for the crawler), so the route serves **200 + the turn OG in `<head>`**, then client-redirects.
- Detail page: each turn gets `id="turn-{i}"` + scroll-margin so the anchor lands cleanly.
- canonical → full symposium, noindex; ISR by params (doesn't touch the detail cache).

Net: from a tweet you land on the familiar full symposium, scrolled to the shared turn — no confusing twin page. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)