### PR TITLE
api: add GET /api/stats (books/minds/symposiums counts) for landing band

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1905,6 +1905,28 @@ def list_agents_missing_overview(limit: int = 50) -> tuple[list[str], int]:
     return [r["id"] for r in rows], int(total_row["n"] if total_row else 0)
 
 
+def count_landing_stats() -> dict[str, int]:
+    """Public landing-page counts: ready books, minds, and published symposiums
+    (debates). Mirrors the visibility filters of the /library, /minds and
+    /symposiums lists so the band matches what users actually see. Three cheap
+    COUNT(*)s (no fat-column reads); the caller caches the result."""
+    books_where = "is_deleted = false" if _USE_PG else "is_deleted = 0"
+    with get_conn() as conn:
+        books = _fetchone(
+            conn, f"SELECT count(*) AS n FROM agents WHERE {books_where} AND status = 'ready'"
+        )
+        minds = _fetchone(conn, "SELECT count(*) AS n FROM minds")
+        symp = _fetchone(
+            conn,
+            "SELECT count(*) AS n FROM debates WHERE status = 'published' AND slug IS NOT NULL",
+        )
+    return {
+        "books": int((books or {}).get("n") or 0),
+        "minds": int((minds or {}).get("n") or 0),
+        "symposiums": int((symp or {}).get("n") or 0),
+    }
+
+
 def find_agent_by_name(name: str) -> dict[str, Any] | None:
     """Find an agent by name (case-insensitive)."""
     with get_conn() as conn:

--- a/app/main.py
+++ b/app/main.py
@@ -54,6 +54,7 @@ from .core.db import (
     count_assistant_messages_batch,
     count_assistant_messages_for_minds_batch,
     count_chunks_batch,
+    count_landing_stats,
     count_llm_referrals,
     count_pending_public_sessions,
     get_chat_session_with_public_status,
@@ -378,6 +379,7 @@ _seo_cache: dict[str, tuple[float, Any]] = {}
 _seo_cache_lock = threading.Lock()
 _SEO_CACHE_TTL = 3600  # 1 hour — acceptable staleness for catalog listings
 _BOOK_CACHE_TTL = 1800  # 30 min for individual published book content
+_STATS_CACHE_TTL = 300  # 5 min — landing stat band; counts move slowly
 
 
 def _cache_get(key: str, ttl: float) -> Any | None:
@@ -3902,6 +3904,26 @@ def api_list_agents():
         # from this path by ~80%. Drove ~2 GB/month of preventable
         # egress prior to the 2026-05-28 quota overage.
         headers={"Cache-Control": "public, max-age=60, s-maxage=600"},
+    )
+
+
+@app.get("/api/stats")
+def api_stats():
+    """Public landing-page counts (books / minds / symposiums), cached ~5 min.
+    Three cheap COUNT(*)s behind an in-process TTL cache so the high-traffic,
+    signed-out landing band doesn't hit the DB on every view."""
+    from fastapi.responses import JSONResponse
+    cached = _cache_get("landing_stats", _STATS_CACHE_TTL)
+    if cached is None:
+        try:
+            cached = count_landing_stats()
+            _cache_set("landing_stats", cached)
+        except Exception as exc:
+            log.error("landing stats count failed: %s", exc)
+            return JSONResponse(content={"error": "unavailable"}, status_code=503)
+    return JSONResponse(
+        content=cached,
+        headers={"Cache-Control": "public, max-age=120, s-maxage=300"},
     )
 
 


### PR DESCRIPTION
Additive public endpoint `GET /api/stats` → `{"books":N,"minds":M,"symposiums":K}` for the upcoming landing stats band.

- Counts mirror the live list visibility filters: agents `is_deleted=false AND status='ready'`; all minds; debates `status='published' AND slug IS NOT NULL`.
- Three cheap `COUNT(*)`s (no fat-column reads) behind a 5-min in-process TTL cache + `Cache-Control: max-age=120, s-maxage=300` so the signed-out landing doesn't hit the DB per view.
- On DB error → 503 (frontend hides the band).
- Backend-only; ships first so the frontend band (separate PR) can read it from api.feynman.wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)