### PR TITLE
User-initiated symposiums join /symposiums + /discussions UX fixes (mechanism B)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3613,6 +3613,61 @@ def list_debates(limit: int = 200) -> list[dict[str, Any]]:
         return debates
 
 
+def list_community_symposiums(min_minds: int = 2, limit: int = 100) -> list[dict[str, Any]]:
+    """User-initiated symposiums: approved public chat sessions where >= min_minds
+    distinct minds spoke. These join the curated /symposiums feed (Steve, 2026-06-14:
+    "multi-mind chats the user shared as public can enter symposiums"). Shaped like
+    list_debates items but with source='community' and the slug carrying the SESSION
+    id, since the card links to /discussions/{id} (not /symposium/{slug}). Minds are
+    derived from session_messages role='mind' meta.mindName (no session.minds field
+    exists). Idempotent/read-only."""
+    with get_conn() as conn:
+        rows = _fetchall(conn, _q(
+            "SELECT id, public_title, title, created_at, approved_at FROM chat_sessions "
+            "WHERE public_status = 'approved' AND session_type IN ('chat','mind','book') "
+            "ORDER BY COALESCE(approved_at, created_at) DESC LIMIT ?"
+        ), (limit * 4,))  # over-fetch; the >=min_minds filter below thins it
+        sessions = [dict(r) for r in rows]
+        if not sessions:
+            return []
+        ids = [s["id"] for s in sessions]
+        ph = ",".join(["?"] * len(ids))
+        mrows = _fetchall(conn, _q(
+            f"SELECT session_id, meta_json, created_at FROM session_messages "  # noqa: S608 — ph is ?-placeholders
+            f"WHERE session_id IN ({ph}) AND role = 'mind' ORDER BY created_at ASC"
+        ), tuple(ids))
+        by_session: dict[str, list[str]] = {}
+        seen: dict[str, set[str]] = {}
+        for r in mrows:
+            sid = r["session_id"]
+            try:
+                name = (json.loads(r.get("meta_json") or "{}").get("mindName") or "").strip()
+            except Exception:
+                name = ""
+            if not name:
+                continue
+            s = seen.setdefault(sid, set())
+            if name not in s:
+                s.add(name)
+                by_session.setdefault(sid, []).append(name)
+        out: list[dict[str, Any]] = []
+        for s in sessions:
+            names = by_session.get(s["id"], [])
+            if len(names) < min_minds:
+                continue
+            out.append({
+                "slug": s["id"],  # session id — the card links to /discussions/{id}
+                "question": (s.get("public_title") or s.get("title") or "Shared discussion").strip(),
+                "topic": None,
+                "created_at": s.get("created_at"),
+                "participants": names,
+                "source": "community",
+            })
+            if len(out) >= limit:
+                break
+        return out
+
+
 def list_debates_for_mind(mind_id: str, limit: int = 10) -> list[dict[str, Any]]:
     """Debates a given mind argued in — the 'Recent debates' rail on /mind/{id}
     and /mind/{id}/dialogues (the per-mind aggregation, philosophie.ai-style)."""

--- a/app/main.py
+++ b/app/main.py
@@ -4548,14 +4548,29 @@ def api_debate(slug: str) -> JSONResponse:
 
 @app.get("/api/debates")
 def api_debates_list() -> JSONResponse:
-    """All published debates (slug + question + topic) — the /debates index."""
-    from .core.db import list_debates
+    """Curated debates + (when public discussions are on) user-initiated community
+    symposiums — the /symposiums index. Both carry a `source` field so the feed can
+    badge community items and link them to /discussions/{id} (not /symposium/{slug}).
+    Community items do NOT enter the sitemap here (the sitemap calls list_debates
+    directly; user discussions have their own gated sitemap path)."""
+    from .core.db import list_community_symposiums, list_debates
     try:
-        rows = list_debates(limit=500)
+        curated = list_debates(limit=500)
+        for d in curated:
+            d["source"] = "curated"
+        community: list[dict[str, Any]] = []
+        if ugc_module.is_enabled():
+            try:
+                community = list_community_symposiums(limit=200)
+            except Exception:
+                community = []
+        merged = curated + community
+        # Newest-first across both sources — the feed is a recency stream.
+        merged.sort(key=lambda x: x.get("created_at") or "", reverse=True)
     except Exception:
