### PR TITLE
Share: real portraits on symposium OG card + tweetable default text

### DIFF
--- a/web/app/a/[id]/page.tsx
+++ b/web/app/a/[id]/page.tsx
@@ -260,6 +260,11 @@ export default async function SharedAnswerPage({
           url={canonical}
           subject={isMind ? `Answer from ${who}` : "Shared answer"}
           title={headline}
+          defaultText={
+            isMind && who
+              ? `${who}: “${truncate(ans.answer.replace(/\s+/g, " ").trim(), 180)}”`
+              : `“${truncate(ans.answer.replace(/\s+/g, " ").trim(), 200)}”`
+          }
           variant="secondary"
         />
       </div>

--- a/web/app/discussions/[id]/page.tsx
+++ b/web/app/discussions/[id]/page.tsx
@@ -217,6 +217,7 @@ export default async function PublicDiscussionPage({
             url={canonical}
             title={title}
             subject="Symposium"
+            defaultText={`${roster} debate: “${title}”`}
             label="Share this symposium"
             variant="secondary"
           />

--- a/web/app/og/route.tsx
+++ b/web/app/og/route.tsx
@@ -330,14 +330,34 @@ async function build(type: string, id: string, slug: string, kind: string) {
       const d = await fetchDebate(slug);
       if (!d) return <HomeCard />;
       const seen = new Set<string>();
-      const parts: { accent: string; initials: string }[] = [];
-      const names: string[] = [];
+      const uniq: { id: string; name: string }[] = [];
       for (const t of d.turns) {
         if (seen.has(t.mind_id)) continue;
         seen.add(t.mind_id);
-        parts.push({ accent: mindAccent(t.mind_name), initials: mindInitials(t.mind_name) });
-        names.push(t.mind_name);
+        uniq.push({ id: t.mind_id, name: t.mind_name });
       }
+      const top = uniq.slice(0, 5); // = the avatars the card shows
+      // Real Wikimedia portraits for the roster (a grid of faces is far more
+      // share-worthy than initial circles). Portrait resolution needs the mind's
+      // wikidata QID — name-only only works for the curated FAMOUS_MIND table —
+      // so resolve each mind for its wikidata_url first. All in parallel; initials
+      // fallback per-mind on any miss (never throws).
+      const portraits = await Promise.all(
+        top.map(async (u) => {
+          try {
+            const m = await fetchMind(u.id);
+            return await mindPortraitDataUri({ name: u.name, wikidata_url: m?.wikidata_url, width: 128, timeoutMs: 6000 });
+          } catch {
+            return null;
+          }
+        }),
+      );
+      const parts = top.map((u, i) => ({
+        accent: mindAccent(u.name),
+        initials: mindInitials(u.name),
+        portrait: portraits[i] || null,
+      }));
+      const names = uniq.map((u) => u.name);
       const rosterLabel =
         names.length <= 1
           ? names[0] || ""

--- a/web/app/symposium/[slug]/page.tsx
+++ b/web/app/symposium/[slug]/page.tsx
@@ -118,6 +118,15 @@ export default async function SymposiumPage({
     [d.question, canonical],
   ]);
 
+  // Tweetable default share text — lead with the roster (the names ARE the hook)
+  // + the question, instead of the weak "{title} — on Feynman" fallback.
+  const rosterNames = participants.map((t) => t.mind_name);
+  const roster =
+    rosterNames.length <= 1
+      ? rosterNames[0] || "Great minds"
+      : rosterNames.slice(0, -1).join(", ") + " & " + rosterNames[rosterNames.length - 1];
+  const shareText = `${roster} debate: “${d.question}”`;
+
   const hero = (
     <>
       <p className="seo-meta">{d.topic ? `${d.topic} · Symposium` : "Symposium"}</p>
@@ -156,6 +165,7 @@ export default async function SymposiumPage({
           url={canonical}
           title={d.question}
           subject="Symposium"
+          defaultText={shareText}
           previewImage={abs(`/og?type=symposium&slug=${encodeURIComponent(d.slug)}`)}
           label="Share this symposium"
           variant="secondary"
@@ -218,6 +228,7 @@ export default async function SymposiumPage({
                     url={`${canonical}/t/${i}`}
                     title={`${t.mind_name} on “${d.question}”`}
                     subject="From a symposium"
+                    defaultText={`${t.mind_name}: “${t.content.replace(/\s+/g, " ").trim().slice(0, 148).trimEnd()}…”`}
                     previewImage={abs(
                       `/og?type=symposium-turn&slug=${encodeURIComponent(d.slug)}&kind=${i}`,
                     )}

--- a/web/lib/og/assets.ts
+++ b/web/lib/og/assets.ts
@@ -20,9 +20,9 @@ import { lookupSameAs } from "@/lib/seo-mind";
 const TIMEOUT_MS = 2500;
 const UA = "FeynmanOG/1.0 (+https://feynman.wiki)";
 
-async function timed(url: string): Promise<Response | null> {
+async function timed(url: string, timeoutMs: number = TIMEOUT_MS): Promise<Response | null> {
   const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
     return await fetch(url, {
       signal: ctrl.signal,
@@ -77,6 +77,13 @@ function qidFrom(url?: string): string | null {
 export async function mindPortraitDataUri(opts: {
   name: string;
   wikidata_url?: string;
+  /** Commons render width. Default 480 (hero cards); pass small (e.g. 128) for
+   *  multi-portrait rosters so 5 parallel fetches stay inside the timeout. */
+  width?: number;
+  /** Per-fetch timeout. Default 2500ms; raise for multi-portrait rosters where
+   *  parallel fetches contend (the card is CDN-cached, so a slower cold render
+   *  is fine and beats a racy partial roster). */
+  timeoutMs?: number;
 }): Promise<string | null> {
   let qid = qidFrom(opts.wikidata_url);
   if (!qid) {
@@ -92,6 +99,7 @@ export async function mindPortraitDataUri(opts: {
 
   const meta = await timed(
     `https://www.wikidata.org/wiki/Special:EntityData/${qid}.json`,
+    opts.timeoutMs,
   );
   if (!meta || !meta.ok) return null;
 
@@ -114,7 +122,8 @@ export async function mindPortraitDataUri(opts: {
   const img = await timed(
     `https://commons.wikimedia.org/wiki/Special:FilePath/${encodeURIComponent(
       filename.replace(/ /g, "_"),
-    )}?width=480`,
+    )}?width=${opts.width || 480}`,
+    opts.timeoutMs,
   );
   if (!img || !img.ok) return null;
   return toDataUri(img);

--- a/web/lib/og/cards.tsx
+++ b/web/lib/og/cards.tsx
@@ -471,7 +471,7 @@ export function SymposiumCard({
 }: {
   question: string;
   topic?: string;
-  participants: { accent: string; initials: string }[];
+  participants: { accent: string; initials: string; portrait?: string | null }[];
   rosterLabel: string;
 }) {
   return (
@@ -486,11 +486,17 @@ export function SymposiumCard({
           </div>
           <div style={{ display: "flex", alignItems: "center" }}>
             <div style={{ display: "flex" }}>
-              {participants.slice(0, 5).map((p, i) => (
-                <div key={i} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 56, height: 56, borderRadius: 56, background: p.accent, color: "#fff", fontSize: 19, fontWeight: 700, fontFamily: FONT, border: "3px solid #faf8f4", marginLeft: i === 0 ? 0 : -14 }}>
-                  {p.initials}
-                </div>
-              ))}
+              {participants.slice(0, 5).map((p, i) =>
+                p.portrait ? (
+                  <div key={i} style={{ display: "flex", width: 56, height: 56, borderRadius: 56, overflow: "hidden", border: "3px solid #faf8f4", marginLeft: i === 0 ? 0 : -14 }}>
+                    <img src={p.portrait} width={56} height={56} style={{ width: 56, height: 56, objectFit: "cover" }} alt="" />
+                  </div>
+                ) : (
+                  <div key={i} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 56, height: 56, borderRadius: 56, background: p.accent, color: "#fff", fontSize: 19, fontWeight: 700, fontFamily: FONT, border: "3px solid #faf8f4", marginLeft: i === 0 ? 0 : -14 }}>
+                    {p.initials}
+                  </div>
+                ),
+              )}
             </div>
             <div style={{ display: "flex", fontSize: 24, color: INK_SOFT, marginLeft: 20, fontFamily: FONT, maxWidth: 760 }}>
               {clip(rosterLabel, 64)}


### PR DESCRIPTION
Layer-2 of "make the product self-grow backlinks" — make shared symposiums/answers more share-worthy + spread-worthy. (Backlinks → domain authority → the real lever for a young site; clicks are gated by authority, not page count.)

## 1 · Real portraits on the symposium OG roster card
The roster card showed **initial-circles**, while single-mind cards already render real **Wikimedia portraits**. Wired them into the roster: resolve each mind's `wikidata_url` (`fetchMind`) → `mindPortraitDataUri`. Added `width` + `timeoutMs` params so 5 parallel fetches at 128px stay reliable (the card is CDN-cached → a ~4s cold render is fine and beats a racy partial roster). Per-mind initials fallback on a miss.

**Before:** PD / CC / ST / SZ initial circles · **After:** 4/4 real faces (verified locally).

## 2 · Tweetable default share text
Was the weak `"{title} — on Feynman"`. Now artifact-specific:
- **Symposium** → `{roster} debate: "{question}"` (the names are the hook)
- **Per-turn / shared answer** → the speaker's killer quote
- **Community symposium** → roster + question

`ShareButton`/`ShareDialog` already accepted `defaultText`; the pages just weren't passing it.

## Files
`og/route.tsx` (roster portraits), `lib/og/cards.tsx` (SymposiumCard portrait render), `lib/og/assets.ts` (width + timeoutMs), `symposium/[slug]`, `a/[id]`, `discussions/[id]` (defaultText).

## Verified
`tsc --noEmit` clean; OG card rendered locally — 4/4 portraits, cold ~3.8s then CDN-cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)