### PR TITLE
Refresh a book's Twitter/X share card after a title edit

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -739,6 +739,32 @@ def privacy_page() -> HTMLResponse:
 
 _SITE_URL = os.getenv("APP_URL", "https://feynman.wiki").rstrip("/")
 
+# Token for the Next on-demand cache-bust route (web/app/revalidate/route.ts).
+# Same default as that file; override via env in BOTH projects if rotated.
+_REVALIDATE_TOKEN = os.getenv("REVALIDATE_TOKEN", "fey_rv_9f3a7c2e8b1d4056b7e21ad4c8")
+
+
+def _revalidate_book_share(agent_id: str) -> None:
+    """Best-effort: bust the Next ISR page + ssr data cache for a book's SEO
+    page after its title/subtitle changed, so the og:title + og:image on share
+    cards (Twitter/X, etc.) refresh without waiting out the 24h revalidate
+    window. The book page also content-versions its OG image URL, so the new
+    title re-renders a fresh card image rather than serving the CDN-cached PNG.
+    Runs as a background task — never blocks or fails the edit.
+    """
+    try:
+        import httpx
+
+        agent = get_agent(agent_id)
+        slug = (agent or {}).get("slug") or agent_id
+        httpx.post(
+            f"{_SITE_URL}/revalidate",
+            params={"token": _REVALIDATE_TOKEN, "path": f"/book/{slug}", "tag": "ssr"},
+            timeout=8,
+        )
+    except Exception as exc:  # cache refresh must never break a save
+        log.warning("book share revalidate failed for %s: %s", agent_id, exc)
+
 
 # ─── Phase 7.2 — IndexNow key verification file ───
 #
@@ -5058,7 +5084,7 @@ def api_ai_book_start(payload: AIBookStartRequest, request: Request) -> dict[str
 
 
 @app.post("/api/ai-books/{book_id}/chat")
-def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request) -> dict[str, Any]:
+def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
     """Refine the book outline through conversation."""
     _check_quota(request, "chat")
     user_id = _get_user_id(request) or "anon"
@@ -5109,6 +5135,13 @@ def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request)
         rename_agent(book["agent_id"], new_title)
     else:
         update_agent_meta(book["agent_id"], {"title": new_title or book["title"]})
+
+    # A published book (completed/failed/cancelled) has live SEO + share pages,
+    # and its title/subtitle/category just changed — bust the Next ISR page + ssr
+    # data cache now so the Twitter/X card's og:title/og:image don't stay stale
+    # for up to 24h. Skipped for outlining drafts (not shared yet).
+    if book["status"] != "outlining":
+        background_tasks.add_task(_revalidate_book_share, book["agent_id"])
 
     _track_usage(request, "ai_book", usage.get("total_tokens", 0))
     return {

--- a/web/app/book/[id]/page.tsx
+++ b/web/app/book/[id]/page.tsx
@@ -44,6 +44,19 @@ interface PageProps {
   params: { id: string };
 }
 
+/**
+ * Cache-bust token for the OG card. The /og image URL is otherwise keyed only by
+ * id, so the CDN (s-maxage 24h) keeps serving a stale card after a title/subtitle
+ * edit. Folding a short content hash into the URL makes a rename re-render a fresh
+ * card image. Deterministic (no Date/random) so ISR output stays stable.
+ */
+function ogVersion(...parts: (string | undefined | null)[]): string {
+  const s = parts.filter(Boolean).join("|");
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
 /** Shared description logic for both generateMetadata and the page body. */
 function bookDescription(
   subtitle: string,
@@ -79,7 +92,7 @@ export async function generateMetadata({
     stubPassages.length === 0 && data.chapters.length === 0 && stubQuestions.length === 0;
 
   const canonical = `${SITE_URL}/book/${encodeURIComponent(params.id)}`;
-  const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(params.id)}`;
+  const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(params.id)}&v=${ogVersion(data.title, data.subtitle)}`;
   const desc = bookDescription(data.subtitle, data.author);
   return {
     // Type-0 title rule (seo-geo-master-plan §3.5): state the unique artifact
@@ -153,7 +166,7 @@ export default async function BookLandingPage({ params }: PageProps) {
 
   const canonical = `${SITE_URL}/book/${encodeURIComponent(id)}`;
   const desc = bookDescription(data.subtitle, data.author);
-  const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(id)}`;
+  const ogImage = `${SITE_URL}/og?type=book&id=${encodeURIComponent(id)}&v=${ogVersion(data.title, data.subtitle)}`;
   const createdAt = data.agent.created_at || "";
 
   // ── JSON-LD ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

After editing a finished book's title, the shared tweet **text** updated (it's composed client-side) but the unfurled **card** kept the old title/subtitle — see the SpaceX book renamed to *"SpaceX Chronicle: 2002-2026"* still showing *"SpaceX: A Decade of Innovation and Beyond"* in the X preview.

Follow-up to #211 (title edit): the DB updated, but the SEO/share surface didn't. Two of our cache layers held it stale:

1. **`/book/[id]` is ISR-cached 24h** (`revalidate = 86400`), so `og:title`/`twitter:title` (what the card crawler reads) didn't refresh.
2. **The OG image URL was keyed only by `id`** (`/og?type=book&id=…`), so the Vercel CDN (`s-maxage=86400`) kept serving the old rendered PNG even after the data changed.

(There's a 3rd layer outside our control — X caches unfurled cards per-URL; see note below.)

## Fix

**Frontend — `web/app/book/[id]/page.tsx`:**
- Content-version the OG image URL: `&v=${ogVersion(title, subtitle)}` (a tiny deterministic hash). A rename changes the hash → the card points at a fresh, uncached image. Applied to both the `generateMetadata` `og:image` and the JSON-LD `image`.

**Backend — `app/main.py`:**
- New fire-and-forget `_revalidate_book_share(agent_id)` → `POST {APP_URL}/revalidate?path=/book/{slug}&tag=ssr` (the existing token-gated Next cache-bust route). Busts the page route cache + ssr data cache immediately so the card refreshes in seconds, not after the 24h ISR window.
- Wired into `api_ai_book_chat` after a rename, **only for published books** (`status != "outlining"` — drafts aren't shared yet). Runs as a `BackgroundTasks` task; never blocks or fails the edit.

## Notes / decisions
- **X's own card cache:** an already-composed tweet may still show the old card until X re-scrapes the URL (the [Card Validator](https://cards-dev.twitter.com/validator) forces it). New shares are correct once our caches bust.
- **Slug stays the same** on a title edit (URL stability + X doesn't follow 301s on slug changes — see `web/lib/catalog.ts`). The page at the existing slug simply renders the new title.

## Verification
- `python -m py_compile app/main.py` ✅
- `ogVersion` unit-checked with node: deterministic, changes on title edit (`1rkdsw9` → `11v6890`), undefined-safe ✅
- `get_agent` returns `slug`; `BackgroundTasks` already imported ✅
- Frontend types gated on the feynman-web build (no local tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)