-        rows = []
+        merged = []
     return JSONResponse(
-        content={"debates": rows},
+        content={"debates": merged},
         headers={"Cache-Control": "public, max-age=1800, s-maxage=3600"},
     )
 

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -116,14 +116,9 @@ export default async function PublicDiscussionPage({
   }
 
   const title = disc.title || "Discussion on Feynman";
-  // Cross-link back to the entity (book or mind) this discussion is about.
-  const entityRef = disc.entity_slug || disc.entity_id; // prefer slug, uuid fallback
-  const entityHref =
-    entityRef && disc.session_type === "book"
-      ? `/book/${entityRef}`
-      : entityRef
-        ? `/mind/${entityRef}`
-        : null;
+  // Footer is just the continue-composer now (Steve, 2026-06-14): no "Browse the
+  // library" / "More from this book" link — a shared chat should only offer to
+  // continue the conversation.
   const forumLd = {
     "@context": "https://schema.org",
     "@type": "DiscussionForumPosting",
@@ -213,13 +208,6 @@ export default async function PublicDiscussionPage({
       </div>
 
       <ContinueComposer id={params.id} />
-      <p className="shared-cta-foot">
-        <Link className="shared-cta-alt" href={entityHref || "/library"}>
-          {entityHref
-            ? `More from this ${disc.session_type === "book" ? "book" : "mind"}`
-            : "Browse the library"}
-        </Link>
-      </p>
     </SeoColumn>
   );
 }

--- a/web/components/chat/ContinueComposer.tsx
+++ b/web/components/chat/ContinueComposer.tsx
@@ -43,7 +43,8 @@ export default function ContinueComposer({ id }: { id: string }) {
   return (
     <div className="shared-continue">
       <p className="shared-continue-hint">
-        Continue privately — your follow-ups create a copy only you can see.
+        This is a shared, read-only conversation. Ask a follow-up and we&rsquo;ll open
+        a private copy — only you can see it.
       </p>
       <div className="shared-continue-bar">
         <textarea

--- a/web/components/seo/SymposiumsFeed.tsx
+++ b/web/components/seo/SymposiumsFeed.tsx
@@ -44,30 +44,40 @@ export default function SymposiumsFeed({ debates }: { debates: DebateListItem[] 
       ) : null}
 
       <div className="symposium-feed">
-        {shown.map((d) => (
-          <Link key={d.slug} href={`/symposium/${d.slug}`} className="symposium-row">
-            <div className="symposium-row-q">{d.question}</div>
-            <div className="symposium-row-meta">
-              {d.participants && d.participants.length ? (
-                <>
-                  <span className="symposium-row-avatars">
-                    {d.participants.slice(0, 5).map((name, i) => (
-                      <span
-                        key={i}
-                        className="symposium-row-avatar"
-                        style={{ background: mindColor(name) }}
-                      >
-                        {mindInitials(name)}
-                      </span>
-                    ))}
-                  </span>
-                  <span className="symposium-row-names">{d.participants.join(", ")}</span>
-                </>
-              ) : null}
-              {d.topic ? <span className="symposium-row-topic">{d.topic}</span> : null}
-            </div>
-          </Link>
-        ))}
+        {shown.map((d) => {
+          // Community symposiums are user-shared multi-mind discussions — they
+          // live at /discussions/{id}, not /symposium/{slug}, and carry a badge.
+          const community = d.source === "community";
+          const href = community ? `/discussions/${d.slug}` : `/symposium/${d.slug}`;
+          return (
+            <Link key={d.slug} href={href} className="symposium-row">
+              <div className="symposium-row-q">{d.question}</div>
+              <div className="symposium-row-meta">
+                {d.participants && d.participants.length ? (
+                  <>
+                    <span className="symposium-row-avatars">
+                      {d.participants.slice(0, 5).map((name, i) => (
+                        <span
+                          key={i}
+                          className="symposium-row-avatar"
+                          style={{ background: mindColor(name) }}
+                        >
+                          {mindInitials(name)}
+                        </span>
+                      ))}
+                    </span>
+                    <span className="symposium-row-names">{d.participants.join(", ")}</span>
+                  </>
+                ) : null}
+                {community ? (
+                  <span className="symposium-row-badge">Community</span>
+                ) : d.topic ? (
+                  <span className="symposium-row-topic">{d.topic}</span>
+                ) : null}
+              </div>
+            </Link>
+          );
+        })}
       </div>
     </>
   );

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -422,6 +422,9 @@ export interface DebateListItem {
   topic?: string;
   created_at?: string;
   participants?: string[];
+  /** "curated" = a debate (/symposium/{slug}); "community" = a user-shared
+   *  multi-mind discussion (/discussions/{slug}). Absent ⇒ treat as curated. */
+  source?: "curated" | "community";
 }
 
 /** A debate + its ordered turns (GET /api/debates/{slug}); null if absent. */

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -692,6 +692,13 @@ body { background-color: var(--bg-home); }
   flex-shrink: 0; margin-left: auto; font-size: 11px; color: var(--text-muted);
   padding: 3px 10px; border-radius: 999px; background: var(--bg-sidebar);
 }
+/* Community symposium = a user-shared multi-mind discussion (vs a curated debate).
+   Accent-tinted so it reads as a distinct, member-made source in the feed. */
+.symposium-row-badge {
+  flex-shrink: 0; margin-left: auto; font-size: 11px; font-weight: 600;
+  color: var(--accent); padding: 3px 10px; border-radius: 999px;
+  background: var(--bg-hover); letter-spacing: 0.01em;
+}
 
 /* ── Compact symposium list embedded in topic / book pages. ── */
 .symposium-links { list-style: none; padding: 0; margin: 8px 0 0; }


### PR DESCRIPTION
Replaces #195 (auto-closed when its stacked base #194 was deleted on merge). Rebased onto main — now contains **only** mechanism B.

## What
Per Steve (2026-06-14): a user's **public** chat where ≥2 minds spoke joins the Symposiums feed.

## Backend
- `list_community_symposiums()`: approved `chat_sessions` with ≥2 distinct minds (from `session_messages` `role='mind'` `meta.mindName`), shaped like `list_debates` items + `source='community'`; slug = session id → links to `/discussions/{id}`.
- `/api/debates` merges curated + community (when public discussions on), newest-first. Community OUT of sitemap.

## Frontend
- `DebateListItem.source`; `SymposiumsFeed` links community rows to `/discussions/{id}` + a "Community" badge.

## /discussions UX (from the Twitter book-chat screenshot)
- footer dropped "Browse the library" / "More from this book" — only offers to continue now.
- continue-composer hint says it's a read-only preview → private copy.

## Verified locally (e2e)
Seeded approved 2-mind session → surfaces in /api/debates (source=community), renders on /symposiums with badge + /discussions link; 1-mind excluded; footer clean. tsc + py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)