### PR TITLE
SEO: point /?mind=&q= param canonicals to the real entity (not home)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,22 +1,34 @@
 import type { Metadata } from "next";
 import HomeOrLanding from "@/components/landing/HomeOrLanding";
 
+type SP = { [key: string]: string | string[] | undefined };
+
 /**
  * Route entry for `/`. Stays a server component; the client gate decides
  * whether an anonymous first-time visitor sees the marketing LANDING or the
  * app HOME (the previous contents of this file, now in components/home/HomePage).
  */
-export const metadata: Metadata = {
-  // Self-canonicalize the `/` route. It renders the SAME app shell for every
-  // query-param variant — ?book / ?q / ?mind / ?debate are utility deep-links
-  // into the composer, not distinct content — so without this each variant is a
-  // canonical-less duplicate of home ("Duplicate without user-selected
-  // canonical"). The unique content lives at /book/{slug}, /mind/{slug}, etc.,
-  // which set their own canonicals; the root layout deliberately sets none (a
-  // layout-level canonical would force EVERY page to claim "/"). Relative — Next
-  // resolves it against metadataBase → https://feynman.wiki/.
-  alternates: { canonical: "/" },
-};
+export async function generateMetadata(
+  { searchParams }: { searchParams: SP },
+): Promise<Metadata> {
+  // `/` renders the SAME app shell for every query-param variant — ?book / ?q /
+  // ?mind / ?debate are utility deep-links into the composer (a preselected
+  // entity + prefilled question), NOT distinct content. Google had indexed ~2K
+  // thin `/?mind=X&q=Y` quote-CTA URLs that earn ZERO impressions while the real
+  // entity pages they point at sit "discovered, not indexed". So canonicalize
+  // each param page to the REAL entity it's a chat-entry for — consolidating the
+  // signal onto the page that actually ranks (and nudging Google to index it),
+  // not generic home. Paramless `/`, a bare `?q=`, or `?debate=1` → home.
+  // The entity detail pages set their own canonicals; the root layout sets none.
+  const one = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v) || "";
+  // Slug/uuid only — reject anything with a slash, dot or space so a stray param
+  // can never point the canonical outside the entity namespace.
+  const safe = (s: string) => (/^[a-zA-Z0-9-]+$/.test(s) ? s : "");
+  const mind = safe(one(searchParams.mind));
+  const book = safe(one(searchParams.book));
+  const canonical = mind ? `/mind/${mind}` : book ? `/book/${book}` : "/";
+  return { alternates: { canonical } };
+}
 
 export default function Page() {
   return <HomeOrLanding />;


### PR DESCRIPTION
## Why
Follow-up to #208, driven by the GSC data behind the "Duplicate without user-selected canonical" alert.

The indexed 2.02K is **dominated by ~2K thin `/?mind={slug}&q={question}` quote-CTA URLs** (composer deep-links with a prefilled question, no answer content). Per the GSC page report they earn **0 impressions / 0 clicks over 28 days** — pure index bloat — while the real entity pages they deep-link into sit "discovered, not indexed":

| bucket | URLs | impressions (28d) |
|---|---|---|
| `/mind/{slug}` | 183 | **619** |
| `/mind/{}/q/` | 74 | 171 |
| `/book/{slug}` | 81 | 162 |
| `/?mind=&q=` (≈2K indexed) | — | **0** |

## What
`#208` canonicalized every `/?…` variant to **home**. This points each param page to its **real entity** instead, so the (small) signal consolidates onto the page that actually ranks — and nudges Google to index the entity page rather than the thin param page (it currently has it backwards).

`generateMetadata` reads `searchParams`:
- `?mind={slug}` → `/mind/{slug}`
- `?book={slug}` → `/book/{slug}`
- `/`, bare `?q=`, `?debate=1` → `/`
- slug-only guard (reject `/`,`.`,space) so a stray param can't aim the canonical outside the entity namespace

## Verified locally
`/?mind=karl-marx&q=…` → `/mind/karl-marx`, `/?book=the-hobbit` → `/book/the-hobbit`, `/` `/?q=` `/?debate=1` → home, `/?mind=bad%2Fslug` → home.

## Expected effect
The indexed count will **drop from 2.02K** as the ~2K zero-traffic param pages deindex — this is healthy index hygiene (no traffic lost), and it concentrates crawl/index signal on the entity pages that earn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)