### PR TITLE
Investing topic + 3 investing-greats symposiums (Buffett/Munger/Graham/Dalio + Duan Yongping/Li Lu)

### DIFF
--- a/app/core/catalog.py
+++ b/app/core/catalog.py
@@ -25,6 +25,10 @@ TOPIC_TAGS = [
     # AI also tracks verified GSC demand (lecun/hinton/hassabis queries) and
     # grows with every tech-minds batch.
     "Artificial Intelligence", "Ethics",
+    # 2026-06-15 — Investing hub (Steve-requested). In-library greats
+    # Buffett/Munger/Graham/Dalio (domain contains "investing"), plus the built
+    # Duan Yongping / Li Lu for the Chinese value-investing side.
+    "Investing",
 ]
 
 # Number of books to discover per topic

--- a/app/core/debates.py
+++ b/app/core/debates.py
@@ -209,6 +209,16 @@ SEED_DEBATES: list[dict[str, Any]] = [
      "minds": ["Steve Jobs", "Jeff Bezos", "Clayton Christensen", "Bret Victor"]},
     {"q": "Do more features make a product better or worse?", "topic": "Business & Strategy",
      "minds": ["Steve Jobs", "Fred Brooks", "Donald Knuth", "Paul Graham"]},
+
+    # ── Investing greats (2026-06-15, Steve-requested) — value-investing tensions
+    # cast from the in-library greats (Buffett/Munger/Graham/Dalio) + the built
+    # Duan Yongping / Li Lu (Chinese value investing). topic "Investing".
+    {"q": "Should you concentrate your portfolio or diversify?", "topic": "Investing",
+     "minds": ["Warren Buffett", "Charlie Munger", "Benjamin Graham", "Ray Dalio"]},
+    {"q": "Cheap and safe, or a wonderful company at a fair price?", "topic": "Investing",
+     "minds": ["Benjamin Graham", "Warren Buffett", "Charlie Munger", "Duan Yongping"]},
+    {"q": "Can a patient investor reliably beat the market?", "topic": "Investing",
+     "minds": ["Warren Buffett", "Ray Dalio", "Li Lu", "Duan Yongping"]},
 ]
 
 


### PR DESCRIPTION
Steve-requested. New **Investing** TOPIC_TAGS hub + 3 value-investing symposiums.

## What
- **Topic**: `Investing` added to TOPIC_TAGS (Buffett/Munger/Graham/Dalio already carry domain "investing").
- **3 symposiums** (SEED_DEBATES): *concentrate vs diversify* · *cheap-and-safe vs wonderful-at-a-fair-price* · *can a patient investor beat the market* — cast from the in-library 4 + the newly built **Duan Yongping** ("China's Buffett") and **Li Lu** (Himalaya Capital, Munger's disciple).
- **Two new minds** built (`create_mind`, hand-written personas) and the symposiums generated on **prod** via DeepSeek. This PR carries the code record (topic + seed) for reproducibility; the data already lives in prod. The 2 minds' embeddings backfill via the `embed-minds` cron.

## Verified on prod
Voices are on point — Duan Yongping ("cheap or wonderful is secondary; understand the business — its model, its culture"), Li Lu ("a fractional ownership stake in a business, not an index to outmaneuver").

🤖 Generated with [Claude Code](https://claude.com/claude-code)