### PR TITLE
Fix truncated starter questions + fragmented citation markdown

### DIFF
--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -136,30 +136,41 @@ export default function HomeComposer() {
 
   // Starters mirror the book context: with a single selected book they become
   // title-specific (legacy generateStarters); with none, the default set.
-  const starters = (() => {
+  // Each starter is {label, value}: `label` truncates the (often long) title so
+  // the chip stays compact, but `value` keeps the FULL title so the question that
+  // actually gets sent — and shown in the transcript — isn't truncated. (Before,
+  // a single truncated string was both shown AND sent, so the chat asked about
+  // "…Coffee St…" instead of the whole book.)
+  const starters: { label: string; value: string }[] = (() => {
     const sel = [...books.values()];
     const short = (t: string, max = 30) =>
       t.length <= max ? t : t.slice(0, max - 1).trimEnd() + "…";
+    const mk = (label: string, value: string) => ({ label, value });
     if (sel.length === 1) {
-      const t = short(sel[0].title);
+      const full = sel[0].title;
+      const t = short(full);
       return [
-        `What are the key ideas in "${t}"?`,
-        `Summarize the core argument of "${t}"`,
-        `What makes "${t}" unique?`,
-        `Quiz me on "${t}"`,
+        mk(`What are the key ideas in "${t}"?`, `What are the key ideas in "${full}"?`),
+        mk(`Summarize the core argument of "${t}"`, `Summarize the core argument of "${full}"`),
+        mk(`What makes "${t}" unique?`, `What makes "${full}" unique?`),
+        mk(`Quiz me on "${t}"`, `Quiz me on "${full}"`),
       ];
     }
     if (sel.length >= 2) {
-      const a = short(sel[0].title);
-      const b = short(sel[1].title);
+      const fa = sel[0].title;
+      const fb = sel[1].title;
+      const a = short(fa);
+      const b = short(fb);
       return [
-        `Compare "${a}" and "${b}"`,
-        `What do "${a}" and "${b}" have in common?`,
-        `Key ideas in "${a}"?`,
-        sel.length > 2 ? `What do these ${sel.length} books cover together?` : `Key ideas in "${b}"?`,
+        mk(`Compare "${a}" and "${b}"`, `Compare "${fa}" and "${fb}"`),
+        mk(`What do "${a}" and "${b}" have in common?`, `What do "${fa}" and "${fb}" have in common?`),
+        mk(`Key ideas in "${a}"?`, `Key ideas in "${fa}"?`),
+        sel.length > 2
+          ? mk(`What do these ${sel.length} books cover together?`, `What do these ${sel.length} books cover together?`)
+          : mk(`Key ideas in "${b}"?`, `Key ideas in "${fb}"?`),
       ];
     }
-    return DEFAULT_STARTERS;
+    return DEFAULT_STARTERS.map((s) => mk(s, s));
   })();
 
   const pickStarter = (q: string) => {
@@ -516,9 +527,9 @@ export default function HomeComposer() {
             Start a debate between great minds
           </button>
         ) : null}
-        {starters.map((q) => (
-          <button key={q} type="button" className="starter-pill" onClick={() => pickStarter(q)}>
-            {q}
+        {starters.map((s) => (
+          <button key={s.value} type="button" className="starter-pill" onClick={() => pickStarter(s.value)}>
+            {s.label}
           </button>
         ))}
       </div>

--- a/web/components/chat/MessageList.tsx
+++ b/web/components/chat/MessageList.tsx
@@ -15,7 +15,7 @@
 
 import { useRef, useState } from "react";
 import type { Message, Reference, WebSource } from "@/lib/chat";
-import { renderMarkdown, esc, mindColor, mindInitials } from "./markdown";
+import { renderMarkdown, renderMarkdownBlocks, esc, mindColor, mindInitials } from "./markdown";
 import styles from "./MessageList.module.css";
 
 function FeynmanGlyph() {
@@ -204,8 +204,7 @@ function AssistantMessage({
   const cleaned = String(msg.content ?? "")
     .replace(/<div\b[^>]*>|<\/div>/gi, "")
     .trim();
-  const html = renderMarkdown(cleaned);
-  const tokens = tokenizeCitations(html, refsByIndex, webSrcs);
+  const blocks = renderMarkdownBlocks(cleaned);
 
   // Group references by book (port of the grouped-refs block in appendMsg).
   const grouped: { book: string; chunks: Reference[] }[] = [];
@@ -230,6 +229,24 @@ function AssistantMessage({
       ?.scrollIntoView({ behavior: "smooth", block: "center" });
   };
 
+  // Render one block's inline HTML, tokenizing citation [n] markers into real
+  // <Citation> nodes as CHILDREN of the block element — so block tags
+  // (ul/li/p/h) are never split across separate spans (the fragmentation bug).
+  const renderInline = (h: string) =>
+    tokenizeCitations(h, refsByIndex, webSrcs).map((t, i) =>
+      t.kind === "html" ? (
+        <span key={i} dangerouslySetInnerHTML={{ __html: t.html }} />
+      ) : (
+        <Citation
+          key={i}
+          num={t.num}
+          ref={refsByIndex.get(t.num)}
+          web={!refsByIndex.has(t.num) ? webSrcs[t.num - 1] : undefined}
+          onJump={jumpToRef}
+        />
+      ),
+    );
+
   return (
     <div className="chat-message assistant" dir="auto" ref={rootRef}>
       <div className="feynman-msg-avatar">
@@ -238,19 +255,22 @@ function AssistantMessage({
       <div className="feynman-msg-body">
         <div className="feynman-msg-name">Feynman</div>
         <div className="msg-content" dir="auto">
-          {tokens.map((t, i) =>
-            t.kind === "html" ? (
-              <span key={i} dangerouslySetInnerHTML={{ __html: t.html }} />
-            ) : (
-              <Citation
-                key={i}
-                num={t.num}
-                ref={refsByIndex.get(t.num)}
-                web={!refsByIndex.has(t.num) ? webSrcs[t.num - 1] : undefined}
-                onJump={jumpToRef}
-              />
-            ),
-          )}
+          {blocks.map((b, bi) => {
+            if (b.tag === "ul")
+              return (
+                <ul key={bi}>
+                  {b.items.map((it, ii) => (
+                    <li key={ii}>{renderInline(it)}</li>
+                  ))}
+                </ul>
+              );
+            if (b.tag === "raw")
+              return <div key={bi} dangerouslySetInnerHTML={{ __html: b.html }} />;
+            if (b.tag === "h2") return <h2 key={bi}>{renderInline(b.html)}</h2>;
+            if (b.tag === "h3") return <h3 key={bi}>{renderInline(b.html)}</h3>;
+            if (b.tag === "h4") return <h4 key={bi}>{renderInline(b.html)}</h4>;
+            return <p key={bi}>{renderInline(b.html)}</p>;
+          })}
         </div>
 
         {grouped.length > 0 && (

--- a/web/components/chat/markdown.ts
+++ b/web/components/chat/markdown.ts
@@ -86,6 +86,69 @@ export function renderMarkdown(text: string): string {
   return html;
 }
 
+/** A BLOCK-STRUCTURED variant of renderMarkdown (same rules), returning the
+ *  blocks so a caller can render each as a REAL element (ul/li/p/h) and tokenize
+ *  inline citations as that element's CHILDREN. The flat-string path splits the
+ *  citation `[n]` across separate dangerouslySetInnerHTML spans, and the browser
+ *  auto-closes the block tag (`<ul>/<li>/<p>`) inside each span — which
+ *  fragmented bulleted answers (a citation right after a bullet broke the list).
+ *  Used by AssistantMessage; mind/share messages keep plain renderMarkdown. */
+export type MdBlock =
+  | { tag: "ul"; items: string[] }
+  | { tag: "p" | "h2" | "h3" | "h4"; html: string }
+  | { tag: "raw"; html: string };
+
+export function renderMarkdownBlocks(text: string): MdBlock[] {
+  if (!text) return [];
+  const codeBlocks: string[] = [];
+  let s = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+    codeBlocks.push("<pre><code>" + esc(code) + "</code></pre>");
+    return "\x00CB" + (codeBlocks.length - 1) + "\x00";
+  });
+  const inlineCodes: string[] = [];
+  s = s.replace(/`([^`]+)`/g, (_m, code) => {
+    inlineCodes.push("<code>" + esc(code) + "</code>");
+    return "\x00IC" + (inlineCodes.length - 1) + "\x00";
+  });
+  const inline = (t: string): string => {
+    t = esc(t);
+    t = t.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    t = t.replace(/\*(.+?)\*/g, "<em>$1</em>");
+    t = t.replace(
+      /\[([^\]]+)\]\(([^\s؀-ۿ)]+)\)/g,
+      '<a href="$2" target="_blank" rel="noopener">$1</a>',
+    );
+    t = t.replace(/\x00IC(\d+)\x00/g, (_m, i) => inlineCodes[+i]);
+    return t;
+  };
+
+  const blocks: MdBlock[] = [];
+  let ul: string[] | null = null;
+  const flush = () => {
+    if (ul) {
+      blocks.push({ tag: "ul", items: ul });
+      ul = null;
+    }
+  };
+  for (const line of s.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("### ")) { flush(); blocks.push({ tag: "h4", html: inline(trimmed.slice(4)) }); continue; }
+    if (trimmed.startsWith("## ")) { flush(); blocks.push({ tag: "h3", html: inline(trimmed.slice(3)) }); continue; }
+    if (trimmed.startsWith("# ")) { flush(); blocks.push({ tag: "h2", html: inline(trimmed.slice(2)) }); continue; }
+    const m = trimmed.match(/^[-*]\s+(.+)$/) || trimmed.match(/^\d+[.)]\s+(.+)$/);
+    if (m) { (ul ??= []).push(inline(m[1])); continue; }
+    flush();
+    if (trimmed.startsWith("\x00CB")) {
+      blocks.push({ tag: "raw", html: trimmed.replace(/\x00CB(\d+)\x00/g, (_x, i) => codeBlocks[+i]) });
+      continue;
+    }
+    if (!trimmed) continue; // blank line is just a block separator
+    blocks.push({ tag: "p", html: inline(trimmed) });
+  }
+  flush();
+  return blocks;
+}
+
 // ── Mind avatar helpers (port of mindColor / mindInitials) ──────────────
 
 const MIND_COLORS = [


### PR DESCRIPTION
Two issues from screenshots:

## 1) Starter questions truncated the title — and sent it truncated
`short(title, 30)` truncated the book title, and that string was both shown AND sent → the chat asked about "…Coffee St…" instead of the whole book. Each starter is now `{label, value}`: label truncates for a compact chip, **value keeps the full title** so the sent question + the transcript are complete.

## 2) Feynman's bulleted answers rendered fragmented
`tokenizeCitations` split the block-level HTML at each `[n]`, and each slice rendered as its own `<span dangerouslySetInnerHTML>` → the browser auto-closed `<ul>/<li>/<p>` inside every span → a citation right after a bullet broke the list into stray pieces. Added `renderMarkdownBlocks()` so `AssistantMessage` renders each block as a **real element** (ul/li/p/h) and tokenizes inline citations as that element's **children** — block tags are never split, the React Citation hover popover is kept. Mind/share messages keep plain `renderMarkdown`.

## Verified
tsc clean; `renderMarkdownBlocks` unit test confirms bullet items keep their citation + trailing clause within one item. Will spot-check on prod after deploy (real RAG citations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)