### PR TITLE
Symposiums: "Convene your own symposium" CTA → the debate composer

### DIFF
--- a/web/app/symposiums/page.tsx
+++ b/web/app/symposiums/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import SeoColumn from "@/components/seo/SeoColumn";
 import JsonLd from "@/components/seo/JsonLd";
 import SymposiumsFeed from "@/components/seo/SymposiumsFeed";
@@ -73,6 +74,38 @@ export default async function SymposiumsIndexPage() {
         question, each in their own voice, engaging the others. Read the
         symposium, then join the conversation.
       </p>
+
+      {/* Create affordance. Most visitors never discover that a symposium is
+          just a chat with 2+ minds invited — this panel teaches the mechanic and
+          routes into the SAME home debate composer (?debate=1) the "Start a
+          debate" pill uses, so convening one is identical to that flow and
+          inherits its sign-in → Pro gate. Shown even with zero debates so the
+          first symposium can be convened. */}
+      <Link href="/?debate=1" prefetch={false} className="symposium-create">
+        <span className="symposium-create-text">
+          <span className="symposium-create-title">Convene your own symposium</span>
+          <span className="symposium-create-sub">
+            Pick 2-4 great minds, pose a question, and watch them debate it — each
+            in their own voice.
+          </span>
+        </span>
+        <span className="symposium-create-cta">
+          Start a symposium
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14M13 6l6 6-6 6" />
+          </svg>
+        </span>
+      </Link>
 
       {debates.length ? (
         <SymposiumsFeed debates={debates} />

--- a/web/components/chat/HomeComposer.tsx
+++ b/web/components/chat/HomeComposer.tsx
@@ -199,6 +199,18 @@ export default function HomeComposer() {
       return;
     }
 
+    // ?debate=1 — the "convene a symposium" deep link (the /symposiums "Start a
+    // symposium" CTA, and any future cross-surface link to the multi-mind path).
+    // Open the invite popover so the visitor assembles a 2+ mind panel; the
+    // placeholder then nudges "pose a question — they'll debate it". Identical
+    // behaviour to the home "Start a debate" pill (onClick setMindsOpen), just
+    // reachable by URL so other surfaces can route into the SAME flow.
+    if (params.get("debate")) {
+      setMindsOpen(true);
+      track("chat_cta_clicked", { surface: "symposiums", label: "convene_symposium" });
+      return;
+    }
+
     // No query params → try a pending intent (read+validate TTL+clear).
     const intent = restorePendingBookIntent();
     if (intent) {

--- a/web/components/landing/HomeOrLanding.tsx
+++ b/web/components/landing/HomeOrLanding.tsx
@@ -31,12 +31,13 @@ export default function HomeOrLanding() {
 
   // Tracks the localStorage flag. `null` = not yet read (SSR / first paint).
   const [landed, setLanded] = useState<boolean | null>(null);
-  // A cross-surface chat link — /?book, /?q or /?mind — means the visitor came
-  // to chat about something specific (the SEO, Reader and library "Chat" CTAs
-  // all route through these params). Such a visitor must drop into the composer
-  // with the book preselected, NEVER the marketing landing page — otherwise an
-  // anonymous arrival from Google/an SEO page silently loses the book they came
-  // for. `null` = not yet read (SSR / first paint).
+  // A cross-surface chat link — /?book, /?q, /?mind or /?debate — means the
+  // visitor came to chat about something specific (the SEO, Reader and library
+  // "Chat" CTAs route through book/q/mind; the /symposiums "Convene a symposium"
+  // CTA routes through ?debate). Such a visitor must drop into the composer,
+  // NEVER the marketing landing page — otherwise an anonymous arrival from
+  // Google/an SEO page silently loses the intent they came for. `null` = not yet
+  // read (SSR / first paint).
   const [hasChatIntent, setHasChatIntent] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -47,7 +48,9 @@ export default function HomeOrLanding() {
     }
     try {
       const sp = new URLSearchParams(window.location.search);
-      setHasChatIntent(sp.has("book") || sp.has("q") || sp.has("mind"));
+      setHasChatIntent(
+        sp.has("book") || sp.has("q") || sp.has("mind") || sp.has("debate"),
+      );
     } catch {
       setHasChatIntent(false);
     }

--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -661,6 +661,41 @@ body { background-color: var(--bg-home); }
 .symposium-join-cta:hover { opacity: 0.88; }
 .symposium-join-cta:disabled { opacity: 0.55; cursor: default; }
 
+/* "Convene your own symposium" — the create affordance atop the /symposiums
+   feed. One inviting panel: a label that teaches the mechanic + a primary
+   button. The whole panel is the link (a big, smooth target) into ?debate=1. */
+/* Scoped to .seo-content so `text-decoration: none` beats the prose-link rule
+   `.seo-content a { text-decoration: underline }` — otherwise the whole panel
+   (an anchor) gets an underline under its title/sub. */
+.seo-content a.symposium-create {
+  display: flex; align-items: center; justify-content: space-between; gap: 18px;
+  margin: 18px 0 6px; padding: 16px 18px;
+  border: 1px solid var(--border-strong); border-radius: 14px;
+  background: var(--bg-chat); color: var(--text); text-decoration: none;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.12s ease;
+}
+.symposium-create:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 12px rgba(10, 110, 230, 0.13);
+  transform: translateY(-1px);
+}
+.symposium-create-text { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.symposium-create-title { font-size: 15px; font-weight: 650; color: var(--text); }
+.symposium-create-sub { font-size: 13px; line-height: 1.45; color: var(--text-muted); }
+.symposium-create-cta {
+  flex-shrink: 0; display: inline-flex; align-items: center; gap: 6px;
+  padding: 9px 16px; border-radius: var(--r-control);
+  background: var(--accent); color: #fff; font-size: 14px; font-weight: 600;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.10), 0 2px 8px rgba(10, 110, 230, 0.22);
+  transition: filter 0.15s ease;
+}
+.symposium-create:hover .symposium-create-cta { filter: brightness(0.96); }
+@media (max-width: 560px) {
+  .symposium-create { flex-direction: column; align-items: stretch; gap: 12px; }
+  .symposium-create-cta { justify-content: center; }
+}
+
 /* ── /symposiums index — a single-column question stream (the question is the
    hook), with topic chips to filter. Not grouped, not a grid. ── */
 .symposium-filters { display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 6px; }


### PR DESCRIPTION
## What
The `/symposiums` feed had no way to **start** one. This adds a "Convene your own symposium" panel atop the feed.

Most visitors never discover that a symposium is just a chat with 2+ minds invited — the panel teaches that mechanic and presents the value, then one click drops the visitor into the **same** home debate composer the "Start a debate" pill already uses (via a new `?debate=1` deep link). No divergent create-flow — convening a symposium is identical to that flow and inherits its sign-in → Pro gate.

## How
- **`symposiums/page.tsx`** — `Convene your own symposium` panel (`Link` → `/?debate=1`), shown even with zero debates so the first can be convened.
- **`HomeComposer`** — `?debate=1` opens the minds invite popover (mirrors the pill's `onClick={() => setMindsOpen(true)}`) + fires `chat_cta_clicked{surface:"symposiums"}` for funnel parity.
- **`HomeOrLanding`** — `?debate` counts as chat-intent, so a signed-out arrival reaches the composer instead of the marketing landing (matches the existing `?book`/`?q`/`?mind` override).
- **`liquid.css`** — `.symposium-create` panel styling, scoped to `.seo-content` so the no-underline reset beats the prose-link rule.

## Verified (local open-source build)
- Card renders clean on `/symposiums` (no stray prose underline), placed between the intro and the topic filters.
- `/?debate=1` opens the composer with the **minds picker open** (search + multi-select) and the Pro/sign-in gate intact (locked items + "Pro Upgrade" badge for a signed-out visitor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)