### PR TITLE
Landing: add below-the-hero feature & value sections + footer

### DIFF
--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -1123,20 +1123,20 @@
   background: var(--landing-bg);
   border-top: 1px solid var(--border);
 }
+/* Full-bleed with the SAME 32px side padding as the topbar, so the footer's
+   left/right edges line up with the top menu's edges (no centered max-width box). */
 .footerInner {
-  max-width: 1080px;
-  margin: 0 auto;
-  padding: 56px 32px 36px;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: flex-end;
   gap: 32px;
   flex-wrap: wrap;
+  padding: 40px 32px;
 }
 .footerBrand {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 .footerLogo {
   display: inline-flex;
@@ -1149,21 +1149,12 @@
 .footerTagline {
   font-size: 13px;
   color: var(--text-muted);
-  margin: 0;
+  margin: 2px 0 0;
 }
-.footerNav {
-  display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
-}
-.footerLink {
-  font-size: 13px;
-  color: var(--text-secondary);
-  text-decoration: none;
-  transition: color 0.15s;
-}
-.footerLink:hover {
-  color: var(--text);
+.footerCopy {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 8px 0 0;
 }
 .footerSocials {
   display: flex;
@@ -1184,18 +1175,12 @@
   color: var(--text);
   background: var(--border);
 }
-.footerBottom {
-  border-top: 1px solid var(--border);
-  padding: 18px 32px;
-  text-align: center;
-  font-size: 12px;
-  color: var(--text-muted);
-}
 
 @media (max-width: 960px) {
   .footerInner {
     flex-direction: column;
-    gap: 24px;
-    padding: 40px 20px 28px;
+    align-items: flex-start;
+    gap: 18px;
+    padding: 32px;
   }
 }

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -1134,16 +1134,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 32px;
+  gap: 24px;
   flex-wrap: wrap;
-  padding: 34px 32px 24px;
+  padding: 28px 32px;
 }
-.footerBottom {
-  border-top: 1px solid var(--border);
-  padding: 16px 32px;
-  text-align: center;
-  font-size: 12px;
-  color: var(--text-muted);
+.footerRight {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
 }
 .footerBrand {
   display: flex;

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -1184,3 +1184,51 @@
     padding: 32px;
   }
 }
+
+/* §5 on-demand book — book-writing canvas mock: composed pages + right-side
+   outline (mirrors the real write-book BookCanvas; no chat UI). */
+.bookCanvas {
+  display: flex;
+  gap: 18px;
+  align-items: stretch;
+  width: 100%;
+}
+.bookCanvasPage {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.bookCanvasTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 15px;
+  line-height: 1.3;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+.bookCanvasOutline {
+  flex-shrink: 0;
+  width: 134px;
+  border-left: 1px solid var(--border);
+  padding-left: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.bookOutlineLabel {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.bookOutlineItem {
+  font-size: 10px;
+  line-height: 1.3;
+  color: var(--text-secondary);
+}
+.bookOutlineActive {
+  color: var(--accent);
+  font-weight: 600;
+}

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -1136,7 +1136,7 @@
 .footerBrand {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 7px;
 }
 .footerLogo {
   display: inline-flex;
@@ -1154,7 +1154,7 @@
 .footerCopy {
   font-size: 12px;
   color: var(--text-muted);
-  margin: 8px 0 0;
+  margin: 0;
 }
 .footerSocials {
   display: flex;

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -821,10 +821,15 @@
   align-items: center;
   gap: 6px;
   margin-top: 22px;
+  padding: 0;
   font-size: 14px;
   font-weight: 500;
+  font-family: inherit;
   color: var(--accent);
   text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
   transition: gap 0.15s;
 }
 .softLink:hover {
@@ -964,21 +969,21 @@
   white-space: nowrap;
 }
 .cUpload {
-  width: 46px;
-  height: 46px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1.5px dashed var(--accent);
-  color: var(--accent);
-  background: var(--accent-light);
+  border: 1px dashed var(--border-strong);
+  color: var(--text-muted);
+  background: var(--bg-chat);
 }
 .cUpload svg {
   stroke: currentColor;
 }
 .cNodeUpload .cName {
-  color: var(--accent);
+  color: var(--text-muted);
 }
 
 /* §5 Closing CTA band */
@@ -1128,10 +1133,17 @@
 .footerInner {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: center;
   gap: 32px;
   flex-wrap: wrap;
-  padding: 40px 32px;
+  padding: 34px 32px 24px;
+}
+.footerBottom {
+  border-top: 1px solid var(--border);
+  padding: 16px 32px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
 }
 .footerBrand {
   display: flex;
@@ -1233,26 +1245,140 @@
   font-weight: 600;
 }
 
-/* §2 Library — a grid of book covers (mirrors the real library page) */
+/* §2 Library — a grid of book cards (mirrors the real library page:
+   colored gradient cover + faded initials watermark + title beneath). */
 .libraryGrid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+  gap: 14px;
   width: 100%;
 }
-.libCover {
-  aspect-ratio: 3 / 4;
-  border-radius: 6px;
-  background: var(--cover-placeholder-bg);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-  padding: 10px 9px;
+.libCard {
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
 }
-.libCoverTitle {
+.libArt {
+  aspect-ratio: 3 / 4;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.libArtInitials {
   font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 26px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.28);
+  letter-spacing: 0.02em;
+}
+.libTitle {
   font-size: 10px;
+  line-height: 1.3;
+  color: var(--text-secondary);
+  margin-top: 7px;
+}
+
+/* §3 On-demand books — the composed book + chapter outline (mirrors the real
+   write-book page: the book/outline is the main element). */
+.bookBuild {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  width: 100%;
+}
+.bookBuildTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 16px;
   line-height: 1.25;
   color: var(--text);
+}
+.bookBuildStatus {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: -4px;
+}
+.bookBuildBar {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+  overflow: hidden;
+}
+.bookBuildBarFill {
+  height: 100%;
+  width: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+}
+.bookChapters {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  margin-top: 2px;
+}
+.bookChapter {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.bookChapterCheck {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--success-bg);
+  color: var(--success-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+}
+.bookChapterTitle {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.bookChapterWords {
+  flex-shrink: 0;
+  font-size: 9px;
+  color: var(--text-muted);
+}
+
+/* §5 Symposium — question as a prominent heading (mirrors the real page) */
+.symQuestion {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 15px;
+  line-height: 1.3;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+/* Closing CTA — a glass card so it matches the page's card aesthetic */
+.ctaCard {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 52px 32px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(20px) saturate(1.3);
+  -webkit-backdrop-filter: blur(20px) saturate(1.3);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+:global(html.dark) .ctaCard {
+  background: rgba(44, 44, 46, 0.42);
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+@media (prefers-color-scheme: dark) {
+  :global(html:not(.light)) .ctaCard {
+    background: rgba(44, 44, 46, 0.42);
+    border-color: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
 }

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -726,6 +726,7 @@
   letter-spacing: -0.01em;
   color: var(--text);
   margin: 0 0 14px;
+  text-wrap: balance;
 }
 .bodyText {
   font-size: 15px;
@@ -1000,6 +1001,7 @@
   letter-spacing: -0.01em;
   color: var(--text);
   margin: 0 0 14px;
+  text-wrap: balance;
 }
 .ctaSub {
   font-size: 16px;

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -1055,3 +1055,147 @@
     padding: 80px 0;
   }
 }
+
+/* ── Mock tweaks ── */
+.mockStack > .bookChip {
+  align-self: flex-start;
+}
+
+/* "Network builds itself" topic mock (topic entry + on-demand books) */
+.topicMock {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 13px;
+}
+.topicChip {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 13px;
+  border-radius: 999px;
+  background: var(--accent-light);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+}
+.topicLabel {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.miniCovers {
+  display: flex;
+  gap: 10px;
+}
+.miniCover {
+  width: 56px;
+  height: 78px;
+  border-radius: 5px;
+  background: var(--cover-placeholder-bg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  padding: 7px 6px;
+  display: flex;
+  align-items: flex-end;
+}
+.miniCoverTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 8px;
+  line-height: 1.25;
+  color: var(--text);
+}
+.miniCoverGen {
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-light);
+  border: 1px dashed var(--accent);
+  color: var(--accent);
+}
+.miniCoverGen svg {
+  stroke: currentColor;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   FOOTER (social links moved here from the topbar)
+   ════════════════════════════════════════════════════════════════════ */
+.footer {
+  position: relative;
+  z-index: 1;
+  background: var(--landing-bg);
+  border-top: 1px solid var(--border);
+}
+.footerInner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 56px 32px 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+.footerBrand {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.footerLogo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 16px;
+  color: var(--text);
+}
+.footerTagline {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+.footerNav {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.footerLink {
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.footerLink:hover {
+  color: var(--text);
+}
+.footerSocials {
+  display: flex;
+  gap: 10px;
+}
+.footerSocial {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+}
+.footerSocial:hover {
+  color: var(--text);
+  background: var(--border);
+}
+.footerBottom {
+  border-top: 1px solid var(--border);
+  padding: 18px 32px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 960px) {
+  .footerInner {
+    flex-direction: column;
+    gap: 24px;
+    padding: 40px 20px 28px;
+  }
+}

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -1232,3 +1232,27 @@
   color: var(--accent);
   font-weight: 600;
 }
+
+/* §2 Library — a grid of book covers (mirrors the real library page) */
+.libraryGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  width: 100%;
+}
+.libCover {
+  aspect-ratio: 3 / 4;
+  border-radius: 6px;
+  background: var(--cover-placeholder-bg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  padding: 10px 9px;
+  display: flex;
+  align-items: flex-end;
+}
+.libCoverTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 10px;
+  line-height: 1.25;
+  color: var(--text);
+}

--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -685,3 +685,373 @@
     width: 140px;
   }
 }
+
+/* ════════════════════════════════════════════════════════════════════
+   BELOW-THE-HERO FEATURE SECTIONS (appended — the hero above is 100%
+   untouched). Editorial value sections that introduce the five core
+   capabilities, built on the same Liquid-Glass tokens and reusing the
+   demo message classes above (.msg*, .mnAvatar, .joinInner, .sourceTag,
+   .bookChip …) so the static feature mocks look native to the product.
+   ════════════════════════════════════════════════════════════════════ */
+
+.sections {
+  position: relative;
+  z-index: 1;
+  background: var(--landing-bg);
+  border-top: 1px solid var(--border);
+}
+.section {
+  padding: 104px 0;
+}
+.sectionInner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+/* Eyebrow / title / body — shared editorial type */
+.eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 14px;
+}
+.sectionTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-weight: 400;
+  font-size: 28px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 14px;
+}
+.bodyText {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  margin: 0;
+  max-width: 460px;
+}
+
+/* §0 Positioning band (centered) */
+.positioning {
+  text-align: center;
+}
+.positioning .sectionInner {
+  max-width: 760px;
+}
+.positioningTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-weight: 400;
+  font-size: 34px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 16px;
+}
+.positioning .bodyText {
+  max-width: 600px;
+  margin: 0 auto;
+  font-size: 16px;
+}
+.pillars {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px 28px;
+  margin-top: 30px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.pillar {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.pillarDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  opacity: 0.65;
+}
+
+/* Feature row layout */
+.featureRow {
+  display: flex;
+  align-items: center;
+  gap: 64px;
+}
+.featureRowReverse {
+  flex-direction: row-reverse;
+}
+.featureCopy {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.featureVisual {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+}
+
+/* Micro proof chips */
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 22px;
+}
+.chip {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-chat);
+}
+
+/* Low-emphasis exploration link */
+.softLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 22px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--accent);
+  text-decoration: none;
+  transition: gap 0.15s;
+}
+.softLink:hover {
+  gap: 10px;
+}
+.softLink svg {
+  stroke: currentColor;
+}
+
+/* Frosted mock frame — reuses the .chatCard material recipe */
+.mockFrame {
+  width: 100%;
+  max-width: 460px;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(20px) saturate(1.3);
+  -webkit-backdrop-filter: blur(20px) saturate(1.3);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 16px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  padding: 20px;
+}
+:global(html.dark) .mockFrame {
+  background: rgba(44, 44, 46, 0.42);
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+@media (prefers-color-scheme: dark) {
+  :global(html:not(.light)) .mockFrame {
+    background: rgba(44, 44, 46, 0.42);
+    border-color: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+}
+
+/* Mock: a stacked chat / debate column */
+.mockStack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.mockQuestion {
+  align-self: center;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  margin-bottom: 2px;
+}
+
+/* §2 Book-canvas mock */
+.bookMock {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.bookCover {
+  flex-shrink: 0;
+  width: 100px;
+  height: 138px;
+  border-radius: 8px;
+  background: var(--cover-placeholder-bg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 12px 11px;
+}
+.bookCoverTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-size: 14px;
+  line-height: 1.25;
+  color: var(--text);
+}
+.bookCoverAuthor {
+  font-size: 9px;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+  margin-top: 7px;
+}
+.bookPage {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.bookLine {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--border-strong);
+}
+.bookPage .bookChip {
+  margin-top: 6px;
+  align-self: flex-start;
+}
+
+/* §3 Minds-network constellation mock */
+.constellation {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  height: 264px;
+}
+.constellation svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+.cNode {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+.cAvatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: #fff;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.14);
+  border: 1.5px solid rgba(255, 255, 255, 0.35);
+}
+.cName {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.cUpload {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.5px dashed var(--accent);
+  color: var(--accent);
+  background: var(--accent-light);
+}
+.cUpload svg {
+  stroke: currentColor;
+}
+.cNodeUpload .cName {
+  color: var(--accent);
+}
+
+/* §5 Closing CTA band */
+.ctaBand {
+  text-align: center;
+  padding: 116px 0 128px;
+  border-top: 1px solid var(--border);
+}
+.ctaTitle {
+  font-family: 'Libre Baskerville', Georgia, serif;
+  font-weight: 400;
+  font-size: 32px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 14px;
+}
+.ctaSub {
+  font-size: 16px;
+  color: var(--text-secondary);
+  margin: 0 0 28px;
+}
+.ctaBand .heroCta {
+  margin-top: 0;
+}
+
+/* Scroll reveal — motion users only; reduced-motion shows everything */
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    transition: opacity 0.7s ease, transform 0.7s ease;
+  }
+  .reveal.isVisible {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Responsive — mirrors the hero's 960px collapse */
+@media (max-width: 960px) {
+  .section {
+    padding: 72px 0;
+  }
+  .sectionInner {
+    padding: 0 20px;
+  }
+  .featureRow,
+  .featureRowReverse {
+    flex-direction: column;
+    gap: 32px;
+    text-align: center;
+  }
+  .featureCopy .bodyText {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .chips {
+    justify-content: center;
+  }
+  .featureVisual {
+    width: 100%;
+  }
+  .positioningTitle {
+    font-size: 27px;
+  }
+  .sectionTitle {
+    font-size: 24px;
+  }
+  .ctaTitle {
+    font-size: 26px;
+  }
+  .ctaBand {
+    padding: 80px 0;
+  }
+}

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1697,19 +1697,24 @@ export function LandingPage({
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
-                <div className={styles.bookMock}>
-                  <div className={styles.bookCover}>
-                    <div className={styles.bookCoverTitle}>The History of Coffee</div>
-                    <div className={styles.bookCoverAuthor}>Written on demand</div>
-                  </div>
-                  <div className={styles.bookPage}>
-                    <div className={styles.bookLine} style={{ width: "92%" }} />
-                    <div className={styles.bookLine} style={{ width: "100%" }} />
+                <div className={styles.bookCanvas}>
+                  <div className={styles.bookCanvasPage}>
+                    <div className={styles.bookCanvasTitle}>The History of Coffee</div>
                     <div className={styles.bookLine} style={{ width: "96%" }} />
-                    <div className={styles.bookLine} style={{ width: "68%" }} />
-                    <span className={styles.bookChip}>
-                      <span>Ready to chat</span>
-                    </span>
+                    <div className={styles.bookLine} style={{ width: "100%" }} />
+                    <div className={styles.bookLine} style={{ width: "92%" }} />
+                    <div className={styles.bookLine} style={{ width: "98%" }} />
+                    <div className={styles.bookLine} style={{ width: "58%" }} />
+                  </div>
+                  <div className={styles.bookCanvasOutline}>
+                    <div className={styles.bookOutlineLabel}>Outline</div>
+                    <div className={styles.bookOutlineItem}>1 · Origins in Ethiopia</div>
+                    <div className={`${styles.bookOutlineItem} ${styles.bookOutlineActive}`}>
+                      2 · The Spread of Coffee
+                    </div>
+                    <div className={styles.bookOutlineItem}>3 · Coffeehouse Culture</div>
+                    <div className={styles.bookOutlineItem}>4 · Coffee &amp; Commerce</div>
+                    <div className={styles.bookOutlineItem}>5 · The Modern Cup</div>
                   </div>
                 </div>
               </div>

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1459,57 +1459,24 @@ export function LandingPage({
       </section>
 
       {/* ═══════════ BELOW-THE-HERO SECTIONS (appended) ═══════════
-          The hero <section> above is 100% untouched. Consistent layout: every
-          feature row is text-left / visual-right; the intro and CTA are centered
-          bands. Copy follows the README narrative — the knowledge network: chat a
-          book → great minds join in → sit with a mind → set them debating → a
-          network that builds itself. Visuals reuse the demo message classes. */}
+          The hero <section> above is 100% untouched. Order follows the README's
+          narrative — three ways to enter (a book, a topic, a mind), then the two
+          extensions (symposiums, on-demand books). Consistent layout: every feature
+          row is text-left / visual-right; the CTA is a centered band. Visuals reuse
+          the demo message classes. */}
       <div className={styles.sections}>
-        {/* Intro band */}
-        <section className={`${styles.section} ${styles.positioning} ${styles.reveal}`} data-reveal>
-          <div className={styles.sectionInner}>
-            <p className={styles.eyebrow}>An interactive knowledge network</p>
-            <h2 className={styles.positioningTitle}>Knowledge you can talk to.</h2>
-            <p className={styles.bodyText}>
-              Feynman turns the world&apos;s most important books and the great minds behind them
-              into a living network you explore by talking to it. Chat with a book to understand it
-              fast, start from a topic to map a new field, and watch the right thinkers join in to
-              think alongside you — books, minds, and ideas as one navigable map of human thought.
-            </p>
-            <div className={styles.pillars}>
-              <span className={styles.pillar}>
-                <span className={styles.pillarDot} />
-                Grounded in the actual pages
-              </span>
-              <span className={styles.pillar}>
-                <span className={styles.pillarDot} />
-                Great minds join in
-              </span>
-              <span className={styles.pillar}>
-                <span className={styles.pillarDot} />
-                A network that grows as you explore
-              </span>
-            </div>
-          </div>
-        </section>
-
-        {/* Chat with books */}
+        {/* 1 — Enter through a book: grounded book chat + great minds joining in (the core) */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Chat with books</p>
-              <h2 className={styles.sectionTitle}>Understand any book without reading all 300 pages.</h2>
+              <h2 className={styles.sectionTitle}>Chat with a book — the great minds behind it join in.</h2>
               <p className={styles.bodyText}>
-                Ask anything and get a clear answer grounded in the book&apos;s actual text — every
-                claim linked to the exact passage it came from, so nothing is a black box. Feynman
-                reaches beyond the page too, drawing on the work, the web, and the world&apos;s
-                knowledge, so each conversation gives you the context of an afternoon with the author.
+                Ask a book anything and get answers grounded in its actual text, traced to the
+                passage they came from. As you go, the relevant great minds join on their own —
+                Adam Smith makes his case, Marx counters, Keynes reframes — turning a solo read into
+                a conversation with the people who shaped the field.
               </p>
-              <div className={styles.chips}>
-                <span className={styles.chip}>Every claim cited [1][2]</span>
-                <span className={styles.chip}>Beyond the page, four ways</span>
-                <span className={styles.chip}>Chat across many books at once</span>
-              </div>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
@@ -1522,38 +1489,12 @@ export function LandingPage({
                   </div>
                   <div className={`${styles.msg} ${styles.msgAssistant}`}>
                     <span>
-                      Smith&apos;s answer is the division of labour — productivity rises when work is
-                      specialized and freely exchanged, not from hoarding gold.
+                      The division of labour — productivity rises when work is specialized and
+                      freely exchanged, not from hoarding gold.
                     </span>
                     <div className={styles.msgSources}>
                       <span className={styles.sourceTag}>Bk.1 Ch.1 — Of the Division of Labour</span>
                     </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Great minds join in */}
-        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
-          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
-            <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>Great minds join in</p>
-              <h2 className={styles.sectionTitle}>You&apos;re never reading alone.</h2>
-              <p className={styles.bodyText}>
-                As you chat, the most relevant great minds join the conversation on their own — you
-                see &ldquo;Adam Smith joined the discussion,&rdquo; just like a group chat. Ask what
-                creates a nation&apos;s wealth and Smith lays out his reasoning while Marx pushes back
-                and Keynes offers another lens. They remember the thread and stay as it evolves — a
-                study group of history&apos;s most brilliant minds, always on call.
-              </p>
-            </div>
-            <div className={styles.featureVisual} aria-hidden="true">
-              <div className={styles.mockFrame}>
-                <div className={styles.mockStack}>
-                  <div className={styles.bookChip}>
-                    <span>The Wealth of Nations</span>
                   </div>
                   <MockJoin
                     names={["Adam Smith", "Karl Marx", "John Maynard Keynes"]}
@@ -1561,7 +1502,7 @@ export function LandingPage({
                   />
                   <MockMind
                     name="Adam Smith"
-                    text="Wealth grows from the division of labour and free exchange — not from the gold in a treasury."
+                    text="Just so — and the wider the market, the further that division of labour can go."
                   />
                   <MockMind
                     name="Karl Marx"
@@ -1573,17 +1514,50 @@ export function LandingPage({
           </div>
         </section>
 
+        {/* 2 — Enter through a topic */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Start from a topic</p>
+              <h2 className={styles.sectionTitle}>No book yet? Start from a topic.</h2>
+              <p className={styles.bodyText}>
+                Name a field and Feynman finds the books worth reading, raises the questions you
+                should be asking, and teaches you through conversation — your library grows as you
+                explore.
+              </p>
+            </div>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.topicMock}>
+                  <span className={styles.topicChip}>Microeconomics</span>
+                  <span className={styles.topicLabel}>Feynman found the books to start with</span>
+                  <div className={styles.miniCovers}>
+                    <div className={styles.miniCover}>
+                      <span className={styles.miniCoverTitle}>Principles of Economics</span>
+                    </div>
+                    <div className={styles.miniCover}>
+                      <span className={styles.miniCoverTitle}>Thinking, Fast and Slow</span>
+                    </div>
+                    <div className={styles.miniCover}>
+                      <span className={styles.miniCoverTitle}>The Wealth of Nations</span>
+                    </div>
+                  </div>
+                  <span className={styles.topicLabel}>…and the questions to ask first</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
         {/* Chat with great minds (the network + upload your own) */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Chat with great minds</p>
-              <h2 className={styles.sectionTitle}>Ask Aristotle. Get an answer.</h2>
+              <h2 className={styles.sectionTitle}>Ask Aristotle. Or anyone you admire.</h2>
               <p className={styles.bodyText}>
-                Every book is a window into a great mind — but a mind is far more than any one book.
-                Chat one-on-one with Feynman, Adam Smith, or Socrates and get their way of thinking
-                applied to your own questions. Explore the network as a living map where minds cluster
-                by the ideas they share — and upload your own, or anyone you admire, from a profile, a
+                Chat one-on-one with any thinker and get their reasoning applied to your questions.
+                Explore the network to find your next mind — or upload your own, from a profile, a
                 blog, or a page of text.
               </p>
               <Link className={styles.softLink} href="/minds">
@@ -1663,11 +1637,11 @@ export function LandingPage({
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Symposiums</p>
-              <h2 className={styles.sectionTitle}>Set great minds debating.</h2>
+              <h2 className={styles.sectionTitle}>Put your question to a panel of great minds.</h2>
               <p className={styles.bodyText}>
-                Pose one big question and a panel of thinkers takes it up — each arguing in their own
-                voice, each answering the others. Read the exchange like a transcript of a debate that
-                never happened, then step in and press them further yourself.
+                Pose one big question and a handful of thinkers take it up, each in their own voice,
+                answering the others — so you see how history&apos;s sharpest minds would approach
+                what you care about. Read one, then step in and steer it.
               </p>
               <Link className={styles.softLink} href="/symposiums">
                 Browse symposiums
@@ -1710,53 +1684,33 @@ export function LandingPage({
           </div>
         </section>
 
-        {/* The network builds itself — topic entry + on-demand books */}
+        {/* 5 — On-demand books: the book you need, written on demand */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>Start from a topic</p>
-              <h2 className={styles.sectionTitle}>No book in mind? Start with a question.</h2>
+              <p className={styles.eyebrow}>On-demand books</p>
+              <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
               <p className={styles.bodyText}>
-                Name a field you&apos;re curious about and Feynman finds the books worth reading,
-                proposes the questions you should be asking, and teaches you through conversation.
-                There&apos;s no fixed catalog — every search and mention grows your library, and if
-                the book you need doesn&apos;t exist yet, Feynman writes it on demand.
+                Can&apos;t find the right one? Describe what you want to learn and Feynman writes a
+                book for it — ready to chat with on the spot.
               </p>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
-                <div className={styles.topicMock}>
-                  <span className={styles.topicChip}>Microeconomics</span>
-                  <span className={styles.topicLabel}>Feynman found the books to start with</span>
-                  <div className={styles.miniCovers}>
-                    <div className={styles.miniCover}>
-                      <span className={styles.miniCoverTitle}>Principles of Economics</span>
-                    </div>
-                    <div className={styles.miniCover}>
-                      <span className={styles.miniCoverTitle}>Thinking, Fast and Slow</span>
-                    </div>
-                    <div className={styles.miniCover}>
-                      <span className={styles.miniCoverTitle}>The Wealth of Nations</span>
-                    </div>
-                    <div className={`${styles.miniCover} ${styles.miniCoverGen}`}>
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <line x1="12" y1="5" x2="12" y2="19" />
-                        <line x1="5" y1="12" x2="19" y2="12" />
-                      </svg>
-                    </div>
+                <div className={styles.bookMock}>
+                  <div className={styles.bookCover}>
+                    <div className={styles.bookCoverTitle}>The History of Coffee</div>
+                    <div className={styles.bookCoverAuthor}>Written on demand</div>
                   </div>
-                  <span className={styles.bookChip}>
-                    <span>…or written on demand</span>
-                  </span>
+                  <div className={styles.bookPage}>
+                    <div className={styles.bookLine} style={{ width: "92%" }} />
+                    <div className={styles.bookLine} style={{ width: "100%" }} />
+                    <div className={styles.bookLine} style={{ width: "96%" }} />
+                    <div className={styles.bookLine} style={{ width: "68%" }} />
+                    <span className={styles.bookChip}>
+                      <span>Ready to chat</span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1767,7 +1721,6 @@ export function LandingPage({
         <section className={`${styles.ctaBand} ${styles.reveal}`} data-reveal>
           <div className={styles.sectionInner}>
             <h2 className={styles.ctaTitle}>Open a book. Invite a few great minds.</h2>
-            <p className={styles.ctaSub}>Your first conversation is one question away.</p>
             <button className={styles.heroCta} onClick={onCta}>
               {ctaLabel}
               <svg

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1472,10 +1472,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>Chat with books</p>
               <h2 className={styles.sectionTitle}>Chat with any book — and the most relevant minds join in.</h2>
               <p className={styles.bodyText}>
-                Ask a book anything and get answers grounded in its actual text, traced to the
-                passage they came from. As you go, the relevant great minds join on their own —
-                Adam Smith makes his case, Marx counters, Keynes reframes — turning a solo read into
-                a conversation with the people who shaped the field.
+                Every answer grounded in the book, cited to the exact page.
               </p>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
@@ -1521,9 +1518,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>Start from a topic</p>
               <h2 className={styles.sectionTitle}>No book yet? Start from a topic.</h2>
               <p className={styles.bodyText}>
-                Name a field and Feynman finds the books worth reading, raises the questions you
-                should be asking, and teaches you through conversation — your library grows as you
-                explore.
+                Feynman finds the books worth reading and the questions to ask first.
               </p>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
@@ -1556,9 +1551,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>Great minds</p>
               <h2 className={styles.sectionTitle}>An ever-evolving network of great minds.</h2>
               <p className={styles.bodyText}>
-                Chat one-on-one with any thinker — faithfully simulated from their own work — and
-                they grow richer as you talk, accumulating memory over time. Explore the network, or
-                expand it by uploading your own mind from a profile, a blog, or a page of text.
+                Chat any mind one-on-one — faithfully simulated, and growing as you talk.
               </p>
               <Link className={styles.softLink} href="/minds">
                 Explore the network
@@ -1639,9 +1632,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>Symposiums</p>
               <h2 className={styles.sectionTitle}>Put your question to a panel of great minds.</h2>
               <p className={styles.bodyText}>
-                Pose one big question and a handful of thinkers take it up, each in their own voice,
-                answering the others — so you see how history&apos;s sharpest minds would approach
-                what you care about. Read one, then step in and steer it.
+                See how each reasons it through — then step in yourself.
               </p>
               <Link className={styles.softLink} href="/symposiums">
                 Browse symposiums
@@ -1691,8 +1682,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>On-demand books</p>
               <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
               <p className={styles.bodyText}>
-                Can&apos;t find the right one? Describe what you want to learn and Feynman writes a
-                book for it — ready to chat with on the spot.
+                Can&apos;t find it? Describe it, and Feynman writes the book.
               </p>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1816,7 +1816,9 @@ export function LandingPage({
             </svg>
             Feynman
           </span>
-          <div className={styles.footerSocials}>
+          <div className={styles.footerRight}>
+            <span className={styles.footerCopy}>© 2026 Feynman. All rights reserved.</span>
+            <div className={styles.footerSocials}>
             <a
               className={styles.footerSocial}
               href="https://github.com/steveyeow/feynman"
@@ -1854,9 +1856,7 @@ export function LandingPage({
               </svg>
             </a>
           </div>
-        </div>
-        <div className={styles.footerBottom}>
-          <span>© 2026 Feynman. All rights reserved.</span>
+          </div>
         </div>
       </footer>
     </div>

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1755,12 +1755,8 @@ export function LandingPage({
               Feynman
             </span>
             <p className={styles.footerTagline}>Chat with books. Great minds join in.</p>
+            <p className={styles.footerCopy}>© 2026 Feynman · MIT licensed</p>
           </div>
-          <nav className={styles.footerNav}>
-            <Link className={styles.footerLink} href="/minds">Great Minds</Link>
-            <Link className={styles.footerLink} href="/symposiums">Symposiums</Link>
-            <Link className={styles.footerLink} href="/library">Library</Link>
-          </nav>
           <div className={styles.footerSocials}>
             <a
               className={styles.footerSocial}
@@ -1799,9 +1795,6 @@ export function LandingPage({
               </svg>
             </a>
           </div>
-        </div>
-        <div className={styles.footerBottom}>
-          <span>© 2026 Feynman · MIT licensed</span>
         </div>
       </footer>
     </div>

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback } from "react";
+import Link from "next/link";
 import * as d3 from "d3";
 import styles from "./LandingPage.module.css";
 
@@ -278,6 +279,71 @@ type GParticle = {
   size: number;
   opacity: number;
 };
+
+/* ════════════════════════════════════════════════════════════════════
+   BELOW-THE-HERO FEATURE SECTIONS — static helpers + data.
+   These render NON-animated feature mocks that reuse the demo message
+   classes (.msg*, .mnAvatar, .joinInner …) so they look native. The hero
+   above is untouched.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* One mind message — same DOM shape as the animated demo's mind row. */
+function MockMind({ name, text }: { name: string; text: string }) {
+  return (
+    <div className={`${styles.msg} ${styles.msgMind}`}>
+      <span className={styles.mnAvatar} style={{ background: lpColor(name) }}>
+        {initials(name)}
+      </span>
+      <div className={styles.mindBodyWrap}>
+        <div className={styles.mindHeader}>
+          <span className={styles.mnName}>{name}</span>
+        </div>
+        <div className={styles.mindBody}>{text}</div>
+      </div>
+    </div>
+  );
+}
+
+/* A "minds joined" / "in conversation" notice — ports the demo's join row. */
+function MockJoin({ names, verb }: { names: string[]; verb: string }) {
+  const label =
+    names.length === 1
+      ? names[0]
+      : names.slice(0, -1).join(", ") + " and " + names[names.length - 1];
+  return (
+    <div className={styles.systemNotice}>
+      <div className={styles.joinInner}>
+        {names.map((n) => (
+          <span key={n} className={styles.mnAvatar} style={{ background: lpColor(n) }}>
+            {initials(n)}
+          </span>
+        ))}
+        <span>
+          {label} {verb}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* §3 constellation — node placements (left/top = CSS %, cx/cy = SVG viewBox
+   coords in a 420×264 box, kept in sync so the links land on the avatars). */
+const NETWORK_NODES: { name: string; left: string; top: string; cx: number; cy: number }[] = [
+  { name: "Richard Feynman", left: "20%", top: "26%", cx: 84, cy: 68.6 },
+  { name: "Socrates", left: "52%", top: "16%", cx: 218.4, cy: 42.2 },
+  { name: "Adam Smith", left: "82%", top: "33%", cx: 344.4, cy: 87.1 },
+  { name: "Ada Lovelace", left: "26%", top: "74%", cx: 109.2, cy: 195.4 },
+];
+const NETWORK_UPLOAD = { left: "72%", top: "78%", cx: 302.4, cy: 205.9 };
+/* Links as [x1,y1,x2,y2] in the same viewBox. */
+const NETWORK_LINKS: [number, number, number, number][] = [
+  [84, 68.6, 218.4, 42.2],
+  [218.4, 42.2, 344.4, 87.1],
+  [84, 68.6, 109.2, 195.4],
+  [109.2, 195.4, 302.4, 205.9],
+  [302.4, 205.9, 344.4, 87.1],
+  [218.4, 42.2, 302.4, 205.9],
+];
 
 export function LandingPage({
   ctaLabel,
@@ -961,6 +1027,27 @@ export function LandingPage({
     };
   }, [renderChatStatic, startChatDemo, startSearchDemo, startMindsGraph]);
 
+  /* ---- Scroll-reveal for the below-hero sections (motion users only;
+         reduced-motion keeps them statically visible via the CSS gate). ---- */
+  useEffect(() => {
+    if (prefersReducedMotion()) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const els = Array.from(document.querySelectorAll<HTMLElement>("[data-reveal]"));
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            e.target.classList.add(styles.isVisible);
+            io.unobserve(e.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: "0px 0px -8% 0px" }
+    );
+    els.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
   /* ---- Theme toggle (ports the inline lp-theme-toggle handler) ---- */
   const toggleTheme = useCallback(() => {
     const root = document.documentElement;
@@ -1381,6 +1468,268 @@ export function LandingPage({
           </div>
         </div>
       </section>
+
+      {/* ═══════════ BELOW-THE-HERO FEATURE SECTIONS (appended) ═══════════
+          The hero <section> above is 100% untouched. These editorial sections
+          introduce the five core capabilities as two pairs — Books, then Minds —
+          reusing the demo classes for native-looking static mocks. */}
+      <div className={styles.sections}>
+        {/* §0 — Positioning band */}
+        <section className={`${styles.section} ${styles.positioning} ${styles.reveal}`} data-reveal>
+          <div className={styles.sectionInner}>
+            <p className={styles.eyebrow}>An interactive knowledge network</p>
+            <h2 className={styles.positioningTitle}>Knowledge you can talk to.</h2>
+            <p className={styles.bodyText}>
+              The world&apos;s most important books and greatest minds — now people you can
+              actually talk to.
+            </p>
+            <div className={styles.pillars}>
+              <span className={styles.pillar}>
+                <span className={styles.pillarDot} />
+                Books that talk back
+              </span>
+              <span className={styles.pillar}>
+                <span className={styles.pillarDot} />
+                Minds that join in
+              </span>
+              <span className={styles.pillar}>
+                <span className={styles.pillarDot} />
+                Debates across centuries
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* §1 — Chat with books (visual left / text right) */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.mockStack}>
+                  <div className={`${styles.msg} ${styles.msgUser}`}>
+                    What are System 1 and System 2?
+                  </div>
+                  <div className={`${styles.msg} ${styles.msgAssistant}`}>
+                    <span>
+                      System 1 is fast, automatic intuition. System 2 is slow, deliberate
+                      thinking.
+                    </span>
+                    <div className={styles.msgSources}>
+                      <span className={styles.sourceTag}>Ch.1 Two Systems</span>
+                    </div>
+                  </div>
+                  <MockJoin names={["Richard Feynman"]} verb="joined the discussion" />
+                  <MockMind
+                    name="Richard Feynman"
+                    text="The first principle is that you must not fool yourself — and you are the easiest person to fool."
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Chat with books</p>
+              <h2 className={styles.sectionTitle}>Every book becomes a conversation.</h2>
+              <p className={styles.bodyText}>
+                Ask any book anything — get answers cited to the exact page, with great minds
+                joining in to weigh in.
+              </p>
+              <div className={styles.chips}>
+                <span className={styles.chip}>Cited to the page</span>
+                <span className={styles.chip}>Minds join in automatically</span>
+                <span className={styles.chip}>@mention anyone</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* §2 — Create the book you need (text left / visual right) */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow} ${styles.featureRowReverse}`}>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.bookMock}>
+                  <div className={styles.bookCover}>
+                    <div className={styles.bookCoverTitle}>The History of Coffee</div>
+                    <div className={styles.bookCoverAuthor}>Compiled on demand</div>
+                  </div>
+                  <div className={styles.bookPage}>
+                    <div className={styles.bookLine} style={{ width: "92%" }} />
+                    <div className={styles.bookLine} style={{ width: "100%" }} />
+                    <div className={styles.bookLine} style={{ width: "96%" }} />
+                    <div className={styles.bookLine} style={{ width: "68%" }} />
+                    <span className={styles.bookChip}>
+                      <span>Ready to chat</span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>On-demand books</p>
+              <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
+              <p className={styles.bodyText}>
+                Describe what you want to learn and Feynman composes a book for it — ready to
+                chat with on the spot.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* §3 — The minds network + bring your own (visual left / text right) */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.constellation}>
+                <svg viewBox="0 0 420 264" preserveAspectRatio="xMidYMid meet">
+                  {NETWORK_LINKS.map(([x1, y1, x2, y2], i) => (
+                    <line
+                      key={i}
+                      x1={x1}
+                      y1={y1}
+                      x2={x2}
+                      y2={y2}
+                      stroke="rgba(150,160,180,0.35)"
+                      strokeWidth="1.2"
+                    />
+                  ))}
+                </svg>
+                {NETWORK_NODES.map((n) => (
+                  <div
+                    key={n.name}
+                    className={styles.cNode}
+                    style={{ left: n.left, top: n.top }}
+                  >
+                    <span className={styles.cAvatar} style={{ background: lpColor(n.name) }}>
+                      {initials(n.name)}
+                    </span>
+                    <span className={styles.cName}>{n.name}</span>
+                  </div>
+                ))}
+                <div
+                  className={`${styles.cNode} ${styles.cNodeUpload}`}
+                  style={{ left: NETWORK_UPLOAD.left, top: NETWORK_UPLOAD.top }}
+                >
+                  <span className={styles.cUpload}>
+                    <svg
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <line x1="12" y1="5" x2="12" y2="19" />
+                      <line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                  </span>
+                  <span className={styles.cName}>Upload a Mind</span>
+                </div>
+              </div>
+            </div>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Great minds</p>
+              <h2 className={styles.sectionTitle}>A living network of minds — and room for yours.</h2>
+              <p className={styles.bodyText}>
+                Chat one-on-one with history&apos;s greatest thinkers — or upload your own mind
+                and add it to the network.
+              </p>
+              <Link className={styles.softLink} href="/minds">
+                Explore the network
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* §4 — Symposiums (text left / visual right) */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow} ${styles.featureRowReverse}`}>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.mockStack}>
+                  <div className={styles.mockQuestion}>
+                    &ldquo;Is it better to be feared or loved?&rdquo;
+                  </div>
+                  <MockJoin
+                    names={["Machiavelli", "Sun Tzu", "Marcus Aurelius"]}
+                    verb="in conversation"
+                  />
+                  <MockMind
+                    name="Machiavelli"
+                    text="It is far safer to be feared than loved, if one cannot be both."
+                  />
+                  <MockMind
+                    name="Sun Tzu"
+                    text="Fear may win the battle, Niccolò — but the supreme art is to win without the fight."
+                  />
+                </div>
+              </div>
+            </div>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Symposiums</p>
+              <h2 className={styles.sectionTitle}>Convene a symposium of great minds.</h2>
+              <p className={styles.bodyText}>
+                Pose one question — a panel of minds debates it, each in their own voice. Then
+                jump in.
+              </p>
+              <Link className={styles.softLink} href="/symposiums">
+                Browse symposiums
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* §5 — Closing CTA band (reuses the gated hero CTA handler) */}
+        <section className={`${styles.ctaBand} ${styles.reveal}`} data-reveal>
+          <div className={styles.sectionInner}>
+            <h2 className={styles.ctaTitle}>Open a book. Invite a few great minds.</h2>
+            <p className={styles.ctaSub}>Your first conversation is one question away.</p>
+            <button className={styles.heroCta} onClick={onCta}>
+              {ctaLabel}
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="5" y1="12" x2="19" y2="12" />
+                <polyline points="12 5 19 12 12 19" />
+              </svg>
+            </button>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1107,17 +1107,6 @@ export function LandingPage({
           Feynman
         </span>
         <div className={styles.topbarActions}>
-          <a
-            href="https://discord.gg/bCShwbFnCd"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.discordLink}
-            title="Join our Discord"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-            </svg>
-          </a>
           <button className={styles.themeToggle} onClick={toggleTheme} title="Toggle dark mode">
             <svg
               className={styles.iconSun}
@@ -1469,171 +1458,133 @@ export function LandingPage({
         </div>
       </section>
 
-      {/* ═══════════ BELOW-THE-HERO FEATURE SECTIONS (appended) ═══════════
-          The hero <section> above is 100% untouched. These editorial sections
-          introduce the five core capabilities as two pairs — Books, then Minds —
-          reusing the demo classes for native-looking static mocks. */}
+      {/* ═══════════ BELOW-THE-HERO SECTIONS (appended) ═══════════
+          The hero <section> above is 100% untouched. Consistent layout: every
+          feature row is text-left / visual-right; the intro and CTA are centered
+          bands. Copy follows the README narrative — the knowledge network: chat a
+          book → great minds join in → sit with a mind → set them debating → a
+          network that builds itself. Visuals reuse the demo message classes. */}
       <div className={styles.sections}>
-        {/* §0 — Positioning band */}
+        {/* Intro band */}
         <section className={`${styles.section} ${styles.positioning} ${styles.reveal}`} data-reveal>
           <div className={styles.sectionInner}>
             <p className={styles.eyebrow}>An interactive knowledge network</p>
             <h2 className={styles.positioningTitle}>Knowledge you can talk to.</h2>
             <p className={styles.bodyText}>
-              The world&apos;s most important books and greatest minds — now people you can
-              actually talk to.
+              Feynman turns the world&apos;s most important books and the great minds behind them
+              into a living network you explore by talking to it. Chat with a book to understand it
+              fast, start from a topic to map a new field, and watch the right thinkers join in to
+              think alongside you — books, minds, and ideas as one navigable map of human thought.
             </p>
             <div className={styles.pillars}>
               <span className={styles.pillar}>
                 <span className={styles.pillarDot} />
-                Books that talk back
+                Grounded in the actual pages
               </span>
               <span className={styles.pillar}>
                 <span className={styles.pillarDot} />
-                Minds that join in
+                Great minds join in
               </span>
               <span className={styles.pillar}>
                 <span className={styles.pillarDot} />
-                Debates across centuries
+                A network that grows as you explore
               </span>
             </div>
           </div>
         </section>
 
-        {/* §1 — Chat with books (visual left / text right) */}
+        {/* Chat with books */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Chat with books</p>
+              <h2 className={styles.sectionTitle}>Understand any book without reading all 300 pages.</h2>
+              <p className={styles.bodyText}>
+                Ask anything and get a clear answer grounded in the book&apos;s actual text — every
+                claim linked to the exact passage it came from, so nothing is a black box. Feynman
+                reaches beyond the page too, drawing on the work, the web, and the world&apos;s
+                knowledge, so each conversation gives you the context of an afternoon with the author.
+              </p>
+              <div className={styles.chips}>
+                <span className={styles.chip}>Every claim cited [1][2]</span>
+                <span className={styles.chip}>Beyond the page, four ways</span>
+                <span className={styles.chip}>Chat across many books at once</span>
+              </div>
+            </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
                 <div className={styles.mockStack}>
+                  <div className={styles.bookChip}>
+                    <span>The Wealth of Nations</span>
+                  </div>
                   <div className={`${styles.msg} ${styles.msgUser}`}>
-                    What are System 1 and System 2?
+                    What really creates the wealth of a nation?
                   </div>
                   <div className={`${styles.msg} ${styles.msgAssistant}`}>
                     <span>
-                      System 1 is fast, automatic intuition. System 2 is slow, deliberate
-                      thinking.
+                      Smith&apos;s answer is the division of labour — productivity rises when work is
+                      specialized and freely exchanged, not from hoarding gold.
                     </span>
                     <div className={styles.msgSources}>
-                      <span className={styles.sourceTag}>Ch.1 Two Systems</span>
+                      <span className={styles.sourceTag}>Bk.1 Ch.1 — Of the Division of Labour</span>
                     </div>
                   </div>
-                  <MockJoin names={["Richard Feynman"]} verb="joined the discussion" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Great minds join in */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Great minds join in</p>
+              <h2 className={styles.sectionTitle}>You&apos;re never reading alone.</h2>
+              <p className={styles.bodyText}>
+                As you chat, the most relevant great minds join the conversation on their own — you
+                see &ldquo;Adam Smith joined the discussion,&rdquo; just like a group chat. Ask what
+                creates a nation&apos;s wealth and Smith lays out his reasoning while Marx pushes back
+                and Keynes offers another lens. They remember the thread and stay as it evolves — a
+                study group of history&apos;s most brilliant minds, always on call.
+              </p>
+            </div>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.mockStack}>
+                  <div className={styles.bookChip}>
+                    <span>The Wealth of Nations</span>
+                  </div>
+                  <MockJoin
+                    names={["Adam Smith", "Karl Marx", "John Maynard Keynes"]}
+                    verb="joined the discussion"
+                  />
                   <MockMind
-                    name="Richard Feynman"
-                    text="The first principle is that you must not fool yourself — and you are the easiest person to fool."
+                    name="Adam Smith"
+                    text="Wealth grows from the division of labour and free exchange — not from the gold in a treasury."
+                  />
+                  <MockMind
+                    name="Karl Marx"
+                    text="But who owns that labour, Adam? The value the workers create accrues to capital, not to them."
                   />
                 </div>
               </div>
             </div>
-            <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>Chat with books</p>
-              <h2 className={styles.sectionTitle}>Every book becomes a conversation.</h2>
-              <p className={styles.bodyText}>
-                Ask any book anything — get answers cited to the exact page, with great minds
-                joining in to weigh in.
-              </p>
-              <div className={styles.chips}>
-                <span className={styles.chip}>Cited to the page</span>
-                <span className={styles.chip}>Minds join in automatically</span>
-                <span className={styles.chip}>@mention anyone</span>
-              </div>
-            </div>
           </div>
         </section>
 
-        {/* §2 — Create the book you need (text left / visual right) */}
-        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
-          <div className={`${styles.sectionInner} ${styles.featureRow} ${styles.featureRowReverse}`}>
-            <div className={styles.featureVisual} aria-hidden="true">
-              <div className={styles.mockFrame}>
-                <div className={styles.bookMock}>
-                  <div className={styles.bookCover}>
-                    <div className={styles.bookCoverTitle}>The History of Coffee</div>
-                    <div className={styles.bookCoverAuthor}>Compiled on demand</div>
-                  </div>
-                  <div className={styles.bookPage}>
-                    <div className={styles.bookLine} style={{ width: "92%" }} />
-                    <div className={styles.bookLine} style={{ width: "100%" }} />
-                    <div className={styles.bookLine} style={{ width: "96%" }} />
-                    <div className={styles.bookLine} style={{ width: "68%" }} />
-                    <span className={styles.bookChip}>
-                      <span>Ready to chat</span>
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>On-demand books</p>
-              <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
-              <p className={styles.bodyText}>
-                Describe what you want to learn and Feynman composes a book for it — ready to
-                chat with on the spot.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* §3 — The minds network + bring your own (visual left / text right) */}
+        {/* Chat with great minds (the network + upload your own) */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
-            <div className={styles.featureVisual} aria-hidden="true">
-              <div className={styles.constellation}>
-                <svg viewBox="0 0 420 264" preserveAspectRatio="xMidYMid meet">
-                  {NETWORK_LINKS.map(([x1, y1, x2, y2], i) => (
-                    <line
-                      key={i}
-                      x1={x1}
-                      y1={y1}
-                      x2={x2}
-                      y2={y2}
-                      stroke="rgba(150,160,180,0.35)"
-                      strokeWidth="1.2"
-                    />
-                  ))}
-                </svg>
-                {NETWORK_NODES.map((n) => (
-                  <div
-                    key={n.name}
-                    className={styles.cNode}
-                    style={{ left: n.left, top: n.top }}
-                  >
-                    <span className={styles.cAvatar} style={{ background: lpColor(n.name) }}>
-                      {initials(n.name)}
-                    </span>
-                    <span className={styles.cName}>{n.name}</span>
-                  </div>
-                ))}
-                <div
-                  className={`${styles.cNode} ${styles.cNodeUpload}`}
-                  style={{ left: NETWORK_UPLOAD.left, top: NETWORK_UPLOAD.top }}
-                >
-                  <span className={styles.cUpload}>
-                    <svg
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <line x1="12" y1="5" x2="12" y2="19" />
-                      <line x1="5" y1="12" x2="19" y2="12" />
-                    </svg>
-                  </span>
-                  <span className={styles.cName}>Upload a Mind</span>
-                </div>
-              </div>
-            </div>
             <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>Great minds</p>
-              <h2 className={styles.sectionTitle}>A living network of minds — and room for yours.</h2>
+              <p className={styles.eyebrow}>Chat with great minds</p>
+              <h2 className={styles.sectionTitle}>Ask Aristotle. Get an answer.</h2>
               <p className={styles.bodyText}>
-                Chat one-on-one with history&apos;s greatest thinkers — or upload your own mind
-                and add it to the network.
+                Every book is a window into a great mind — but a mind is far more than any one book.
+                Chat one-on-one with Feynman, Adam Smith, or Socrates and get their way of thinking
+                applied to your own questions. Explore the network as a living map where minds cluster
+                by the ideas they share — and upload your own, or anyone you admire, from a profile, a
+                blog, or a page of text.
               </p>
               <Link className={styles.softLink} href="/minds">
                 Explore the network
@@ -1652,39 +1603,71 @@ export function LandingPage({
                 </svg>
               </Link>
             </div>
-          </div>
-        </section>
-
-        {/* §4 — Symposiums (text left / visual right) */}
-        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
-          <div className={`${styles.sectionInner} ${styles.featureRow} ${styles.featureRowReverse}`}>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
-                <div className={styles.mockStack}>
-                  <div className={styles.mockQuestion}>
-                    &ldquo;Is it better to be feared or loved?&rdquo;
+                <div className={styles.constellation}>
+                  <svg viewBox="0 0 420 264" preserveAspectRatio="xMidYMid meet">
+                    {NETWORK_LINKS.map(([x1, y1, x2, y2], i) => (
+                      <line
+                        key={i}
+                        x1={x1}
+                        y1={y1}
+                        x2={x2}
+                        y2={y2}
+                        stroke="rgba(150,160,180,0.35)"
+                        strokeWidth="1.2"
+                      />
+                    ))}
+                  </svg>
+                  {NETWORK_NODES.map((n) => (
+                    <div
+                      key={n.name}
+                      className={styles.cNode}
+                      style={{ left: n.left, top: n.top }}
+                    >
+                      <span className={styles.cAvatar} style={{ background: lpColor(n.name) }}>
+                        {initials(n.name)}
+                      </span>
+                      <span className={styles.cName}>{n.name}</span>
+                    </div>
+                  ))}
+                  <div
+                    className={`${styles.cNode} ${styles.cNodeUpload}`}
+                    style={{ left: NETWORK_UPLOAD.left, top: NETWORK_UPLOAD.top }}
+                  >
+                    <span className={styles.cUpload}>
+                      <svg
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <line x1="12" y1="5" x2="12" y2="19" />
+                        <line x1="5" y1="12" x2="19" y2="12" />
+                      </svg>
+                    </span>
+                    <span className={styles.cName}>Upload a Mind</span>
                   </div>
-                  <MockJoin
-                    names={["Machiavelli", "Sun Tzu", "Marcus Aurelius"]}
-                    verb="in conversation"
-                  />
-                  <MockMind
-                    name="Machiavelli"
-                    text="It is far safer to be feared than loved, if one cannot be both."
-                  />
-                  <MockMind
-                    name="Sun Tzu"
-                    text="Fear may win the battle, Niccolò — but the supreme art is to win without the fight."
-                  />
                 </div>
               </div>
             </div>
+          </div>
+        </section>
+
+        {/* Symposiums */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Symposiums</p>
-              <h2 className={styles.sectionTitle}>Convene a symposium of great minds.</h2>
+              <h2 className={styles.sectionTitle}>Set great minds debating.</h2>
               <p className={styles.bodyText}>
-                Pose one question — a panel of minds debates it, each in their own voice. Then
-                jump in.
+                Pose one big question and a panel of thinkers takes it up — each arguing in their own
+                voice, each answering the others. Read the exchange like a transcript of a debate that
+                never happened, then step in and press them further yourself.
               </p>
               <Link className={styles.softLink} href="/symposiums">
                 Browse symposiums
@@ -1703,10 +1686,84 @@ export function LandingPage({
                 </svg>
               </Link>
             </div>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.mockStack}>
+                  <div className={styles.mockQuestion}>
+                    &ldquo;Is it better to be feared or loved?&rdquo;
+                  </div>
+                  <MockJoin
+                    names={["Machiavelli", "Sun Tzu", "Marcus Aurelius"]}
+                    verb="in conversation"
+                  />
+                  <MockMind
+                    name="Machiavelli"
+                    text="It is far safer to be feared than loved, if one cannot be both."
+                  />
+                  <MockMind
+                    name="Marcus Aurelius"
+                    text="Yet a ruler governed by fear governs nothing in himself, Niccolò. Virtue commands more than dread."
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </section>
 
-        {/* §5 — Closing CTA band (reuses the gated hero CTA handler) */}
+        {/* The network builds itself — topic entry + on-demand books */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>Start from a topic</p>
+              <h2 className={styles.sectionTitle}>No book in mind? Start with a question.</h2>
+              <p className={styles.bodyText}>
+                Name a field you&apos;re curious about and Feynman finds the books worth reading,
+                proposes the questions you should be asking, and teaches you through conversation.
+                There&apos;s no fixed catalog — every search and mention grows your library, and if
+                the book you need doesn&apos;t exist yet, Feynman writes it on demand.
+              </p>
+            </div>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.topicMock}>
+                  <span className={styles.topicChip}>Microeconomics</span>
+                  <span className={styles.topicLabel}>Feynman found the books to start with</span>
+                  <div className={styles.miniCovers}>
+                    <div className={styles.miniCover}>
+                      <span className={styles.miniCoverTitle}>Principles of Economics</span>
+                    </div>
+                    <div className={styles.miniCover}>
+                      <span className={styles.miniCoverTitle}>Thinking, Fast and Slow</span>
+                    </div>
+                    <div className={styles.miniCover}>
+                      <span className={styles.miniCoverTitle}>The Wealth of Nations</span>
+                    </div>
+                    <div className={`${styles.miniCover} ${styles.miniCoverGen}`}>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <line x1="12" y1="5" x2="12" y2="19" />
+                        <line x1="5" y1="12" x2="19" y2="12" />
+                      </svg>
+                    </div>
+                  </div>
+                  <span className={styles.bookChip}>
+                    <span>…or written on demand</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Closing CTA band (reuses the gated hero CTA handler) */}
         <section className={`${styles.ctaBand} ${styles.reveal}`} data-reveal>
           <div className={styles.sectionInner}>
             <h2 className={styles.ctaTitle}>Open a book. Invite a few great minds.</h2>
@@ -1730,6 +1787,70 @@ export function LandingPage({
           </div>
         </section>
       </div>
+
+      {/* Footer — social links live here (moved out of the topbar) */}
+      <footer className={styles.footer}>
+        <div className={styles.footerInner}>
+          <div className={styles.footerBrand}>
+            <span className={styles.footerLogo}>
+              <svg width="18" height="18" viewBox="0 0 64 64" fill="none">
+                <line x1="8" y1="58" x2="32" y2="30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                <line x1="56" y1="58" x2="32" y2="30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                <circle cx="32" cy="30" r="3.5" fill="currentColor" />
+                <path d="M32,30 C26,24 38,18 32,12 C26,6 38,0 32,-4" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              Feynman
+            </span>
+            <p className={styles.footerTagline}>Chat with books. Great minds join in.</p>
+          </div>
+          <nav className={styles.footerNav}>
+            <Link className={styles.footerLink} href="/minds">Great Minds</Link>
+            <Link className={styles.footerLink} href="/symposiums">Symposiums</Link>
+            <Link className={styles.footerLink} href="/library">Library</Link>
+          </nav>
+          <div className={styles.footerSocials}>
+            <a
+              className={styles.footerSocial}
+              href="https://github.com/steveyeow/feynman"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+              title="GitHub"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 .5C5.37.5 0 5.78 0 12.29c0 5.2 3.44 9.6 8.21 11.16.6.11.82-.25.82-.56 0-.28-.01-1.02-.02-2-3.34.71-4.04-1.58-4.04-1.58-.55-1.37-1.34-1.74-1.34-1.74-1.09-.73.08-.72.08-.72 1.2.08 1.84 1.21 1.84 1.21 1.07 1.79 2.81 1.27 3.49.97.11-.76.42-1.27.76-1.56-2.67-.3-5.47-1.31-5.47-5.81 0-1.28.47-2.33 1.24-3.15-.12-.3-.54-1.51.12-3.15 0 0 1.01-.32 3.3 1.2.96-.26 1.98-.39 3-.4 1.02.01 2.04.14 3 .4 2.28-1.52 3.29-1.2 3.29-1.2.66 1.64.24 2.85.12 3.15.77.82 1.24 1.87 1.24 3.15 0 4.51-2.81 5.5-5.49 5.79.43.36.81 1.08.81 2.18 0 1.58-.01 2.85-.01 3.24 0 .31.22.68.83.56C20.57 21.88 24 17.49 24 12.29 24 5.78 18.63.5 12 .5z" />
+              </svg>
+            </a>
+            <a
+              className={styles.footerSocial}
+              href="https://discord.gg/bCShwbFnCd"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Discord"
+              title="Discord"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+              </svg>
+            </a>
+            <a
+              className={styles.footerSocial}
+              href="https://x.com/steve_yeow"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="X (Twitter)"
+              title="X (Twitter)"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.66l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div className={styles.footerBottom}>
+          <span>© 2026 Feynman · MIT licensed</span>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -345,6 +345,17 @@ const NETWORK_LINKS: [number, number, number, number][] = [
   [218.4, 42.2, 302.4, 205.9],
 ];
 
+/* §2 Library cards — colored gradient cover + faded initials + title (mirrors
+   the real /library cards). */
+const LIB_BOOKS: { title: string; initials: string; grad: string }[] = [
+  { title: "Thinking, Fast and Slow", initials: "TF", grad: "linear-gradient(135deg,#6d597a,#355070)" },
+  { title: "The Wealth of Nations", initials: "WN", grad: "linear-gradient(135deg,#2a9d8f,#264653)" },
+  { title: "Meditations", initials: "Md", grad: "linear-gradient(135deg,#e76f51,#9b2226)" },
+  { title: "The Art of War", initials: "AW", grad: "linear-gradient(135deg,#457b9d,#264653)" },
+  { title: "Gödel, Escher, Bach", initials: "GE", grad: "linear-gradient(135deg,#b56576,#6d597a)" },
+  { title: "Sapiens", initials: "Sp", grad: "linear-gradient(135deg,#588157,#2a9d8f)" },
+];
+
 export function LandingPage({
   ctaLabel,
   onCta,
@@ -1474,6 +1485,22 @@ export function LandingPage({
               <p className={styles.bodyText}>
                 Start from a book or a topic — every answer cited to the exact page.
               </p>
+              <button type="button" className={styles.softLink} onClick={onCta}>
+                Start a chat
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              </button>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
@@ -1540,24 +1567,14 @@ export function LandingPage({
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
                 <div className={styles.libraryGrid}>
-                  <div className={styles.libCover}>
-                    <span className={styles.libCoverTitle}>Thinking, Fast and Slow</span>
-                  </div>
-                  <div className={styles.libCover}>
-                    <span className={styles.libCoverTitle}>The Wealth of Nations</span>
-                  </div>
-                  <div className={styles.libCover}>
-                    <span className={styles.libCoverTitle}>Meditations</span>
-                  </div>
-                  <div className={styles.libCover}>
-                    <span className={styles.libCoverTitle}>The Art of War</span>
-                  </div>
-                  <div className={styles.libCover}>
-                    <span className={styles.libCoverTitle}>Gödel, Escher, Bach</span>
-                  </div>
-                  <div className={styles.libCover}>
-                    <span className={styles.libCoverTitle}>Sapiens</span>
-                  </div>
+                  {LIB_BOOKS.map((b) => (
+                    <div key={b.title} className={styles.libCard}>
+                      <div className={styles.libArt} style={{ background: b.grad }}>
+                        <span className={styles.libArtInitials}>{b.initials}</span>
+                      </div>
+                      <span className={styles.libTitle}>{b.title}</span>
+                    </div>
+                  ))}
                 </div>
               </div>
             </div>
@@ -1573,27 +1590,57 @@ export function LandingPage({
               <p className={styles.bodyText}>
                 Describe what you want to learn, and Feynman writes the book for it.
               </p>
+              <button type="button" className={styles.softLink} onClick={onCta}>
+                Write a book
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              </button>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
-                <div className={styles.bookCanvas}>
-                  <div className={styles.bookCanvasPage}>
-                    <div className={styles.bookCanvasTitle}>The History of Coffee</div>
-                    <div className={styles.bookLine} style={{ width: "96%" }} />
-                    <div className={styles.bookLine} style={{ width: "100%" }} />
-                    <div className={styles.bookLine} style={{ width: "92%" }} />
-                    <div className={styles.bookLine} style={{ width: "98%" }} />
-                    <div className={styles.bookLine} style={{ width: "58%" }} />
+                <div className={styles.bookBuild}>
+                  <div className={styles.bookBuildTitle}>The History of Coffee</div>
+                  <div className={styles.bookBuildStatus}>All chapters complete · 100%</div>
+                  <div className={styles.bookBuildBar}>
+                    <div className={styles.bookBuildBarFill} />
                   </div>
-                  <div className={styles.bookCanvasOutline}>
-                    <div className={styles.bookOutlineLabel}>Outline</div>
-                    <div className={styles.bookOutlineItem}>1 · Origins in Ethiopia</div>
-                    <div className={`${styles.bookOutlineItem} ${styles.bookOutlineActive}`}>
-                      2 · The Spread of Coffee
+                  <div className={styles.bookChapters}>
+                    <div className={styles.bookChapter}>
+                      <span className={styles.bookChapterCheck}>✓</span>
+                      <span className={styles.bookChapterTitle}>Ch.1 · Origins in Ethiopia</span>
+                      <span className={styles.bookChapterWords}>1,240 words</span>
                     </div>
-                    <div className={styles.bookOutlineItem}>3 · Coffeehouse Culture</div>
-                    <div className={styles.bookOutlineItem}>4 · Coffee &amp; Commerce</div>
-                    <div className={styles.bookOutlineItem}>5 · The Modern Cup</div>
+                    <div className={styles.bookChapter}>
+                      <span className={styles.bookChapterCheck}>✓</span>
+                      <span className={styles.bookChapterTitle}>Ch.2 · The Spread of Coffee</span>
+                      <span className={styles.bookChapterWords}>1,610 words</span>
+                    </div>
+                    <div className={styles.bookChapter}>
+                      <span className={styles.bookChapterCheck}>✓</span>
+                      <span className={styles.bookChapterTitle}>Ch.3 · Coffeehouse Culture</span>
+                      <span className={styles.bookChapterWords}>1,090 words</span>
+                    </div>
+                    <div className={styles.bookChapter}>
+                      <span className={styles.bookChapterCheck}>✓</span>
+                      <span className={styles.bookChapterTitle}>Ch.4 · Coffee &amp; Commerce</span>
+                      <span className={styles.bookChapterWords}>1,375 words</span>
+                    </div>
+                    <div className={styles.bookChapter}>
+                      <span className={styles.bookChapterCheck}>✓</span>
+                      <span className={styles.bookChapterTitle}>Ch.5 · The Modern Cup</span>
+                      <span className={styles.bookChapterWords}>980 words</span>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1608,7 +1655,8 @@ export function LandingPage({
               <p className={styles.eyebrow}>Great minds</p>
               <h2 className={styles.sectionTitle}>An ever-evolving network of simulated great minds.</h2>
               <p className={styles.bodyText}>
-                Chat any of them one-on-one, or add your own to the network.
+                A living map where minds connect by the ideas they share — move between
+                them, and chat anyone.
               </p>
               <Link className={styles.softLink} href="/minds">
                 Explore the network
@@ -1661,12 +1709,12 @@ export function LandingPage({
                   >
                     <span className={styles.cUpload}>
                       <svg
-                        width="18"
-                        height="18"
+                        width="13"
+                        height="13"
                         viewBox="0 0 24 24"
                         fill="none"
                         stroke="currentColor"
-                        strokeWidth="2"
+                        strokeWidth="1.5"
                         strokeLinecap="round"
                         strokeLinejoin="round"
                       >
@@ -1711,9 +1759,7 @@ export function LandingPage({
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
                 <div className={styles.mockStack}>
-                  <div className={styles.mockQuestion}>
-                    &ldquo;Is it better to be feared or loved?&rdquo;
-                  </div>
+                  <div className={styles.symQuestion}>Is it better to be feared or loved?</div>
                   <MockJoin
                     names={["Machiavelli", "Sun Tzu", "Marcus Aurelius"]}
                     verb="in conversation"
@@ -1735,23 +1781,25 @@ export function LandingPage({
         {/* Closing CTA band (reuses the gated hero CTA handler) */}
         <section className={`${styles.ctaBand} ${styles.reveal}`} data-reveal>
           <div className={styles.sectionInner}>
-            <h2 className={styles.ctaTitle}>Open a book. Invite a few great minds.</h2>
-            <button className={styles.heroCta} onClick={onCta}>
-              {ctaLabel}
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <line x1="5" y1="12" x2="19" y2="12" />
-                <polyline points="12 5 19 12 12 19" />
-              </svg>
-            </button>
+            <div className={styles.ctaCard}>
+              <h2 className={styles.ctaTitle}>Start your first conversation.</h2>
+              <button className={styles.heroCta} onClick={onCta}>
+                {ctaLabel}
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              </button>
+            </div>
           </div>
         </section>
       </div>
@@ -1759,18 +1807,15 @@ export function LandingPage({
       {/* Footer — social links live here (moved out of the topbar) */}
       <footer className={styles.footer}>
         <div className={styles.footerInner}>
-          <div className={styles.footerBrand}>
-            <span className={styles.footerLogo}>
-              <svg width="18" height="18" viewBox="0 0 64 64" fill="none">
-                <line x1="8" y1="58" x2="32" y2="30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-                <line x1="56" y1="58" x2="32" y2="30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-                <circle cx="32" cy="30" r="3.5" fill="currentColor" />
-                <path d="M32,30 C26,24 38,18 32,12 C26,6 38,0 32,-4" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-              Feynman
-            </span>
-            <p className={styles.footerCopy}>© 2026 Feynman · MIT licensed</p>
-          </div>
+          <span className={styles.footerLogo}>
+            <svg width="18" height="18" viewBox="0 0 64 64" fill="none">
+              <line x1="8" y1="58" x2="32" y2="30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              <line x1="56" y1="58" x2="32" y2="30" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              <circle cx="32" cy="30" r="3.5" fill="currentColor" />
+              <path d="M32,30 C26,24 38,18 32,12 C26,6 38,0 32,-4" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            Feynman
+          </span>
           <div className={styles.footerSocials}>
             <a
               className={styles.footerSocial}
@@ -1809,6 +1854,9 @@ export function LandingPage({
               </svg>
             </a>
           </div>
+        </div>
+        <div className={styles.footerBottom}>
+          <span>© 2026 Feynman. All rights reserved.</span>
         </div>
       </footer>
     </div>

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1778,30 +1778,6 @@ export function LandingPage({
           </div>
         </section>
 
-        {/* Closing CTA band (reuses the gated hero CTA handler) */}
-        <section className={`${styles.ctaBand} ${styles.reveal}`} data-reveal>
-          <div className={styles.sectionInner}>
-            <div className={styles.ctaCard}>
-              <h2 className={styles.ctaTitle}>Start your first conversation.</h2>
-              <button className={styles.heroCta} onClick={onCta}>
-                {ctaLabel}
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <line x1="5" y1="12" x2="19" y2="12" />
-                  <polyline points="12 5 19 12 12 19" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </section>
       </div>
 
       {/* Footer — social links live here (moved out of the topbar) */}

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1588,7 +1588,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>On-demand books</p>
               <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
               <p className={styles.bodyText}>
-                Describe what you want to learn, and Feynman writes the book for it.
+                Describe what you want to know, and Feynman generates a book for you on the spot.
               </p>
               <button type="button" className={styles.softLink} onClick={onCta}>
                 Write a book
@@ -1737,7 +1737,7 @@ export function LandingPage({
               <p className={styles.eyebrow}>Symposiums</p>
               <h2 className={styles.sectionTitle}>Put your question to a panel of great minds.</h2>
               <p className={styles.bodyText}>
-                See how each reasons it through — then step in yourself.
+                See how history&apos;s greatest minds view the questions we care about today.
               </p>
               <Link className={styles.softLink} href="/symposiums">
                 Browse symposiums

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1470,7 +1470,7 @@ export function LandingPage({
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Chat with books</p>
-              <h2 className={styles.sectionTitle}>Chat with a book — the great minds behind it join in.</h2>
+              <h2 className={styles.sectionTitle}>Chat with any book — and the most relevant minds join in.</h2>
               <p className={styles.bodyText}>
                 Ask a book anything and get answers grounded in its actual text, traced to the
                 passage they came from. As you go, the relevant great minds join on their own —
@@ -1553,12 +1553,12 @@ export function LandingPage({
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>Chat with great minds</p>
-              <h2 className={styles.sectionTitle}>Ask Aristotle. Or anyone you admire.</h2>
+              <p className={styles.eyebrow}>Great minds</p>
+              <h2 className={styles.sectionTitle}>An ever-evolving network of great minds.</h2>
               <p className={styles.bodyText}>
-                Chat one-on-one with any thinker and get their reasoning applied to your questions.
-                Explore the network to find your next mind — or upload your own, from a profile, a
-                blog, or a page of text.
+                Chat one-on-one with any thinker — faithfully simulated from their own work — and
+                they grow richer as you talk, accumulating memory over time. Explore the network, or
+                expand it by uploading your own mind from a profile, a blog, or a page of text.
               </p>
               <Link className={styles.softLink} href="/minds">
                 Explore the network
@@ -1759,7 +1759,6 @@ export function LandingPage({
               </svg>
               Feynman
             </span>
-            <p className={styles.footerTagline}>Chat with books. Great minds join in.</p>
             <p className={styles.footerCopy}>© 2026 Feynman · MIT licensed</p>
           </div>
           <div className={styles.footerSocials}>

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -1465,14 +1465,14 @@ export function LandingPage({
           row is text-left / visual-right; the CTA is a centered band. Visuals reuse
           the demo message classes. */}
       <div className={styles.sections}>
-        {/* 1 — Enter through a book: grounded book chat + great minds joining in (the core) */}
+        {/* 1 — Chat with a book or a topic; great minds join in (the core) */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Chat with books</p>
               <h2 className={styles.sectionTitle}>Chat with any book — and the most relevant minds join in.</h2>
               <p className={styles.bodyText}>
-                Every answer grounded in the book, cited to the exact page.
+                Start from a book or a topic — every answer cited to the exact page.
               </p>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
@@ -1511,47 +1511,104 @@ export function LandingPage({
           </div>
         </section>
 
-        {/* 2 — Enter through a topic */}
+        {/* 2 — Library (the growing collection of books) */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>Start from a topic</p>
-              <h2 className={styles.sectionTitle}>No book yet? Start from a topic.</h2>
+              <p className={styles.eyebrow}>Library</p>
+              <h2 className={styles.sectionTitle}>A library that grows as you explore.</h2>
               <p className={styles.bodyText}>
-                Feynman finds the books worth reading and the questions to ask first.
+                No fixed catalog — every book you chat, search, or mention joins it.
               </p>
+              <Link className={styles.softLink} href="/library">
+                Browse the library
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="12 5 19 12 12 19" />
+                </svg>
+              </Link>
             </div>
             <div className={styles.featureVisual} aria-hidden="true">
               <div className={styles.mockFrame}>
-                <div className={styles.topicMock}>
-                  <span className={styles.topicChip}>Microeconomics</span>
-                  <span className={styles.topicLabel}>Feynman found the books to start with</span>
-                  <div className={styles.miniCovers}>
-                    <div className={styles.miniCover}>
-                      <span className={styles.miniCoverTitle}>Principles of Economics</span>
-                    </div>
-                    <div className={styles.miniCover}>
-                      <span className={styles.miniCoverTitle}>Thinking, Fast and Slow</span>
-                    </div>
-                    <div className={styles.miniCover}>
-                      <span className={styles.miniCoverTitle}>The Wealth of Nations</span>
-                    </div>
+                <div className={styles.libraryGrid}>
+                  <div className={styles.libCover}>
+                    <span className={styles.libCoverTitle}>Thinking, Fast and Slow</span>
                   </div>
-                  <span className={styles.topicLabel}>…and the questions to ask first</span>
+                  <div className={styles.libCover}>
+                    <span className={styles.libCoverTitle}>The Wealth of Nations</span>
+                  </div>
+                  <div className={styles.libCover}>
+                    <span className={styles.libCoverTitle}>Meditations</span>
+                  </div>
+                  <div className={styles.libCover}>
+                    <span className={styles.libCoverTitle}>The Art of War</span>
+                  </div>
+                  <div className={styles.libCover}>
+                    <span className={styles.libCoverTitle}>Gödel, Escher, Bach</span>
+                  </div>
+                  <div className={styles.libCover}>
+                    <span className={styles.libCoverTitle}>Sapiens</span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </section>
 
-        {/* Chat with great minds (the network + upload your own) */}
+        {/* 3 — On-demand books: write the book you need */}
+        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
+          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
+            <div className={styles.featureCopy}>
+              <p className={styles.eyebrow}>On-demand books</p>
+              <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
+              <p className={styles.bodyText}>
+                Describe what you want to learn, and Feynman writes the book for it.
+              </p>
+            </div>
+            <div className={styles.featureVisual} aria-hidden="true">
+              <div className={styles.mockFrame}>
+                <div className={styles.bookCanvas}>
+                  <div className={styles.bookCanvasPage}>
+                    <div className={styles.bookCanvasTitle}>The History of Coffee</div>
+                    <div className={styles.bookLine} style={{ width: "96%" }} />
+                    <div className={styles.bookLine} style={{ width: "100%" }} />
+                    <div className={styles.bookLine} style={{ width: "92%" }} />
+                    <div className={styles.bookLine} style={{ width: "98%" }} />
+                    <div className={styles.bookLine} style={{ width: "58%" }} />
+                  </div>
+                  <div className={styles.bookCanvasOutline}>
+                    <div className={styles.bookOutlineLabel}>Outline</div>
+                    <div className={styles.bookOutlineItem}>1 · Origins in Ethiopia</div>
+                    <div className={`${styles.bookOutlineItem} ${styles.bookOutlineActive}`}>
+                      2 · The Spread of Coffee
+                    </div>
+                    <div className={styles.bookOutlineItem}>3 · Coffeehouse Culture</div>
+                    <div className={styles.bookOutlineItem}>4 · Coffee &amp; Commerce</div>
+                    <div className={styles.bookOutlineItem}>5 · The Modern Cup</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* 4 — Great minds: an ever-evolving network of simulated minds (chat 1:1 + upload) */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
               <p className={styles.eyebrow}>Great minds</p>
-              <h2 className={styles.sectionTitle}>An ever-evolving network of great minds.</h2>
+              <h2 className={styles.sectionTitle}>An ever-evolving network of simulated great minds.</h2>
               <p className={styles.bodyText}>
-                Chat any mind one-on-one — faithfully simulated, and growing as you talk.
+                Chat any of them one-on-one, or add your own to the network.
               </p>
               <Link className={styles.softLink} href="/minds">
                 Explore the network
@@ -1625,7 +1682,7 @@ export function LandingPage({
           </div>
         </section>
 
-        {/* Symposiums */}
+        {/* 5 — Symposiums */}
         <section className={`${styles.section} ${styles.reveal}`} data-reveal>
           <div className={`${styles.sectionInner} ${styles.featureRow}`}>
             <div className={styles.featureCopy}>
@@ -1669,43 +1726,6 @@ export function LandingPage({
                     name="Marcus Aurelius"
                     text="Yet a ruler governed by fear governs nothing in himself, Niccolò. Virtue commands more than dread."
                   />
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* 5 — On-demand books: the book you need, written on demand */}
-        <section className={`${styles.section} ${styles.reveal}`} data-reveal>
-          <div className={`${styles.sectionInner} ${styles.featureRow}`}>
-            <div className={styles.featureCopy}>
-              <p className={styles.eyebrow}>On-demand books</p>
-              <h2 className={styles.sectionTitle}>The book you need, written on demand.</h2>
-              <p className={styles.bodyText}>
-                Can&apos;t find it? Describe it, and Feynman writes the book.
-              </p>
-            </div>
-            <div className={styles.featureVisual} aria-hidden="true">
-              <div className={styles.mockFrame}>
-                <div className={styles.bookCanvas}>
-                  <div className={styles.bookCanvasPage}>
-                    <div className={styles.bookCanvasTitle}>The History of Coffee</div>
-                    <div className={styles.bookLine} style={{ width: "96%" }} />
-                    <div className={styles.bookLine} style={{ width: "100%" }} />
-                    <div className={styles.bookLine} style={{ width: "92%" }} />
-                    <div className={styles.bookLine} style={{ width: "98%" }} />
-                    <div className={styles.bookLine} style={{ width: "58%" }} />
-                  </div>
-                  <div className={styles.bookCanvasOutline}>
-                    <div className={styles.bookOutlineLabel}>Outline</div>
-                    <div className={styles.bookOutlineItem}>1 · Origins in Ethiopia</div>
-                    <div className={`${styles.bookOutlineItem} ${styles.bookOutlineActive}`}>
-                      2 · The Spread of Coffee
-                    </div>
-                    <div className={styles.bookOutlineItem}>3 · Coffeehouse Culture</div>
-                    <div className={styles.bookOutlineItem}>4 · Coffee &amp; Commerce</div>
-                    <div className={styles.bookOutlineItem}>5 · The Modern Cup</div>
-                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Adds editorial feature/value sections **below the hero** on the marketing landing (shown to signed-out first-time visitors), plus a footer. **The hero is 100% untouched** (its demo, copy, background minds-graph, floating toolbar, and right-side animated preview card).

## Sections (books → minds)
1. **Chat with any book — and the most relevant minds join in** (grounded + cited answers; minds join the conversation). Starts from a book or a topic.
2. **Library** — a growing collection (gradient covers).
3. **On-demand books** — describe what you want to know, a book is generated for you on the spot (book + chapter/progress panel).
4. **Great minds** — an ever-evolving network of simulated minds connected by their ideas (graph viz + upload your own).
5. **Symposiums** — see how history's greatest minds view the questions we care about today.

Each section has a CTA; visuals mirror the real product UI (chat, library cards, book-build panel, minds graph, symposium transcript).

## Footer
Brand logo (left), © + GitHub/Discord/X (right). Discord moved out of the topbar.

## Notes
- Frontend-only: two files (`web/components/landing/LandingPage.tsx`, `LandingPage.module.css`). No backend/routes/deps/SEO changes.
- Light/dark + responsive (<960px) handled; scroll-reveal respects `prefers-reduced-motion`.
- Verified green on the feynman-web preview across iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)