### PR TITLE
Strip orphan [n] citation markers from public discussions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4783,6 +4783,10 @@ def api_public_discussion(session_id: str) -> JSONResponse:
         if role == "system-notice":
             continue
         content = ugc_module.scrub_pii_for_public_display(m.get("content", "") or "")
+        # Strip orphan citation markers: a shared discussion exposes no reference
+        # data (we don't return refs here), so [1] / [1, 2] would render as bare
+        # literal text instead of superscripts. Remove them so the reply reads clean.
+        content = re.sub(r"\s*\[\d+(?:\s*,\s*\d+)*\]", "", content)
         if not content.strip():
             continue
         # Speaker label: a 'mind' turn carries the mind's name in meta; the


### PR DESCRIPTION
Follow-up to the markdown-fragmentation fix. A shared discussion (`/discussions/{id}`, the community-symposium target) exposes no reference data — `/api/public-discussions` doesn't return refs — so a Feynman reply forked from a book chat showed bare literal `[1]` / `[1, 2]` text instead of superscripts. Strip the markers in `api_public_discussion` after the PII scrub. Private book chats keep refs + render real citation superscripts; only the ref-less public copy is stripped.

Verified: regex strips `[1]` / `[1, 2]` while keeping the trailing period; py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)