### PR TITLE
SEO ①: noindex the 5 generic-fallback /q questions (2,005 duplicate pages)

### DIFF
--- a/app/core/seo.py
+++ b/app/core/seo.py
@@ -55,6 +55,25 @@ def slugify(text: str, max_len: int = 80) -> str:
     return s
 
 
+# The 5 generic fallback questions inserted when book-specific question
+# generation fails. Byte-identical across ~400 books, so their /q pages
+# duplicate one another in GSC ("Duplicate without user-selected canonical")
+# and aren't real search queries. Excluded from the sitemap (below) + noindexed
+# on the frontend (web/lib/seo-book.ts GENERIC_FALLBACK_QUESTIONS — keep in sync).
+GENERIC_FALLBACK_QUESTIONS = frozenset({
+    "What is the central thesis of this text?",
+    "What evidence does the author provide?",
+    "How would you explain the key concepts in your own words?",
+    "What are the practical implications?",
+    "What questions remain unanswered?",
+})
+
+
+def is_generic_fallback_question(q: str) -> bool:
+    """A question that is one of the templated fallbacks (duplicate across books)."""
+    return (q or "").strip() in GENERIC_FALLBACK_QUESTIONS
+
+
 # ─── JSON-LD schema builders ──────────────────────────────────────────
 
 def breadcrumb_jsonld(items: list[tuple[str, str]]) -> dict[str, Any]:

--- a/app/main.py
+++ b/app/main.py
@@ -928,6 +928,12 @@ def sitemap_xml():
             if _editorial_frozen(agent):
                 continue
             for q in questions_by_agent.get(agent_id, []):
+                # Generic fallback questions are byte-identical across ~400 books
+                # (duplicate /q pages); the frontend noindexes them, so don't
+                # advertise them here either (avoids "submitted URL marked
+                # noindex" sitemap warnings).
+                if seo_render.is_generic_fallback_question(q):
+                    continue
                 qslug = seo_render.slugify(q)
                 if not qslug:
                     continue

--- a/web/app/book/[id]/q/[slug]/page.tsx
+++ b/web/app/book/[id]/q/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   getSamplePassages,
   getBookQa,
   findQuestionBySlug,
+  isGenericFallbackQuestion,
   clampDescription,
   qaPageJsonld,
   breadcrumbJsonld,
@@ -65,6 +66,10 @@ export async function generateMetadata({
   const qa = await getBookQa(params.id, resolved.question);
   const answer = (qa?.answer || "").trim();
   const hasGrounded = Boolean(answer || qa?.passages?.length);
+  // A generic fallback question (one of the 5 the backend inserts when
+  // book-specific generation failed) is byte-identical across ~400 books, so its
+  // /q page is a duplicate even WITH a grounded answer — never index it.
+  const generic = isGenericFallbackQuestion(resolved.question);
 
   const canonical = `${SITE_URL}/book/${encodeURIComponent(params.id)}/q/${params.slug}`;
   const ogImage = `${SITE_URL}/og?type=qa&id=${encodeURIComponent(params.id)}&slug=${encodeURIComponent(params.slug)}`;
@@ -81,11 +86,15 @@ export async function generateMetadata({
     title: pageTitle,
     description: desc,
     alternates: { canonical },
-    // No grounded answer or cited passage yet → keep this thin question page out
-    // of the index (its only on-page content would be generic fallback passages,
-    // not an answer to THIS question). It indexes once the answer is generated +
-    // cached on a later crawl; `follow` keeps link equity flowing meanwhile.
-    ...(hasGrounded ? {} : { robots: { index: false, follow: true } }),
+    // Keep this question page OUT of the index when EITHER:
+    //  (a) no grounded answer/passage yet — its only content would be generic
+    //      fallback passages, not an answer to THIS question (it indexes later
+    //      once the answer is generated + cached on a crawl), OR
+    //  (b) it's one of the 5 generic fallback questions — byte-identical across
+    //      ~400 books, so a duplicate even WITH a grounded answer ("Duplicate
+    //      without user-selected canonical" in GSC).
+    // `follow` keeps link equity flowing to the book either way.
+    ...(hasGrounded && !generic ? {} : { robots: { index: false, follow: true } }),
     openGraph: {
       type: "article",
       title: resolved.question,

--- a/web/lib/seo-book.ts
+++ b/web/lib/seo-book.ts
@@ -67,6 +67,27 @@ export function findQuestionBySlug(
 }
 
 /**
+ * The 5 generic fallback questions the backend inserts when book-specific
+ * question generation fails. They are byte-identical across ~400 books, so
+ * their /q pages duplicate one another ("Duplicate without user-selected
+ * canonical" in GSC) and aren't real search queries — keep them OUT of the
+ * index regardless of whether a grounded answer exists. (Regenerating
+ * book-specific questions is the eventual fix; until then, noindex.) Keep in
+ * sync with GENERIC_FALLBACK_QUESTIONS in app/core/seo.py.
+ */
+export const GENERIC_FALLBACK_QUESTIONS: ReadonlySet<string> = new Set([
+  "What is the central thesis of this text?",
+  "What evidence does the author provide?",
+  "How would you explain the key concepts in your own words?",
+  "What are the practical implications?",
+  "What questions remain unanswered?",
+]);
+
+export function isGenericFallbackQuestion(q: string): boolean {
+  return GENERIC_FALLBACK_QUESTIONS.has((q || "").trim());
+}
+
+/**
  * Map a book's free-form `meta.category` to one of the 15 canonical topic
  * hubs, so the "More on …" link resolves to a real /topic/{slug} (200) instead
  * of 404'ing. Books carry 46+ ad-hoc categories ("Business" vs the canonical


### PR DESCRIPTION
## Root cause (from prod DB audit)
The GSC "Duplicate without user-selected canonical" bucket traces to **401 of 643 books (62%) still carrying the 5 generic templated fallback questions verbatim**:
- "What is the central thesis of this text?" → 401 books
- "What evidence does the author provide?" → 401 books
- "How would you explain the key concepts in your own words?" → 401 books
- "What are the practical implications?" → 401 books
- "What questions remain unanswered?" → 401 books

= **2,005 /q pages with byte-identical titles** across different books. #61's de-templating only covered ~242 books.

The `/q` page *already* noindexes pages without a grounded answer — but these 401 books have real overviews → grounded answers → they passed the gate and got indexed **despite** the duplicate title.

## Fix (①)
Also noindex when the question is one of the 5 fallbacks, regardless of grounded content. Shared list, frontend + backend:
- `web/lib/seo-book.ts` — `GENERIC_FALLBACK_QUESTIONS` + `isGenericFallbackQuestion`
- `/q` `generateMetadata` — `noindex,follow` when generic
- `app/core/seo.py` — matching `GENERIC_FALLBACK_QUESTIONS` + `is_generic_fallback_question`
- `app/main.py` sitemap — skip generic-fallback `/q` (avoids "submitted URL marked noindex" warnings)

## Verified
- Templated `/q` (`…/q/what-is-the-central-thesis-of-this-text`) → `<meta name="robots" content="noindex, follow">`
- Book-specific grounded `/q` (a-game-of-thrones) → no robots tag, stays indexable (no regression)
- `tsc --noEmit` clean; backend helper unit-checked
- **mind-q unaffected** — 7,204 mind questions, ~zero duplication (only 11 legit topic overlaps), all with substantive stored answers

## Note
Already-indexed templated `/q` deindex on next crawl (noindex,follow preserves link equity). The 386/401 templated books that are real `ready` books with overviews are candidates for question *regeneration* (②) — separate, opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)