### PR TITLE
Fix: community symposiums hidden on prod (COALESCE type mismatch)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3623,9 +3623,15 @@ def list_community_symposiums(min_minds: int = 2, limit: int = 100) -> list[dict
     exists). Idempotent/read-only."""
     with get_conn() as conn:
         rows = _fetchall(conn, _q(
-            "SELECT id, public_title, title, created_at, approved_at FROM chat_sessions "
+            # ORDER BY created_at (TEXT, ISO-8601 → lexical == chronological), NOT
+            # COALESCE(approved_at, created_at): on Postgres approved_at is
+            # timestamptz and created_at is text, and COALESCE rejects the mixed
+            # types — which made this THROW (SQLite tolerated it locally, a
+            # SQLite≠PG miss), and /api/debates swallowed it so community was
+            # always empty in prod.
+            "SELECT id, public_title, title, created_at FROM chat_sessions "
             "WHERE public_status = 'approved' AND session_type IN ('chat','mind','book') "
-            "ORDER BY COALESCE(approved_at, created_at) DESC LIMIT ?"
+            "ORDER BY created_at DESC LIMIT ?"
         ), (limit * 4,))  # over-fetch; the >=min_minds filter below thins it
         sessions = [dict(r) for r in rows]
         if not sessions:


### PR DESCRIPTION
Hotfix for #197. `list_community_symposiums`' `ORDER BY COALESCE(approved_at, created_at)` threw on Postgres (approved_at=timestamptz, created_at=text → COALESCE type mismatch). The exception was swallowed by `/api/debates`' try/except, so the **community section was always empty in prod** despite 4 real user-shared multi-mind discussions existing (the von Neumann/Metzinger chat, Thiel/Smith on monopoly, etc.). SQLite is untyped so the local e2e passed — a SQLite≠PG miss.

Fix: `ORDER BY created_at DESC` (TEXT, ISO-8601 so lexical == chronological). Verified against the prod DB — now returns the 4 community symposiums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)