### PR TITLE
Allow editing a finished book's title via chat

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5068,8 +5068,12 @@ def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request)
         raise HTTPException(status_code=404, detail="AI book not found")
     if book["user_id"] != user_id:
         raise HTTPException(status_code=403, detail="Access denied")
-    if book["status"] not in ("outlining",):
-        raise HTTPException(status_code=409, detail=f"Book is in '{book['status']}' state, cannot edit outline")
+    # In-flight states (about to write / actively writing) can't be edited — the
+    # background writer reads the outline mid-run. Any other state is editable;
+    # for an already-written book the edit is constrained to title/metadata below
+    # so it can't desync from the chapters already on disk.
+    if book["status"] in ("confirmed", "writing"):
+        raise HTTPException(status_code=409, detail="The book is being written right now — wait until it finishes, then you can edit it.")
 
     history = None
     if payload.history:
@@ -5084,9 +5088,27 @@ def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request)
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Refinement failed: {exc}")
 
+    # An already-written book keeps its chapter structure (content is on disk and
+    # isn't rewritten here) — only title/subtitle/category may change. An
+    # outlining book can still be restructured freely.
+    if book["status"] != "outlining":
+        preserved = dict(book["outline"] or {})
+        for key in ("title", "subtitle", "category"):
+            if updated_outline.get(key):
+                preserved[key] = updated_outline[key]
+        updated_outline = preserved
+
     update_ai_book_outline(book_id, updated_outline)
-    # Sync title to agent
-    update_agent_meta(book["agent_id"], {"title": updated_outline.get("title", book["title"])})
+    # update_ai_book_outline syncs ai_books.title; also push the new title to the
+    # agent (agents.name + meta.title) so the library, reader, and a finished
+    # book's canvas reflect it. rename_agent keeps all three in sync — the old
+    # meta-only bump left agents.name/ai_books.title stale, so a finished book's
+    # displayed title never changed.
+    new_title = (updated_outline.get("title") or book["title"] or "").strip()
+    if new_title and new_title != (book["title"] or ""):
+        rename_agent(book["agent_id"], new_title)
+    else:
+        update_agent_meta(book["agent_id"], {"title": new_title or book["title"]})
 
     _track_usage(request, "ai_book", usage.get("total_tokens", 0))
     return {

--- a/web/components/chat/useWriteBook.ts
+++ b/web/components/chat/useWriteBook.ts
@@ -128,6 +128,10 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
   // Latest bookId for the poll guard (avoids stale closure when session changes).
   const bookIdRef = useRef<string | null>(null);
   bookIdRef.current = bookId;
+  // Latest status for the post-refine refresh: a finished book's canvas title
+  // reads `status`, not `outline`, so editing its title must refetch the book.
+  const statusRef = useRef<BookStatus | null>(null);
+  statusRef.current = status;
 
   // ── Polling lifecycle ──────────────────────────────────────────────────
   const stopPolling = useCallback(() => {
@@ -295,6 +299,22 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
         if (genRef.current !== gen) return;
         setOutline(res.outline);
         cbRef.current.onAssistant(res.response);
+        // A finished book's canvas shows `status.title` (not `outline.title`) and
+        // polling is stopped — so after editing it (e.g. a title fix) refetch once
+        // to surface the new title/metadata.
+        const refetchId = bookIdRef.current;
+        if (statusRef.current && refetchId) {
+          try {
+            const fresh = await getBook(refetchId);
+            if (genRef.current === gen) {
+              setStatus(fresh);
+              setOutline(fresh.outline);
+              setBookContent(fresh.content || null);
+            }
+          } catch {
+            /* keep the refine result we already applied */
+          }
+        }
       } catch (err) {
         if (genRef.current !== gen) return;
         const msg = describeError(err, "Couldn't update the outline. Try again.");


### PR DESCRIPTION
## Problem

After a book finished writing, asking to fix its title in chat returned **409 "Book is in 'completed' state, cannot edit outline"**. There was no chat path *and* no UI rename wired up for books — so a bad AI-generated title (e.g. *"SpaceX: A Decade of Innovation and Beyond"* for a 20+-year year-by-year chronicle) could never be corrected by the user.

The chat-refine endpoint was hard-gated to `status == "outlining"`. The gate existed to stop outline edits from desyncing with already-written chapters — but it also blocked the safe, common case: fixing the title.

## Fix

**Backend — `api_ai_book_chat` (`app/main.py`):**
- Gate **only** the in-flight states (`confirmed`/`writing`) where the background writer reads the outline mid-run. `outlining` / `completed` / `failed` / `cancelled` are now editable.
- For an **already-written** book, constrain the edit to `title`/`subtitle`/`category` and **preserve the existing chapter structure**, so the outline can't desync from the chapters already on disk (no rewrite happens on this path).
- Sync the new title via `rename_agent` (`agents.name` + `meta.title` + `ai_books.title`) instead of the old meta-only bump that left `agents.name`/`ai_books.title` stale — so a finished book's *displayed* title actually changes (library, reader, canvas).

**Frontend — `useWriteBook` (`web/components/chat/useWriteBook.ts`):**
- After a refine on a finished book, refetch the book once so the canvas title (which reads `status`, not `outline`) reflects the change. No extra fetch during the common outlining flow (`status` is `null` there).

Chat-refine is already cheap/fast (grounding + thinking disabled in #204), and this path triggers **no chapter rewrite** — it's one light LLM call to re-title.

## Why chat (not an inline rename box)
The user gives *critique* ("not 'a decade'; convey 'chronicle/yearbook'; 'Innovation and Beyond' is vague"), not an exact string — so having the model re-title from feedback fits better than asking them to type the full title.

## Out of scope
Restructuring a finished book (add/remove/reorder chapters) still isn't supported — that requires regenerating content. A request like "split chapter 5" on a finished book will only update the title/metadata; the chapters stay as written.

## Verification
- `python -m py_compile app/main.py` ✅
- `rename_agent` already imported in `main.py`; frontend symbols (`getBook`, `BookStatus`, `setBookContent`) all present ✅
- No tests reference the old 409 behavior ✅
- Frontend can't be typechecked locally (no `node_modules`); gated on the feynman-web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)