### PR TITLE
SEO: self-canonicalize the / route (param variants were canonical-less)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import HomeOrLanding from "@/components/landing/HomeOrLanding";
 
 /**
@@ -5,6 +6,18 @@ import HomeOrLanding from "@/components/landing/HomeOrLanding";
  * whether an anonymous first-time visitor sees the marketing LANDING or the
  * app HOME (the previous contents of this file, now in components/home/HomePage).
  */
+export const metadata: Metadata = {
+  // Self-canonicalize the `/` route. It renders the SAME app shell for every
+  // query-param variant — ?book / ?q / ?mind / ?debate are utility deep-links
+  // into the composer, not distinct content — so without this each variant is a
+  // canonical-less duplicate of home ("Duplicate without user-selected
+  // canonical"). The unique content lives at /book/{slug}, /mind/{slug}, etc.,
+  // which set their own canonicals; the root layout deliberately sets none (a
+  // layout-level canonical would force EVERY page to claim "/"). Relative — Next
+  // resolves it against metadataBase → https://feynman.wiki/.
+  alternates: { canonical: "/" },
+};
+
 export default function Page() {
   return <HomeOrLanding />;
 }


### PR DESCRIPTION
## Context
Triggered by a GSC alert — "Duplicate without user-selected canonical" on sitemap pages.

## Finding
The home route (`web/app/page.tsx`) exported **no metadata**, so `/` and every query-param variant (`?book`, `?q`, `?mind`, and the new `?debate=1` from #206) emitted **no canonical tag** — the literal "without user-selected canonical" case. The unique content already lives at `/book/{slug}`, `/mind/{slug}`, etc., which self-canonicalize correctly.

## Fix
Add a page-level self-canonical to `/` (relative, resolves against the layout's `metadataBase`). Consistent with the root layout's deliberate "pages self-canonicalize, layout sets none" design.

## Verified locally
`/`, `/?debate=1`, `/?book=the-hobbit` all now emit `<link rel="canonical" href="https://feynman.wiki">`.

> Note: this closes the one canonical gap I could confirm. Per URL-Inspection-API diagnosis, the **dominant** not-indexed reason remains "Discovered – currently not indexed" (crawl budget — even flagship pages aren't crawled yet); the duplicate bucket is a smaller secondary issue still being pinpointed from the GSC report examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)