### PR TITLE
Unify community symposiums with curated (one experience + one label dimension)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -3656,6 +3656,37 @@ def list_community_symposiums(min_minds: int = 2, limit: int = 100) -> list[dict
             if name not in s:
                 s.add(name)
                 by_session.setdefault(sid, []).append(name)
+        # Infer a topic (community symposiums have none of their own) so the
+        # /symposiums feed shows a CONSISTENT label dimension — a topic tag, like
+        # the curated rows — rather than a "Community" source badge sitting where a
+        # topic should be (Steve, 2026-06-14: community should also carry a topic,
+        # drop the "Community" word). Match a participant's domain against
+        # TOPIC_TAGS; first hit wins, else None.
+        from .catalog import TOPIC_TAGS
+        # Reuse the casting matcher: whole-word, EXCLUDES the ambiguous "design"
+        # (a product founder's "design" domain must not read as Art & Design) and
+        # carries the Art&Design synonym set. Far less noisy than naive substring.
+        from .debates import _topic_match
+        all_names = {n for names in by_session.values() for n in names}
+        domain_by_name: dict[str, str] = {}
+        if all_names:
+            nph = ",".join(["?"] * len(all_names))
+            nrows = _fetchall(conn, _q(
+                f"SELECT name, domain FROM minds WHERE name IN ({nph})"  # noqa: S608 — ph is ?-placeholders
+            ), tuple(all_names))
+            for r in nrows:
+                domain_by_name[r["name"]] = r.get("domain") or ""
+
+        def _infer_topic(names: list[str]) -> str | None:
+            for n in names:
+                dom = domain_by_name.get(n, "")
+                if not dom:
+                    continue
+                for tag in TOPIC_TAGS:
+                    if _topic_match(dom, tag):
+                        return tag
+            return None
+
         out: list[dict[str, Any]] = []
         for s in sessions:
             names = by_session.get(s["id"], [])
@@ -3664,7 +3695,7 @@ def list_community_symposiums(min_minds: int = 2, limit: int = 100) -> list[dict
             out.append({
                 "slug": s["id"],  # session id — the card links to /discussions/{id}
                 "question": (s.get("public_title") or s.get("title") or "Shared discussion").strip(),
-                "topic": None,
+                "topic": _infer_topic(names),
                 "created_at": s.get("created_at"),
                 "participants": names,
                 "source": "community",

--- a/app/main.py
+++ b/app/main.py
@@ -4755,7 +4755,28 @@ def api_public_discussion(session_id: str) -> JSONResponse:
         raw_msgs = list_messages_for_public_session(session_id)
     except Exception:
         raw_msgs = []
+    # Resolve each distinct mind's id+slug from its name (meta stores only the
+    # name). Lets the UNIFIED symposium detail page offer "Join this discussion"
+    # (chips need ids) + a per-participant chat rail (links need slugs), exactly
+    # like a curated /symposium. Cached per name (a mind speaks 2+ turns).
+    from .core.db import get_mind_by_name as _get_mind_by_name
+    _mind_cache: dict[str, dict[str, str]] = {}
+
+    def _resolve_mind(name: str) -> dict[str, str]:
+        if name not in _mind_cache:
+            try:
+                mm = _get_mind_by_name(name)
+            except Exception:
+                mm = None
+            _mind_cache[name] = {
+                "mind_id": (mm or {}).get("id") or "",
+                "mind_slug": (mm or {}).get("slug") or "",
+            }
+        return _mind_cache[name]
+
     messages = []
+    participants: list[dict[str, str]] = []
+    _seen_minds: set[str] = set()
     for m in raw_msgs:
         role = m.get("role") or ""
         # Drop the "minds joined" system notices (they're empty → blank bubbles).
@@ -4768,13 +4789,21 @@ def api_public_discussion(session_id: str) -> JSONResponse:
         # default answerer is Feynman; a 'user' turn is the asker (rendered as
         # "Question" client-side). Without this every reply showed as "Feynman".
         meta = m.get("meta") or {}
+        msg: dict[str, Any] = {"role": role, "content": content, "speaker": ""}
         if role == "mind":
-            speaker = meta.get("mindName") or "A great mind"
+            name = meta.get("mindName") or "A great mind"
+            ref = _resolve_mind(name)
+            msg["speaker"] = name
+            msg["mind_id"] = ref["mind_id"]
+            msg["mind_slug"] = ref["mind_slug"]
+            if name not in _seen_minds:
+                _seen_minds.add(name)
+                participants.append(
+                    {"mind_id": ref["mind_id"], "mind_name": name, "mind_slug": ref["mind_slug"]}
+                )
         elif role == "assistant":
-            speaker = "Feynman"
-        else:
-            speaker = ""
-        messages.append({"role": role, "content": content, "speaker": speaker})
+            msg["speaker"] = "Feynman"
+        messages.append(msg)
     # Resolve the entity's slug so the discussion's backlink to its book/mind
     # skips the 301 hop (entity_id is a uuid). One lookup, cached with the page;
     # book sessions point at an agent, mind sessions at a mind.
@@ -4803,6 +4832,7 @@ def api_public_discussion(session_id: str) -> JSONResponse:
             "entity_slug": entity_slug,
             "approved_at": session.get("approved_at") or session.get("consent_at") or "",
             "messages": messages,
+            "participants": participants,
         }),
         headers={"Cache-Control": "public, max-age=600, s-maxage=600"},
     )

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -1,29 +1,47 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import SeoColumn from "@/components/seo/SeoColumn";
+import EntityLayout from "@/components/seo/EntityLayout";
 import JsonLd from "@/components/seo/JsonLd";
 import {
   SITE_URL,
   abs,
   breadcrumbJsonLd,
   fetchPublicDiscussion,
+  fetchDebatesList,
   metaDescription,
+  type PublicDiscussion,
 } from "@/lib/seo-mind";
 import MessageList from "@/components/chat/MessageList";
 import ContinueComposer from "@/components/chat/ContinueComposer";
 import ShareButton from "@/components/share/ShareButton";
+import JoinDiscussionButton from "@/components/symposium/JoinDiscussionButton";
 import type { Message } from "@/lib/chat";
 import { mindColor, mindInitials } from "@/lib/minds";
 
 // A single approved, PII-scrubbed public discussion. Data comes from
-// GET /api/public-discussions/{id} (mirrors the legacy public_session_page:
-// gated on ENABLE_PUBLIC_DISCUSSIONS + public_status='approved'). When the
-// feature is off or the session isn't approved the endpoint 404s and we keep
-// a stable, friendly "not available" page (the URL is a shareable permalink,
-// so we avoid a hard 404) and noindex it.
+// GET /api/public-discussions/{id} (gated on ENABLE_PUBLIC_DISCUSSIONS +
+// public_status='approved'). When the feature is off or the session isn't
+// approved the endpoint 404s and we keep a stable, friendly "not available"
+// page (the URL is a shareable permalink, so we avoid a hard 404) + noindex.
+//
+// A MULTI-MIND discussion (>=2 minds spoke) renders as a FULL symposium —
+// identical experience to a curated /symposium (Join this discussion +
+// participant chat rail + More symposiums), so the two kinds the /symposiums
+// feed mixes together behave the same (Steve, 2026-06-14). A single-mind / book
+// chat keeps the plain read-only "shared conversation" page.
 
 export const revalidate = 600;
 export const dynamicParams = true;
+
+/** Display title: a session shared without a title comes through as "New chat";
+ *  fall back to the first user question (the actual topic), else a generic label. */
+function pickTitle(disc: PublicDiscussion): string {
+  const t = (disc.title || "").trim();
+  if (t && t.toLowerCase() !== "new chat") return t;
+  const firstQ = (disc.messages.find((m) => m.role === "user")?.content || "").trim();
+  return firstQ.slice(0, 90) || "Symposium";
+}
 
 export async function generateMetadata({
   params,
@@ -40,7 +58,7 @@ export async function generateMetadata({
       alternates: { canonical },
     };
   }
-  const title = disc.title || "Discussion on Feynman";
+  const title = pickTitle(disc);
   const desc = metaDescription(
     `A public discussion shared by ${disc.handle} on Feynman.`,
   );
@@ -115,10 +133,7 @@ export default async function PublicDiscussionPage({
     );
   }
 
-  const title = disc.title || "Discussion on Feynman";
-  // Footer is just the continue-composer now (Steve, 2026-06-14): no "Browse the
-  // library" / "More from this book" link — a shared chat should only offer to
-  // continue the conversation.
+  const title = pickTitle(disc);
   const forumLd = {
     "@context": "https://schema.org",
     "@type": "DiscussionForumPosting",
@@ -136,7 +151,7 @@ export default async function PublicDiscussionPage({
 
   // Render the shared transcript with the SAME component the live chat uses, so
   // a shared conversation looks exactly like it does in-app (Feynman + mind
-  // avatars, names, markdown) — read-only (no composer, no per-message share).
+  // avatars, names, markdown), read-only.
   const transcript: Message[] = disc.messages.map((m): Message =>
     m.role === "mind"
       ? { role: "mind", content: m.content, mindName: m.speaker || "A great mind" }
@@ -149,64 +164,136 @@ export default async function PublicDiscussionPage({
       disc.messages.filter((m) => m.role === "mind").map((m) => m.speaker || ""),
     ),
   ].filter(Boolean) as string[];
-  // A multi-mind discussion (2+ minds spoke) is a user-made symposium — give it
-  // the same header as the curated /symposium pages (question title + a
-  // participant roster strip) instead of the generic "shared conversation"
-  // banner. Single-mind / book chats keep the plain banner.
   const isSymposium = knownMindNames.length >= 2;
-  const roster =
-    knownMindNames.length <= 1
-      ? knownMindNames[0] || ""
-      : knownMindNames.slice(0, -1).join(", ") +
-        " and " +
-        knownMindNames[knownMindNames.length - 1];
 
+  // ── Multi-mind discussion → a FULL symposium, identical to a curated
+  //    /symposium: Join this discussion (→ live multi-mind chat) + participant
+  //    chat rail + More symposiums. Unifies the experience the /symposiums feed
+  //    mixes together (Steve, 2026-06-14). ──
+  if (isSymposium) {
+    const participants = (disc.participants || []).filter((p) => p.mind_name);
+    // The minds' remarks replayed into the live chat on Join (same handoff as a
+    // curated symposium): each mind turn → {mind_id, mind_name, content}.
+    const turns = disc.messages
+      .filter((m) => m.role === "mind")
+      .map((m) => ({
+        mind_id: m.mind_id || "",
+        mind_name: m.speaker || "A great mind",
+        content: m.content,
+      }));
+    const pNames = participants.map((p) => p.mind_name);
+    const roster =
+      pNames.length <= 1
+        ? pNames[0] || ""
+        : pNames.slice(0, -1).join(", ") + " and " + pNames[pNames.length - 1];
+    const more = (await fetchDebatesList()).filter((x) => x.slug !== disc.id).slice(0, 6);
+
+    const hero = (
+      <>
+        <p className="seo-meta">Symposium · shared by {disc.handle || "Anonymous"}</p>
+        <h1>{title}</h1>
+        <div className="chat-system-notice mind-join-notice symposium-join">
+          <div className="join-notice-inner">
+            {participants.map((p) => (
+              <span
+                key={p.mind_id || p.mind_name}
+                className="join-avatar"
+                style={{ background: mindColor(p.mind_name) }}
+              >
+                {mindInitials(p.mind_name)}
+              </span>
+            ))}
+            <span>{roster} in conversation</span>
+          </div>
+        </div>
+        <p className="symposium-lede">
+          {participants.length} great minds took up one question — each in their own
+          voice, answering the others. Read the exchange, then join the conversation
+          yourself.
+        </p>
+        <div className="symposium-hero-actions">
+          <JoinDiscussionButton question={title} participants={participants} turns={turns} />
+          <ShareButton
+            url={canonical}
+            title={title}
+            subject="Symposium"
+            label="Share this symposium"
+            variant="secondary"
+          />
+        </div>
+      </>
+    );
+
+    const rail = (
+      <>
+        <div className="seo-rail-card">
+          <h3>Chat with a participant</h3>
+          <ul>
+            {participants.map((p) => {
+              const ref = p.mind_slug || p.mind_id;
+              return (
+                <li key={p.mind_id || p.mind_name}>
+                  {ref ? (
+                    <Link href={`/mind/${encodeURIComponent(ref)}/chat`}>{p.mind_name}</Link>
+                  ) : (
+                    <span>{p.mind_name}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        {more.length ? (
+          <div className="seo-rail-card">
+            <h3>More symposiums</h3>
+            <ul>
+              {more.map((x) => (
+                <li key={x.slug}>
+                  <Link
+                    href={
+                      x.source === "community"
+                        ? `/discussions/${x.slug}`
+                        : `/symposium/${x.slug}`
+                    }
+                  >
+                    {x.question}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </>
+    );
+
+    return (
+      <EntityLayout hero={hero} rail={rail}>
+        <JsonLd data={forumLd} />
+        <JsonLd data={breadcrumbLd} />
+        <div className="shared-transcript">
+          <MessageList messages={transcript} knownMindNames={knownMindNames} />
+        </div>
+      </EntityLayout>
+    );
+  }
+
+  // ── Single-mind / book chat → the plain read-only shared-conversation page
+  //    (banner + transcript + continue). Not a symposium. ──
   return (
     <SeoColumn>
       <JsonLd data={forumLd} />
       <JsonLd data={breadcrumbLd} />
-
-      {isSymposium ? (
-        // User-made symposium: question as the visible title + a participant
-        // roster strip (the same .mind-join-notice treatment as /symposium).
-        <>
-          <p className="seo-meta">Symposium · shared by {disc.handle || "Anonymous"}</p>
-          <h1 className="discussion-symposium-h1">{title}</h1>
-          <div className="chat-system-notice mind-join-notice symposium-join">
-            <div className="join-notice-inner">
-              {knownMindNames.map((name) => (
-                <span
-                  key={name}
-                  className="join-avatar"
-                  style={{ background: mindColor(name) }}
-                >
-                  {mindInitials(name)}
-                </span>
-              ))}
-              <span>{roster} in conversation</span>
-            </div>
-          </div>
-          <div className="symposium-hero-actions">
-            <ShareButton url={canonical} subject="Symposium" title={title} variant="secondary" />
-          </div>
-        </>
-      ) : (
-        <>
-          {/* h1 kept for SEO but visually hidden — the chat itself has no big
-              title; the question is the first turn of the transcript below. */}
-          <h1 className="sr-only">{title}</h1>
-          <div className="shared-banner">
-            <span className="shared-banner-label">Shared conversation on Feynman</span>
-            <span className="shared-banner-by">Shared by {disc.handle || "Anonymous"}</span>
-            <ShareButton url={canonical} subject="Shared conversation" title={title} variant="ghost" />
-          </div>
-        </>
-      )}
-
+      {/* h1 kept for SEO but visually hidden — the chat itself has no big title;
+          the question is the first turn of the transcript below. */}
+      <h1 className="sr-only">{title}</h1>
+      <div className="shared-banner">
+        <span className="shared-banner-label">Shared conversation on Feynman</span>
+        <span className="shared-banner-by">Shared by {disc.handle || "Anonymous"}</span>
+        <ShareButton url={canonical} subject="Shared conversation" title={title} variant="ghost" />
+      </div>
       <div className="shared-transcript">
         <MessageList messages={transcript} knownMindNames={knownMindNames} />
       </div>
-
       <ContinueComposer id={params.id} />
     </SeoColumn>
   );

--- a/web/components/seo/SymposiumsFeed.tsx
+++ b/web/components/seo/SymposiumsFeed.tsx
@@ -45,8 +45,10 @@ export default function SymposiumsFeed({ debates }: { debates: DebateListItem[] 
 
       <div className="symposium-feed">
         {shown.map((d) => {
-          // Community symposiums are user-shared multi-mind discussions — they
-          // live at /discussions/{id}, not /symposium/{slug}, and carry a badge.
+          // Community symposiums (user-shared multi-mind discussions) live at
+          // /discussions/{id} — but render as a full symposium there now, so the
+          // experience is identical to a curated /symposium/{slug}. Same label
+          // dimension too: they carry an inferred topic (not a "Community" badge).
           const community = d.source === "community";
           const href = community ? `/discussions/${d.slug}` : `/symposium/${d.slug}`;
           return (
@@ -69,11 +71,7 @@ export default function SymposiumsFeed({ debates }: { debates: DebateListItem[] 
                     <span className="symposium-row-names">{d.participants.join(", ")}</span>
                   </>
                 ) : null}
-                {community ? (
-                  <span className="symposium-row-badge">Community</span>
-                ) : d.topic ? (
-                  <span className="symposium-row-topic">{d.topic}</span>
-                ) : null}
+                {d.topic ? <span className="symposium-row-topic">{d.topic}</span> : null}
               </div>
             </Link>
           );

--- a/web/lib/seo-mind.ts
+++ b/web/lib/seo-mind.ts
@@ -908,8 +908,18 @@ export interface PublicDiscussion {
   /** Descriptive slug of the linked book/mind (uuid fallback). Avoids the 301. */
   entity_slug?: string;
   approved_at: string;
-  /** speaker: a mind answer's name (mind turns), "Feynman" (assistant), or "" (user). */
-  messages: Array<{ role: string; content: string; speaker?: string }>;
+  /** speaker: a mind answer's name (mind turns), "Feynman" (assistant), or "" (user).
+   *  mind_id/mind_slug: resolved per mind turn so a multi-mind discussion can render
+   *  as a full symposium (Join chips + per-participant chat links need ids/slugs). */
+  messages: Array<{
+    role: string;
+    content: string;
+    speaker?: string;
+    mind_id?: string;
+    mind_slug?: string;
+  }>;
+  /** Distinct minds that spoke (≥2 ⇒ rendered as a symposium) — drives Join + rail. */
+  participants?: Array<{ mind_id: string; mind_name: string; mind_slug?: string }>;
 }
 
 /**


### PR DESCRIPTION
Steve flagged the /symposiums feed: two card types that look alike but behaved totally differently — a "Community" source badge vs a topic tag (different label *dimensions*), and clicking through gave a read-only `/discussions` page vs a full `/symposium` (Join + participant rail). Root cause: I'd reused the plain UGC discussion page for community symposiums.

## Now unified
- **Detail**: a multi-mind `/discussions/{id}` renders as a **full symposium** — EntityLayout + "Join this discussion" (→ live multi-mind chat, same handoff as curated) + "Chat with a participant" rail + "More symposiums", identical to a curated `/symposium`. `api_public_discussion` resolves each mind's id/slug from its name (meta stores only the name) + returns `participants[]` so the Join chips + rail links work. Single-mind / book chats keep the plain read-only page.
- **Label**: community rows carry an **inferred topic** (participant domain × TOPIC_TAGS via `debates._topic_match` — whole-word, excludes the ambiguous "design"), so the feed shows ONE dimension (topic), no "Community" badge.
- **Bonus**: a session shared without a title (showed "New chat") falls back to its first user question.

## Verified locally (e2e)
Community detail shows Join + rail + participant chat links; feed shows topic (Business & Strategy for a Jobs/Bezos chat), no badge; topic inference fixed (was mis-tagging Jobs/Bezos as Art & Design via the "design" substring). tsc + py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)