### PR TITLE
Starter 'Start a debate' pill: drop static accent (looked default-selected)

### DIFF
--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -691,11 +691,12 @@ body {
   border-color: var(--accent); color: var(--accent);
   box-shadow: var(--shadow-sm);
 }
-/* "Start a debate" — surfaces the multi-mind path from the empty state. Accent
-   outline so it reads as the lead suggestion; fills in on hover. Opens the
+/* "Start a debate" — surfaces the multi-mind path from the empty state. Styled
+   IDENTICALLY to the other starter pills AT REST: the earlier static accent
+   outline read as a "default-selected" first chip (Steve, 2026-06-15). Only its
+   hover fills with accent to mark the special multi-mind entry. Opens the
    invite-minds popover (not a prefilled prompt). */
-.starter-pill-debate { border-color: var(--accent); color: var(--accent); font-weight: 600; }
-.starter-pill-debate:hover { background: var(--accent); color: #fff; box-shadow: var(--shadow-sm); }
+.starter-pill-debate:hover { background: var(--accent); color: #fff; border-color: var(--accent); box-shadow: var(--shadow-sm); }
 
 .home-hint {
   margin-top: 16px; font-size: 13px; color: var(--text-muted);


### PR DESCRIPTION
The empty-state "Start a debate" pill had a static accent border + accent text + bold (#179), which read as a **default-selected first chip** on the home composer. Removed the static accent so it matches the other starter pills at rest; only its hover still fills with accent to mark the special multi-mind entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)