### PR TITLE
Fix outline refine 503 (drop grounding + widen provider fallback budget)

### DIFF
--- a/app/core/ai_writer.py
+++ b/app/core/ai_writer.py
@@ -136,8 +136,16 @@ def refine_outline(
     outline_str = json.dumps(current_outline, ensure_ascii=False, indent=2)
     system = f"{_REFINE_SYSTEM}\n\nCurrent outline:\n{outline_str}"
 
+    # No grounding here: restructuring an existing outline needs no fresh web
+    # research, and the Gemini google_search round-trips were the main cause of
+    # refine timing out (→ all-providers-failed → 503). thinking_budget=0 keeps
+    # this structural transform cheap + fast. A wider budget (45s × up to ~3
+    # providers, vs the default 30/50 that only reaches ~2) routes around a slow
+    # or hung first provider instead of dying before the healthy ones are tried.
     result, _ = chat_with_fallback(
-        system=system, user=user_message, history=history, use_grounding=True,
+        system=system, user=user_message, history=history,
+        use_grounding=False, thinking_budget=0,
+        timeout=45, max_total_seconds=120,
     )
 
     updated = _parse_json_from_text(result.content)

--- a/web/components/chat/useWriteBook.ts
+++ b/web/components/chat/useWriteBook.ts
@@ -88,7 +88,11 @@ export interface WriteBookState {
 function describeError(e: unknown, fallback: string): string {
   if (e instanceof ApiError) {
     if (e.status === 503)
-      return "The book writer is unavailable right now (no AI provider configured). Try again later.";
+      // 503 = all LLM providers were slow/unavailable for this call — a
+      // transient capacity/timeout issue, NOT a missing config. Keep the
+      // user-facing copy clean (no provider names or internals); the real
+      // detail is still in the 503 response body for debugging.
+      return "The book writer is busy right now. Please try again in a moment.";
     if (e.status === 401 || e.status === 403)
       return "You need to be signed in to write a book.";
     const detail =


### PR DESCRIPTION
## Problem

Updating a book outline (the "我觉得还是按年来，每年一个chapter" refine step) intermittently failed with **"Error updating outline: The book writer is unavailable right now (no AI provider configured)"**, even though the *initial* outline generated fine and a trivial message like "try" still worked.

## Root cause

`start` (`generate_outline`) and refine (`refine_outline`) go through the **same** `chat_with_fallback`, so it was never a missing-config issue. But refine is far heavier:

- It re-emits the **entire outline as JSON** every call, and
- ran with **Gemini `google_search` grounding**, whose round-trips made the call slow.

The fallback budget is `timeout=30` + `max_total_seconds=30+20=50`, so a slow first provider (DeepSeek) eats the budget and only **~2 providers** are ever attempted before `ProviderError("All providers failed")` → **503**. The remaining healthy providers are never tried. Trivial messages stayed fast and succeeded — exactly the observed symptom.

## Fix

**Backend — `app/core/ai_writer.py` `refine_outline`:**
- `use_grounding=False` — restructuring an existing outline needs no fresh web research; grounding was the main latency source.
- `thinking_budget=0` — structural transform doesn't need deep reasoning; ~3× cheaper output + faster.
- `timeout=45`, `max_total_seconds=120` — reach ~3 providers instead of ~2, routing around a slow/hung first provider. This is "free" on the happy path (returns in seconds); it only spends more on the path that would otherwise 503.
- `generate_outline` left unchanged (it works, and grounding adds value on the first draft).

**Frontend — `web/components/chat/useWriteBook.ts` `describeError`:**
- 503 no longer claims "no AI provider configured" (misleading — it's a transient timeout, not a config gap) and **no longer leaks provider names** to users. Clean "busy, try again" copy. The real detail stays in the 503 response body for debugging.

## Verification
- `python -m py_compile app/core/ai_writer.py` ✅
- Confirmed `chat_with_fallback` accepts `use_grounding` / `thinking_budget` / `timeout` / `max_total_seconds` ✅
- Frontend can't be typechecked locally (no `node_modules`); gated on the feynman-web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)