### PR TITLE
Stop AI-book chapter writing from timing out + surface the failure reason

### DIFF
--- a/app/core/ai_writer.py
+++ b/app/core/ai_writer.py
@@ -199,8 +199,16 @@ def write_chapter(
         f"Target length: ~{chapter.get('estimated_words', 2000)} words\n"
     )
 
+    # Chapter writing is a BACKGROUND task that emits a long (~2000-word),
+    # grounded generation — routinely well over the 30s/50s interactive default,
+    # which made a single slow chapter time out across the ~2 providers the
+    # budget allowed and fail the whole book (it always died on the first
+    # heavier chapter). Give it a background-sized budget so a long generation
+    # has room and the fallback can reach every provider. Grounding stays on —
+    # factual books benefit from it, and 120s accommodates the search latency.
     result, _ = chat_with_fallback(
         system=_CHAPTER_SYSTEM, user=user_prompt, use_grounding=True,
+        timeout=120, max_total_seconds=300,
     )
 
     return result.content.strip(), _extract_usage(result)
@@ -286,7 +294,7 @@ def _write_full_book_impl(book_id: str) -> None:
             log.info("Wrote chapter %d/%d for book %s", ch["number"], len(chapters), book_id)
         except Exception as exc:
             log.error("Failed writing chapter %d for book %s: %s", ch["number"], book_id, exc)
-            update_ai_book_status(book_id, "failed")
+            update_ai_book_status(book_id, "failed", error=f"Chapter {ch['number']}: {exc}")
             return
 
     # Combine all chapters into full text for indexing
@@ -308,7 +316,7 @@ def _write_full_book_impl(book_id: str) -> None:
         log.info("Book %s completed and indexed (%s)", book_id, outline.get("title"))
     except Exception as exc:
         log.error("Indexing failed for book %s: %s", book_id, exc)
-        update_ai_book_status(book_id, "failed")
+        update_ai_book_status(book_id, "failed", error=f"Indexing: {exc}")
 
 
 def _index_partial_book(book_id: str) -> None:

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -4346,12 +4346,14 @@ def get_ai_book_status(book_id: str) -> dict[str, Any] | None:
     with get_conn() as conn:
         row = _fetchone(conn, _q(
             "SELECT id, agent_id, user_id, status, title, outline_json, "
-            "chapters_total, chapters_written, updated_at FROM ai_books WHERE id = ?"
+            "preferences_json, chapters_total, chapters_written, updated_at FROM ai_books WHERE id = ?"
         ), (book_id,))
         if not row:
             return None
         result = dict(row)
         result["outline"] = json.loads(result.pop("outline_json", None) or "{}")
+        prefs = json.loads(result.pop("preferences_json", None) or "{}")
+        result["error"] = prefs.get("_write_error")  # failure reason, else None
         return result
 
 
@@ -4382,12 +4384,26 @@ def update_ai_book_outline(book_id: str, outline: dict[str, Any]) -> None:
             outline.get("title", "Untitled"), now, book_id))
 
 
-def update_ai_book_status(book_id: str, status: str) -> None:
+def update_ai_book_status(book_id: str, status: str, error: str | None = None) -> None:
     now = _utcnow()
     with get_conn() as conn:
         _execute(conn, _q(
             "UPDATE ai_books SET status = ?, updated_at = ? WHERE id = ?"
         ), (status, now, book_id))
+        # Record (or clear) the failure reason in preferences_json so the status
+        # endpoint can surface WHY a write failed — no schema change. Set on
+        # failure; cleared when a (re)write starts or completes so a stale reason
+        # doesn't linger after a successful retry.
+        if error is not None or status in ("writing", "completed"):
+            prow = _fetchone(conn, _q("SELECT preferences_json FROM ai_books WHERE id = ?"), (book_id,))
+            if prow:
+                prefs = json.loads(prow["preferences_json"] or "{}")
+                if error is not None:
+                    prefs["_write_error"] = error[:500]
+                else:
+                    prefs.pop("_write_error", None)
+                _execute(conn, _q("UPDATE ai_books SET preferences_json = ? WHERE id = ?"),
+                         (json.dumps(prefs, ensure_ascii=False), book_id))
         # Sync agent status when book completes, fails, or is cancelled
         if status in ("completed", "failed", "cancelled"):
             row = _fetchone(conn, _q("SELECT agent_id, chapters_written FROM ai_books WHERE id = ?"), (book_id,))
