### PR TITLE
Content sources: add Internet Archive + arXiv to the full-text chain

### DIFF
--- a/app/core/sources.py
+++ b/app/core/sources.py
@@ -145,17 +145,29 @@ def fetch_book_content(title: str, author: str = "") -> str:
         from .sources_wikisource import fetch_wikisource_content
         return fetch_wikisource_content(t, a)
 
+    def _internet_archive(t: str, a: str) -> str:
+        from .sources_internetarchive import fetch_internetarchive_content
+        return fetch_internetarchive_content(t, a)
+
+    def _arxiv(t: str, a: str) -> str:
+        from .sources_arxiv import fetch_arxiv_content
+        return fetch_arxiv_content(t, a)
+
     try:
         from .sources_wikisource import _detect_lang
         lang = _detect_lang(title)
     except Exception:
         lang = "en"
 
-    chain = (
+    # Precise canon first (Gutenberg/Wikisource, ordered by language), then the
+    # Internet Archive catch-all (strict-gated, huge OCR corpus), then arXiv
+    # (only matches real preprints). First substantial hit (>2000 chars) wins.
+    canon = (
         [("gutenberg", _gutenberg), ("wikisource", _wikisource)]
         if lang == "en"
         else [("wikisource", _wikisource), ("gutenberg", _gutenberg)]
     )
+    chain = canon + [("internet_archive", _internet_archive), ("arxiv", _arxiv)]
     for name, fn in chain:
         try:
             body = fn(title, author)

--- a/app/core/sources_arxiv.py
+++ b/app/core/sources_arxiv.py
@@ -1,0 +1,111 @@
+"""arXiv content source — full text of scientific preprints via ar5iv HTML.
+
+Niche + LAST in the full-text chain: only matches actual arXiv papers (1991+
+preprints, mostly physics/math/CS/quant-bio). It will NOT help pre-arXiv works
+(old Nobel lectures, books, historical papers) — those fall through. It fires
+only when a catalog title confidently matches an arXiv paper title, so it's
+safe to try for everything that misses the earlier sources.
+
+Pipeline: arXiv Atom API (title search, HTTPS — http returns empty) → confident
+title match → ar5iv rendered HTML (full paper) → strip; abstract as a thin
+fallback. Never raises.
+
+API: ``fetch_arxiv_content(title, author) -> str``.
+"""
+from __future__ import annotations
+
+import html
+import logging
+import re
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_TIMEOUT = 30
+_UA = "Mozilla/5.0 (compatible; FeynmanBot/1.0; +https://feynman.wiki)"
+_MAX_TEXT_BYTES = 1_500_000
+_MIN_USEFUL_CHARS = 1500
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).strip()
+
+
+def _overlap(a: str, b: str) -> float:
+    sa, sb = set(a.split()), set(b.split())
+    if not sa or not sb:
+        return 0.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def _search_arxiv(title: str) -> tuple[str, str] | None:
+    """Return (arxiv_id, abstract) for a confident title match, else None.
+    Papers have specific titles, so we require near-equality — avoids matching
+    a paper that merely shares a topical word with the catalog title."""
+    q = (title or "").strip()
+    if len(q) < 6:
+        return None
+    try:
+        with httpx.Client(timeout=_TIMEOUT, headers={"User-Agent": _UA}, follow_redirects=True) as c:
+            r = c.get("https://export.arxiv.org/api/query",
+                      params={"search_query": f'ti:"{q}"', "max_results": "5"})
+        if r.status_code >= 400:
+            return None
+        feed = r.text
+    except Exception as exc:
+        log.debug("arxiv search %r: %s", title, exc)
+        return None
+
+    nq = _norm(title)
+    for entry in re.findall(r"<entry>(.*?)</entry>", feed, flags=re.S):
+        tm = re.search(r"<title>(.*?)</title>", entry, flags=re.S)
+        idm = re.search(r"<id>https?://arxiv\.org/abs/([^<]+)</id>", entry)
+        if not tm or not idm:
+            continue
+        et = _norm(html.unescape(tm.group(1)))
+        if et == nq or nq in et or et in nq or _overlap(nq, et) >= 0.8:
+            abs_m = re.search(r"<summary>(.*?)</summary>", entry, flags=re.S)
+            abstract = html.unescape(abs_m.group(1)).strip() if abs_m else ""
+            return idm.group(1), re.sub(r"\s+", " ", abstract)
+    return None
+
+
+def _strip_html(h: str) -> str:
+    h = re.sub(r"<(script|style|math|svg|table|head|nav)[^>]*>.*?</\1>", " ", h, flags=re.S | re.I)
+    return re.sub(r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", " ", h))).strip()
+
+
+def _fetch_ar5iv(arxiv_id: str) -> str:
+    """ar5iv rendered HTML for the paper → plain text. ar5iv uses the bare id
+    (no version suffix)."""
+    bare = re.sub(r"v\d+$", "", arxiv_id)
+    for url in (f"https://ar5iv.labs.arxiv.org/html/{bare}",
+                f"https://ar5iv.org/html/{bare}"):
+        try:
+            with httpx.Client(timeout=_TIMEOUT, headers={"User-Agent": _UA}, follow_redirects=True) as c:
+                r = c.get(url)
+            if r.status_code < 400 and len(r.text) > 4000:
+                return _strip_html(r.text)[:_MAX_TEXT_BYTES]
+        except Exception as exc:
+            log.debug("ar5iv %s: %s", url, exc)
+            continue
+    return ""
+
+
+def fetch_arxiv_content(title: str, author: str = "") -> str:
+    """Orchestrator. Full text of a confidently-matched arXiv paper (ar5iv),
+    or the abstract if ar5iv is unavailable, or "" on no match."""
+    hit = _search_arxiv(title)
+    if not hit:
+        return ""
+    arxiv_id, abstract = hit
+    body = _fetch_ar5iv(arxiv_id)
+    if len(body) >= _MIN_USEFUL_CHARS:
+        log.info("arXiv hit for %r → %s (ar5iv full text, %d chars)", title, arxiv_id, len(body))
+        return body
+    # ar5iv unavailable — the abstract is still real, attributable content.
+    if len(abstract) >= 200:
+        log.info("arXiv hit for %r → %s (abstract only, %d chars)", title, arxiv_id, len(abstract))
+        return f"Title: {title}\n\nAbstract: {abstract}"
+    return ""

--- a/app/core/sources_internetarchive.py
+++ b/app/core/sources_internetarchive.py
@@ -1,0 +1,152 @@
+"""Internet Archive content source — massive OCR'd full text.
+
+The catch-all full-text source: archive.org has millions of digitized texts
+(public-domain + older scans) across languages that Gutenberg and Wikisource
+miss. The trade-off is NOISE — a loose title search over millions of items
+easily returns the wrong book, and indexing the wrong text into an agent is
+worse than no text. So matching is STRICT (mirrors Gutenberg): a hard author
+gate when an author is given, a high title-token threshold, exact-title for
+short titles, and downloads-desc ordering so the canonical edition wins.
+
+Pipeline: advancedsearch (title + mediatype:texts, downloads desc) → client-side
+strict gate → metadata → the item's ``*_djvu.txt`` OCR file. Never raises.
+
+API: ``fetch_internetarchive_content(title, author) -> str`` (cleaned OCR text
+or "" on no confident match). Entry point for ``sources.fetch_book_content``.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_TIMEOUT = 30
+_UA = "FeynmanBot/1.0 (+https://feynman.wiki)"
+_MAX_TEXT_BYTES = 1_500_000
+# An IA hit should be a real book; below this we treat it as a miss and fall
+# through (a stray pamphlet / catalog card / bad OCR derivative).
+_MIN_USEFUL_CHARS = 2000
+_STOP = {"the", "and", "for", "with", "from", "about", "into", "upon", "of", "a", "an"}
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).strip()
+
+
+def _surname(name: str) -> str:
+    name = re.sub(r"\s*\([^)]*\)\s*", "", name or "")
+    head = name.split(",")[0] if "," in name else (name.split()[-1] if name.split() else name)
+    return _norm(head)
+
+
+def _search_ia(title: str, author: str) -> str | None:
+    """Best IA item identifier for (title, author), or None. Strict: hard
+    author-surname gate, high title-token overlap, exact-title for short
+    titles; among survivors the most-downloaded (canonical) edition wins."""
+    tokens = [t for t in _norm(title).split() if len(t) >= 3 and t not in _STOP]
+    if not tokens:
+        return None
+    params = [
+        ("q", f"title:({' '.join(tokens)}) AND mediatype:texts"),
+        ("rows", "20"),
+        ("output", "json"),
+        ("sort[]", "downloads desc"),
+        ("fl[]", "identifier"), ("fl[]", "title"), ("fl[]", "creator"),
+        ("fl[]", "language"), ("fl[]", "downloads"),
+    ]
+    try:
+        with httpx.Client(timeout=_TIMEOUT, headers={"User-Agent": _UA}, follow_redirects=True) as c:
+            r = c.get("https://archive.org/advancedsearch.php", params=params)
+        if r.status_code >= 400:
+            return None
+        docs = r.json().get("response", {}).get("docs", [])
+    except Exception as exc:
+        log.debug("IA search %r: %s", title, exc)
+        return None
+
+    asur = _surname(author) if author else ""
+    nq = _norm(title)
+    # Short / author-less titles need an exact title match (same precision guard
+    # as Gutenberg) — 'Quiet', 'Game' would otherwise grab any item containing
+    # the word out of millions.
+    require_exact = len(tokens) <= 1 or (not asur and len(tokens) <= 2)
+
+    best: str | None = None
+    best_dl = -1
+    qset = set(tokens)
+    for d in docs:
+        bt = _norm(str(d.get("title", "")))
+        if require_exact:
+            if bt != nq:
+                continue
+        else:
+            # BIDIRECTIONAL match: most query tokens must be present AND the
+            # candidate must not be drowned in extra significant tokens (a much
+            # longer title = a different/bigger work). One-directional overlap
+            # let "TED Talk: The Universe as a Laboratory" grab a 1.5MB unrelated
+            # item and "Les Troyens" a 621KB one — the Jaccard guard rejects both.
+            bset = {t for t in bt.split() if len(t) >= 3 and t not in _STOP}
+            if not bset:
+                continue
+            present = len(qset & bset) / len(qset)
+            jaccard = len(qset & bset) / len(qset | bset)
+            if present < 0.8 or jaccard < 0.5:
+                continue
+        cre = d.get("creator", "")
+        cre = cre if isinstance(cre, str) else " ".join(cre or [])
+        if asur and asur not in _surname(cre) and asur not in _norm(cre):
+            continue  # hard author gate
+        dl = int(d.get("downloads") or 0)
+        if dl > best_dl:
+            best_dl, best = dl, d.get("identifier")
+    return best
+
+
+def _clean_ocr(text: str) -> str:
+    if not text:
+        return ""
+    text = text.replace("\f", "\n")  # form-feed page breaks
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _fetch_ia_text(identifier: str) -> str:
+    """Download the item's OCR full text (``*_djvu.txt``, or a Text-format
+    ``.txt`` derivative). Empty string on any failure."""
+    try:
+        with httpx.Client(timeout=_TIMEOUT, headers={"User-Agent": _UA}, follow_redirects=True) as c:
+            m = c.get(f"https://archive.org/metadata/{identifier}")
+            if m.status_code >= 400:
+                return ""
+            files = m.json().get("files", []) or []
+            name = next((f["name"] for f in files if str(f.get("name", "")).endswith("_djvu.txt")), None)
+            if not name:
+                name = next((f["name"] for f in files
+                             if f.get("format") == "Text" and str(f.get("name", "")).endswith(".txt")), None)
+            if not name:
+                return ""
+            r = c.get(f"https://archive.org/download/{identifier}/{name}")
+            if r.status_code >= 400 or len(r.content) < 500:
+                return ""
+            return r.content[:_MAX_TEXT_BYTES].decode("utf-8", errors="replace")
+    except Exception as exc:
+        log.debug("IA fetch %s: %s", identifier, exc)
+        return ""
+
+
+def fetch_internetarchive_content(title: str, author: str = "") -> str:
+    """Orchestrator. Returns cleaned OCR full text from Internet Archive for a
+    confidently-matched item, or "" if no strict match. Entry point for
+    ``sources.fetch_book_content``."""
+    ident = _search_ia(title, author)
+    if not ident:
+        return ""
+    text = _clean_ocr(_fetch_ia_text(ident))
+    if len(text) < _MIN_USEFUL_CHARS:
+        return ""
+    log.info("Internet Archive hit for %r → %s, %d chars", title, ident, len(text))
+    return text


### PR DESCRIPTION
Extends the pluggable full-text chain (#218) with two more sources, completing the mechanism.

## Sources added
- **Internet Archive** (`sources_internetarchive.py`) — the catch-all: millions of OCR'd texts across languages Gutenberg/Wikisource miss. `advancedsearch` (downloads desc) → **strict gate** (hard author-surname gate + **bidirectional token match** so an over-long *different* work can't match) → metadata → `{id}_djvu.txt`. The bidirectional guard was necessary: a one-directional overlap let *"TED Talk: The Universe as a Laboratory"* grab a 1.5 MB unrelated item.
- **arXiv** (`sources_arxiv.py`) — scientific preprints via **ar5iv** HTML (HTTPS; http returns empty). Niche + **last** in the chain: matches only real arXiv papers (won't help pre-arXiv lectures/books), confident title match required.

**Chain:** canon (Gutenberg/Wikisource, language-routed) → Internet Archive → arXiv → metadata fallback (Open Library → Google → Wikipedia).

## Verified
- Wealth of Nations 823K & Origin of Species 1.3M (IA); Attention Is All You Need 35K (arXiv/ar5iv)
- TED-talk false positive now correctly → 0; Les Troyens 621K→110K (right item)

## Dry-run backfill audit
45-book sample of the **2,321** "0-chunk + real-overview" books: **~69% now get full text**, ~500 chunks/book → **~826K chunks** to embed if backfilled. **Backfill NOT run** (ask-before-spike) — recommend a clean re-audit post-precision-fix + a cost OK before running.

## Still open
Backfill the existing 0-chunk books; record `meta.content_source` provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)