### PR TITLE
Content backfill (B): pending_content staging + Vercel index cron + provenance

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -274,6 +274,76 @@ def _conflict_ignore(query: str) -> str:
     return query
 
 
+# ── Content backfill staging (pending_content) ──────────────────────────────
+# Approach-B transport: the LOCAL fetch (network OK locally) writes book text
+# here; the Vercel `/api/cron/index-pending-content` cron reads it, indexes +
+# embeds (Gemini works on Vercel, geoblocked from the dev box), then deletes the
+# row. A separate table — NOT agents.meta_json — so 1.5MB texts never bloat the
+# hot agents read. Created out-of-band (NOT in init_db) so it never touches the
+# cold-start boot path (cf. the init_db zombie-lock incident).
+def ensure_pending_content_table() -> None:
+    with get_conn() as conn:
+        _execute(conn, """
+            CREATE TABLE IF NOT EXISTS pending_content (
+                agent_id TEXT PRIMARY KEY,
+                source TEXT,
+                text TEXT NOT NULL,
+                created_at TEXT
+            )
+        """)
+
+
+def stage_pending_content(agent_id: str, text: str, source: str) -> None:
+    with get_conn() as conn:
+        if _USE_PG:
+            _execute(conn,
+                "INSERT INTO pending_content (agent_id, source, text, created_at) "
+                "VALUES (%s, %s, %s, %s) ON CONFLICT (agent_id) DO UPDATE SET "
+                "text = EXCLUDED.text, source = EXCLUDED.source, created_at = EXCLUDED.created_at",
+                (agent_id, source, text, _utcnow()))
+        else:
+            _execute(conn,
+                "INSERT OR REPLACE INTO pending_content (agent_id, source, text, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (agent_id, source, text, _utcnow()))
+
+
+def pop_pending_content(limit: int = 5) -> list[dict[str, Any]]:
+    # random() order, not created_at — so a row that fails to index (and is left
+    # in place for retry) can't sit at the head and stall the whole drain.
+    with get_conn() as conn:
+        cur = _execute(conn, _q(
+            "SELECT agent_id, source, text FROM pending_content ORDER BY random() LIMIT ?"
+        ), (limit,))
+        rows = cur.fetchall()
+    return [{"agent_id": r[0], "source": r[1], "text": r[2]} for r in rows]
+
+
+def delete_pending_content(agent_id: str) -> None:
+    with get_conn() as conn:
+        _execute(conn, _q("DELETE FROM pending_content WHERE agent_id = ?"), (agent_id,))
+
+
+def count_pending_content() -> int:
+    with get_conn() as conn:
+        cur = _execute(conn, "SELECT COUNT(*) FROM pending_content")
+        return int(cur.fetchone()[0])
+
+
+def set_content_source(agent_id: str, source: str) -> None:
+    """Record meta.content_source provenance on a backfilled book (merge)."""
+    if not source:
+        return
+    agent = get_agent(agent_id)
+    if not agent:
+        return
+    meta = dict(agent.get("meta") or {})
+    meta["content_source"] = source
+    with get_conn() as conn:
+        _execute(conn, _q("UPDATE agents SET meta_json = ? WHERE id = ?"),
+                 (json.dumps(meta), agent_id))
+
+
 def init_db() -> None:
     with get_conn() as conn:
         if _USE_PG:

--- a/app/core/sources.py
+++ b/app/core/sources.py
@@ -123,20 +123,26 @@ def _wrap_fulltext(title: str, author: str, body: str) -> str:
 
 
 def fetch_book_content(title: str, author: str = "") -> str:
+    """Text-only orchestrator — see ``fetch_book_content_sourced`` for the source
+    chain. Most callers want just the text."""
+    return fetch_book_content_sourced(title, author)[0]
+
+
+def fetch_book_content_sourced(title: str, author: str = "") -> tuple[str, str]:
     """Orchestrator: try FULL-TEXT sources (Gutenberg + Wikisource, ordered by
-    the title's language) → METADATA sources (Open Library → Google Books →
-    Wikipedia). Full text means RAG has the actual book to retrieve from;
-    modern in-copyright books fall through to metadata (the best free APIs
-    allow).
+    the title's language) → Internet Archive → arXiv → METADATA sources (Open
+    Library → Google Books → Wikipedia). Returns ``(text, source)`` — the source
+    label lets the backfill record ``meta.content_source`` provenance. Full text
+    means RAG has the actual book to retrieve from; modern in-copyright books
+    fall through to metadata (the best free APIs allow).
 
     - **Gutenberg** — English public-domain canon, clean (boilerplate-stripped).
     - **Wikisource** — ~70 languages incl. CJK + many works Gutenberg lacks, so
       it LEADS for non-English titles and BACKS UP Gutenberg for English.
 
-    Adding a source = a new ``(name, fn)`` in the chain below (Internet Archive,
-    arXiv, … are the planned next entries). Each fn is `(title, author) -> text`
-    and must never raise (local import keeps the module importable if an
-    optional source is stripped)."""
+    Adding a source = a new ``(name, fn)`` in the chain below. Each fn is
+    `(title, author) -> text` and must never raise (local import keeps the
+    module importable if an optional source is stripped)."""
     def _gutenberg(t: str, a: str) -> str:
         from .sources_gutenberg import fetch_gutenberg_content
         return fetch_gutenberg_content(t, a)
@@ -176,7 +182,7 @@ def fetch_book_content(title: str, author: str = "") -> str:
             continue
         if body and len(body) > 2000:
             log.info("Full text for %r from %s (%d chars, lang=%s)", title, name, len(body), lang)
-            return _wrap_fulltext(title, author, body)
+            return _wrap_fulltext(title, author, body), name
 
     # Fallback chain — metadata-only (modern / unmatched books)
     text = fetch_open_library_text(title, author)
@@ -184,14 +190,14 @@ def fetch_book_content(title: str, author: str = "") -> str:
         gb = fetch_google_books_info(title, author)
         if gb:
             text += "\n\n--- Google Books ---\n\n" + gb
-        return text
+        return text, "openlibrary"
 
     text = fetch_google_books_info(title, author)
     if text and len(text) > 50:
-        return text
+        return text, "google_books"
 
     wiki = fetch_wikipedia_summary(title, lang="en")
     if wiki:
-        return f"Title: {title}" + (f" by {author}" if author else "") + f"\n\nWikipedia: {wiki}"
+        return f"Title: {title}" + (f" by {author}" if author else "") + f"\n\nWikipedia: {wiki}", "wikipedia"
 
-    return ""
+    return "", ""

--- a/app/main.py
+++ b/app/main.py
@@ -3710,6 +3710,42 @@ def api_cron_mind_qa(request: Request) -> dict[str, Any]:
         return {"status": "error", "detail": str(exc)}
 
 
+@app.get("/api/cron/index-pending-content")
+def api_cron_index_pending_content(request: Request) -> dict[str, Any]:
+    """Content-backfill drain. The LOCAL fetch (the sources chain) stages book
+    text in pending_content; this runs on Vercel — where the Gemini embedder
+    works (it's geoblocked from the dev box) — to index + embed it, keeping the
+    heavy fetch off Vercel. Per call: pop a few rows, index_text(replace_existing
+    =True) (stub chunks replaced only AFTER embeddings return), record
+    meta.content_source, drop the row. A failed row is left for retry (pop is
+    random-ordered so it can't stall the head). Loop with the CRON_SECRET bearer
+    to drain; bounded per call to stay inside the function limit."""
+    _verify_cron(request)
+    from .core.db import (
+        ensure_pending_content_table, pop_pending_content,
+        delete_pending_content, count_pending_content, set_content_source,
+    )
+    from .core.indexer import index_text
+    ensure_pending_content_table()
+    try:
+        batch = max(1, min(int(request.query_params.get("batch", "4")), 10))
+    except (TypeError, ValueError):
+        batch = 4
+    indexed = failed = 0
+    for row in pop_pending_content(limit=batch):
+        aid = row["agent_id"]
+        try:
+            index_text(aid, row["text"], replace_existing=True)
+            set_content_source(aid, row.get("source") or "")
+            delete_pending_content(aid)
+            indexed += 1
+        except Exception as exc:
+            log.error("index-pending-content %s: %s", aid, exc)
+            failed += 1
+    return {"status": "ok", "indexed": indexed, "failed": failed,
+            "remaining": count_pending_content()}
+
+
 @app.get("/api/minds/{mind_id}/questions")
 def api_mind_questions(mind_id: str) -> JSONResponse:
     """Stored Q&A list for a mind (slug + question). Powers the detail-page

--- a/scripts/backfill_content.py
+++ b/scripts/backfill_content.py
@@ -1,0 +1,99 @@
+"""Local content-backfill fetcher — approach B (fetch local, embed on Vercel).
+
+Runs on the dev box (network to Gutenberg/Wikisource/IA/arXiv is fine here; the
+Gemini EMBEDDER is geoblocked locally, which is why embedding happens on Vercel
+via GET /api/cron/index-pending-content). For each 0-chunk "real" book (one
+with a real AI overview — a legit chattable entity that just lacks full text),
+run the sources chain and STAGE the fetched full text in `pending_content`. The
+Vercel cron then indexes + embeds it and clears the row.
+
+This keeps the heavy, slow fetch OFF Vercel — only the unavoidable Gemini embed
+runs there (cf. dev-resource discipline: heavy lifting local, embed on Vercel).
+
+Usage (against prod):
+  export DATABASE_URL=$POSTGRES_URL_NON_POOLING   # from .env.production.local
+  source .env                                     # provider keys if needed
+  python -m scripts.backfill_content --dry-run [--limit N]
+  python -m scripts.backfill_content --apply [--limit N] [--workers 6]
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import logging
+import sys
+
+from app.core import config  # noqa: F401 — loads env (DATABASE_URL etc.)
+from app.core import db
+from app.core.sources import fetch_book_content_sourced
+
+_MIN_FULLTEXT = 4000  # >= this = real full text (metadata-only is < 2000)
+
+
+def _targets(limit: int | None) -> list[tuple[str, str, str]]:
+    """0-chunk, not-deleted, real-overview books not already staged."""
+    sql = """
+        SELECT a.id, a.name, a.meta_json::jsonb->>'author'
+        FROM agents a
+        LEFT JOIN (SELECT agent_id, COUNT(*) n FROM chunks GROUP BY agent_id) ch
+               ON ch.agent_id = a.id
+        WHERE NOT a.is_deleted
+          AND COALESCE(ch.n, 0) = 0
+          AND length(coalesce(a.meta_json::jsonb->>'overview', '')) > 200
+          AND a.id NOT IN (SELECT agent_id FROM pending_content)
+        ORDER BY a.id
+    """
+    if limit:
+        sql += f" LIMIT {int(limit)}"
+    with db.get_conn() as conn:
+        cur = db._execute(conn, sql)
+        rows = cur.fetchall()
+    return [(r[0], r[1] or "", (r[2] or "").strip()) for r in rows]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--workers", type=int, default=6)
+    args = ap.parse_args()
+    logging.disable(logging.WARNING)
+
+    db.ensure_pending_content_table()
+    targets = _targets(args.limit)
+    print(f"{len(targets)} candidate 0-chunk books", file=sys.stderr)
+
+    staged = miss = 0
+    by_source: dict[str, int] = {}
+
+    def work(t: tuple[str, str, str]):
+        aid, name, author = t
+        try:
+            txt, src = fetch_book_content_sourced(name, author)
+        except Exception:
+            return (0, "")
+        if len(txt) >= _MIN_FULLTEXT:
+            if args.apply:
+                db.stage_pending_content(aid, txt, src)
+            return (len(txt), src)
+        return (0, "")
+
+    with cf.ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for i, (n, src) in enumerate(ex.map(work, targets), 1):
+            if n >= _MIN_FULLTEXT:
+                staged += 1
+                by_source[src] = by_source.get(src, 0) + 1
+            else:
+                miss += 1
+            if i % 50 == 0:
+                print(f"  ...{i}/{len(targets)}  staged={staged}", file=sys.stderr)
+
+    print(f"\ndone: full-text {staged}, miss {miss}", file=sys.stderr)
+    print(f"by source: {by_source}", file=sys.stderr)
+    print(f"pending_content now: {db.count_pending_content()}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Rescues the **~1,463** 0-chunk "real" books (have an AI overview, no full text) through the new source chain (#218, #220). **Approach B** keeps the heavy fetch local; only the geoblocked Gemini embed runs on Vercel.

## Pieces
- **`db.py`** — `pending_content` staging table + helpers. Separate table (not `agents.meta_json`) so 1.5MB texts don't bloat the hot agents read; created out-of-band (not `init_db` → never touches the cold-start boot path); `pop` is `random()`-ordered so a failed row can't stall the drain head.
- **`main.py`** — `GET /api/cron/index-pending-content`: drains the staging table on Vercel (where Gemini embed works) via `index_text(replace_existing=True)` + records `meta.content_source`, batched, CRON_SECRET-gated. Loop the bearer to drain.
- **`sources.py`** — `fetch_book_content_sourced() -> (text, source)` for `content_source` provenance; `fetch_book_content` delegates.
- **`scripts/backfill_content.py`** — the LOCAL fetcher: stages full text for 0-chunk real books via the sources chain (runs on the dev box; embed deferred to the cron).

## Flow
1. Local `backfill_content.py` → fetches + stages text (no Vercel, no Gemini).
2. `index-pending-content` cron on Vercel → indexes + embeds + sets provenance + clears.

## Verified
Staging helpers round-trip against prod; `fetch_book_content_sourced('On Liberty')` → 311K from `gutenberg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)