@@ -4415,6 +4431,7 @@ def update_ai_book_chapter(book_id: str, chapter_num: int, chapter_data: dict[st
 
 
 def _row_to_ai_book(row: dict[str, Any]) -> dict[str, Any]:
+    prefs = json.loads(row["preferences_json"] or "{}")
     return {
         "id": row["id"],
         "agent_id": row["agent_id"],
@@ -4424,9 +4441,10 @@ def _row_to_ai_book(row: dict[str, Any]) -> dict[str, Any]:
         "description": row["description"],
         "outline": json.loads(row["outline_json"] or "{}"),
         "content": json.loads(row["content_json"] or "{}"),
-        "preferences": json.loads(row["preferences_json"] or "{}"),
+        "preferences": prefs,
         "chapters_total": row["chapters_total"],
         "chapters_written": row["chapters_written"],
         "created_at": row["created_at"],
         "updated_at": row["updated_at"],
+        "error": prefs.get("_write_error"),  # failure reason, else None
     }

--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -422,6 +422,7 @@ function WritingProgress({
           <div className="canvas-done-label" style={{ color: "var(--error-color, #e55)" }}>
             Writing failed at chapter {done + 1} of {total}
           </div>
+          {status?.error && <p className="canvas-error">{status.error}</p>}
           <div className="canvas-done-actions">
             <button
               type="button"

--- a/web/lib/aibooks.ts
+++ b/web/lib/aibooks.ts
@@ -66,6 +66,8 @@ export interface BookStatus {
   chaptersDone: number;
   /** 0–100, derived from chaptersDone / chaptersTotal. */
   progressPct: number;
+  /** Failure reason when status is "failed" (else null) — surfaced in the canvas. */
+  error?: string | null;
 }
 
 export interface FullBook extends BookStatus {
@@ -87,6 +89,7 @@ function toStatus(raw: any): BookStatus {
     chaptersTotal: total,
     chaptersDone: done,
     progressPct: total > 0 ? Math.round((done / total) * 100) : 0,
+    error: raw?.error ?? null,
   };
 }
 


### PR DESCRIPTION
## Problem

Writing a book repeatedly **failed at the first heavier chapter** (e.g. ch3); Retry resumed there and hit the same wall, over and over.

**Root cause:** `write_chapter` runs its ~2000-word **grounded** generation through `chat_with_fallback` on the **default interactive budget** (`30s`/provider, `50s` total). But chapter-writing is a **background task**, and a long grounded chapter routinely exceeds 30s — so a provider times out, only ~2 providers get tried within the 50s window, and when the slow ones (DeepSeek, then grounded Gemini) miss it, `chat_with_fallback` raises `ProviderError` → the chapter loop marks the **whole book** failed. ch1/ch2 squeak in under the wire; the first denser chapter reliably doesn't.

Same root-cause family as the outline-refine 503 ([#204](https://github.com/steveyeow/Feynman/pull/204)) — the fix there (wider budget) was never applied to `write_chapter`.

Secondary: the failure reason was **swallowed** (server log only), so the UI just said "Writing failed at chapter N" with no *why* — which is why we were guessing.

## Fix

**Backend:**
- `write_chapter`: `timeout=120, max_total_seconds=300` — a background-sized budget so a long generation has room and the fallback can reach every provider. Grounding stays on (factual books benefit; 120s covers the search latency).
- Capture the reason: `update_ai_book_status(..., error=...)` stashes it in `preferences_json` (`_write_error`; **no schema change**), cleared when a (re)write starts or completes so it doesn't linger after a successful retry. `get_ai_book_status` and the full GET now return `error`.

**Frontend:**
- `BookStatus.error` is mapped from the status payload and shown under "Writing failed at chapter N" in the canvas — so the next failure (if any) tells you why instead of being a black box.

## Notes
- This is the likely cure (a 30s timeout on a long background generation is unambiguously wrong), **and** the error-surfacing means if anything still fails, the reason is now visible in-app + in the status payload to confirm.
- Grounding kept on chapters by choice (accuracy for factual books); if cost/latency ever matters more, dropping it is a lever.

## Verification
- `python -m py_compile app/core/ai_writer.py app/core/db.py` ✅
- Both `/status` and the full GET return `error` (the full GET returns the `_row_to_ai_book` dict directly) ✅
- Frontend types gated on the feynman-web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)