### PR TITLE
Symposiums: daily auto-generation from Hacker News trending (mechanism A)

### DIFF
--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -453,3 +453,117 @@ def expand_symposiums(
             created += 1
             log.info("symposium: %r [%s] (%d turns) → /symposium/%s", q, topic, len(turns), d["slug"])
     return created, attempted
+
+
+# ─── Trending source (daily cron): HN headlines → timeless questions ───
+# Same cast/generate pipeline as expand_symposiums; only the question SOURCE
+# differs — real front-page headlines distilled into enduring tensions, so
+# /symposiums self-updates daily without a human walking the static topic list.
+
+_TREND_QGEN_SYSTEM = (
+    "You read today's headlines and surface the TIMELESS human tension hiding under "
+    "each one — the kind of question Socrates, Confucius, Kant, or Nietzsche could "
+    "each stake out a real position on, centuries before the headline existed. You "
+    "are NOT writing technology questions. Always LIFT the specific news to an "
+    "enduring tension about knowledge, power, human nature, progress, freedom, "
+    "meaning, justice, or creativity. Reject anything only a domain specialist could "
+    "argue, anything naming a product/company/person, anything needing this week's "
+    "context. If a headline hides no timeless tension, skip it — fewer, deeper "
+    "questions beat filling a quota."
+)
+
+
+def _trend_qgen_prompt(titles: list[str], n: int, topics: list[str]) -> str:
+    feed = "\n".join(f"- {t}" for t in titles)
+    return (
+        f"Today's headlines:\n{feed}\n\n"
+        "Surface the enduring human tensions underneath. Examples of the LIFT we want:\n"
+        '  "AI model gets a bigger memory" -> "Does more information bring us closer to truth?"\n'
+        '  "Startup raises a huge round" -> "Does chasing growth corrupt an original vision?"\n'
+        '  "New tool writes code by itself" -> "Can genuine creativity ever be automated?"\n\n'
+        f"Give up to {n} such questions — each a tension great thinkers ACROSS ERAS "
+        "(not just modern experts) would genuinely, deeply disagree on, the kind a "
+        "thoughtful person actually searches. Phrase as a searcher types it (40-90 "
+        "chars), NO product/company/person names, no dates, no tech jargon. Tag each "
+        f"with the single best-fitting topic (exact string) from: {', '.join(topics)}.\n"
+        "Skip any headline with no real timeless tension — quality over quantity.\n"
+        'Return STRICT JSON only: [{"question": "...", "topic": "..."}, ...]'
+    )
+
+
+def _trend_questions(titles: list[str], n: int, topics: list[str]) -> list[dict[str, str]]:
+    """LLM-distilled {question, topic} pairs from headlines. Topic is validated
+    against the allowed list (so _candidates_for_topic can field a real cast)."""
+    res, _ = bulk_chat(system=_TREND_QGEN_SYSTEM, user=_trend_qgen_prompt(titles, n, topics))
+    raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", (res.content or "").strip(), flags=re.M).strip()
+    try:
+        out = json.loads(raw)
+    except Exception:
+        return []
+    allowed = {t.lower(): t for t in topics}
+    items: list[dict[str, str]] = []
+    for it in out if isinstance(out, list) else []:
+        if not isinstance(it, dict):
+            continue
+        q = str(it.get("question") or "").strip()
+        topic = allowed.get(str(it.get("topic") or "").strip().lower())
+        if q and topic:
+            items.append({"question": q, "topic": topic})
+    return items[:n]
+
+
+def expand_from_trending(limit: int = 2, pool: int = 8) -> tuple[int, int]:
+    """Daily-cron path: HN front page → LLM timeless questions → LLM cast →
+    generate. Reuses the expand_symposiums cast/generate pipeline verbatim; only
+    the question SOURCE differs (real headlines vs. a static topic walk). `pool` =
+    how many distilled questions to consider; `limit` caps how many actually get
+    generated this run (cost guard). Idempotent (skips existing questions).
+    Returns (created, attempted)."""
+    from .catalog import TOPIC_TAGS
+    from .trending import fetch_hn_titles
+
+    titles = fetch_hn_titles(30)
+    if not titles:
+        log.warning("expand_from_trending: no HN titles, skipping run")
+        return 0, 0
+    try:
+        items = _trend_questions(titles, pool, TOPIC_TAGS)
+    except Exception as exc:
+        log.warning("trend qgen failed: %s", exc)
+        return 0, 0
+
+    created = attempted = 0
+    for it in items:
+        if created >= limit:
+            break
+        q, topic = it["question"], it["topic"]
+        if debate_question_exists(q):
+            continue
+        attempted += 1
+        cands = _candidates_for_topic(topic)
+        if len(cands) < 3:
+            log.warning("trending %r: topic %s has only %d candidates, skipping", q, topic, len(cands))
+            continue
+        try:
+            names = _pick_debaters(q, cands, 4)
+        except Exception as exc:
+            log.warning("cast failed for %r: %s", q, exc)
+            continue
+        minds, seen = [], set()
+        for nm in names:
+            m = get_mind_by_name(nm)
+            if m and m.get("persona") and m["id"] not in seen:
+                minds.append(m)
+                seen.add(m["id"])
+        if len(minds) < 2:
+            log.warning("trending %r: only %d cast minds resolved, skipping", q, len(minds))
+            continue
+        turns = generate_debate(q, minds, rounds=2)
+        if len(turns) < 2:
+            continue
+        d = create_debate(q, topic, [t["mind"]["id"] for t in turns])
+        for t in turns:
+            add_debate_turn(d["id"], t["mind"]["id"], t["mind"]["name"], t["turn_index"], t["content"])
+        created += 1
+        log.info("trending symposium: %r [%s] (%d turns) → /symposium/%s", q, topic, len(turns), d["slug"])
+    return created, attempted

--- a/app/core/trending.py
+++ b/app/core/trending.py
@@ -1,0 +1,50 @@
+"""Trending-topic source for the daily symposium cron.
+
+Hacker News front page → the seed for the daily auto-generated symposiums. The
+headlines are just a *spark*: an LLM (in debates.py) distills the enduring tension
+underneath them into a TIMELESS question great minds can argue, never the
+ephemeral news itself. HN skews to the AI / founder / product / science audience
+we promote to on Twitter, and the Algolia API is open (no auth), so this runs
+unattended on Vercel cron.
+
+Kept deliberately thin — just the fetch. The distill→cast→generate pipeline lives
+in debates.py (reusing the expand_symposiums machinery)."""
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Algolia's HN search returns the current front page in one call (no pagination,
+# no auth). `query=` empty + tags=front_page = the live front page.
+_HN_FRONT = "https://hn.algolia.com/api/v1/search?tags=front_page&hitsPerPage=40"
+
+
+def fetch_hn_titles(n: int = 30, min_points: int = 0) -> list[str]:
+    """Front-page HN story titles, most-discussed first. Best-effort: returns []
+    on any network/parse failure so the cron degrades to a no-op rather than
+    erroring. `min_points` optionally drops low-signal stories."""
+    try:
+        req = urllib.request.Request(
+            _HN_FRONT,
+            # A browser-ish UA — some CDNs 1010-ban urllib's default agent
+            # (cf. the Resend/Cloudflare note in notify.py).
+            headers={"User-Agent": "Mozilla/5.0 (compatible; feynman-trending/1.0)"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as r:
+            data: dict[str, Any] = json.loads(r.read().decode("utf-8"))
+    except Exception as exc:
+        log.warning("HN front-page fetch failed: %s", exc)
+        return []
+    titles: list[str] = []
+    for h in data.get("hits", []):
+        title = (h.get("title") or "").strip()
+        if not title:
+            continue
+        if min_points and (h.get("points") or 0) < min_points:
+            continue
+        titles.append(title)
+    return titles[:n]

--- a/app/main.py
+++ b/app/main.py
@@ -3722,6 +3722,27 @@ def api_cron_prestore_overviews(request: Request) -> dict[str, Any]:
         return {"status": "error", "detail": str(exc)}
 
 
+@app.get("/api/cron/generate-symposiums")
+def api_cron_generate_symposiums(request: Request) -> dict[str, Any]:
+    """Daily: distill Hacker News front-page headlines into 1-2 fresh symposiums
+    (timeless questions great minds debate), so /symposiums self-updates without
+    manual seeding. HN Algolia API is open; the LLM distills + casts + generates
+    via DeepSeek (bulk_chat, not geoblocked). Idempotent (skips existing
+    questions). `limit` (1-3) caps generation per run for cost + the 60s timeout."""
+    _verify_cron(request)
+    try:
+        limit = max(1, min(3, int(request.query_params.get("limit", "2"))))
+    except ValueError:
+        limit = 2
+    try:
+        from .core.debates import expand_from_trending
+        created, attempted = expand_from_trending(limit=limit)
+        return {"status": "ok", "created": created, "attempted": attempted}
+    except Exception as exc:
+        log.error("generate-symposiums cron failed: %s", exc)
+        return {"status": "error", "detail": str(exc)}
+
+
 @app.get("/api/cron/reset-embeddings")
 def api_cron_reset_embeddings() -> dict[str, Any]:
     """Clear all corrupted embeddings so backfill can regenerate them."""

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,7 @@
     { "path": "/api/cron/mind-qa", "schedule": "0 3 * * *" },
     { "path": "/api/cron/prestore-overviews", "schedule": "30 2 * * *" },
     { "path": "/api/cron/indexnow", "schedule": "0 4 * * *" },
-    { "path": "/api/cron/egress-watch", "schedule": "0 8 * * *" }
+    { "path": "/api/cron/egress-watch", "schedule": "0 8 * * *" },
+    { "path": "/api/cron/generate-symposiums", "schedule": "0 5 * * *" }
   ]
 }


### PR DESCRIPTION
## What
`/symposiums` (now a top-level menu item) was **static** — it only grew when I manually ran `SEED_DEBATES` / `expand_symposiums`. This adds **mechanism A of two**: a daily cron that keeps it self-updating from real trending topics. (Mechanism B — user-initiated discussions feeding the public list — is a separate follow-up PR.)

## How
1. **Source** — `app/core/trending.py` `fetch_hn_titles()` pulls the Hacker News front page (Algolia API, open / no-auth; skews to the AI/founder/product/science audience we promote to on Twitter).
2. **Distill** — `_trend_questions()` has an LLM lift each headline to a **timeless** tension great minds across eras can argue (never the ephemeral news, never a product/company/person name), tagged to a valid `TOPIC_TAGS` hub so casting can field debaters.
3. **Cast + generate** — `expand_from_trending()` reuses the existing `_pick_debaters` + `generate_debate` pipeline verbatim (sensitive-figure blacklist, whole-word topic match, 2-round symposium). Only the question SOURCE differs from `expand_symposiums`.
4. **Cron** — `GET /api/cron/generate-symposiums` (CRON_SECRET bearer, `limit` 1-3), scheduled daily 05:00 UTC.

Idempotent (skips existing questions). Capped at 1-2/day for cost (~8-16 DeepSeek calls/day, ~30-60s Vercel CPU).

## Verified locally (end-to-end)
HN fetch → distill → cast → generate all run. The improved prompt lifts headlines to real timeless tensions:
- "Does more information bring us closer to truth?" [Philosophy]
- "Can genuine creativity ever be automated?" [AI]
- "Does chasing growth corrupt an original vision?" [Business & Strategy]

Turn quality is high (Feyerabend vs Zhuangzi on the truth question — distinct voices, real clash). Local DB has only 81 minds so casts are small / AI topic skipped; production (622 minds) fields fuller casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)