### PR TITLE
fix(book): don't show raw word count on the detail page

### DIFF
--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -192,7 +192,8 @@ export default async function BookLandingPage({ params }: PageProps) {
   }
 
   const metaBits: string[] = [];
-  if (data.totalWords) metaBits.push(`${data.totalWords.toLocaleString()} words`);
+  // Word count intentionally NOT shown (Steve): a raw "250 words" reads as a thin
+  // stub and adds nothing for a reader. It stays in JSON-LD (wordCount) only.
   if (chapterCount) metaBits.push(`${chapterCount} chapter${chapterCount === 1 ? "" : "s"}`);
 
   // Chips only on indexed books — gate on meta.chunk_count >= 5, the SAME


### PR DESCRIPTION
Steve: a bare **"250 words"** under the author on a book detail page reads as a thin stub and adds nothing for a reader.

Removed it from the hero `metaBits`. The count stays in **JSON-LD (`wordCount`)** for structured data — just not rendered. Chapter count (when present) still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)