### PR TITLE
Honor the requested book language + fix the finalize-failure label

### DIFF
--- a/app/core/ai_writer.py
+++ b/app/core/ai_writer.py
@@ -37,7 +37,9 @@ _REFINE_SYSTEM = (
     "Wrap the JSON in ```json and ``` markers. The JSON must have the same structure: "
     "{title, subtitle, category, chapters: [{number, title, summary, key_points, estimated_words}]}.\n\n"
     "If the user's request doesn't require outline changes, return the outline unchanged. "
-    "Always respond in the same language as the user."
+    "If the user asks to change the book's language (e.g. \"write it in English\"), rewrite the "
+    "outline — titles, summaries, and key points — in that language. "
+    "Write your conversational reply in the user's language."
 )
 
 _CHAPTER_SYSTEM = (
@@ -98,7 +100,9 @@ def generate_outline(
         f"Create a book outline based on this description:\n\n{description}\n\n"
         f"Writing style: {style}\n"
         f"Target length: {length_guide.get(length, length_guide['medium'])}\n"
-        f"Language: {lang_names.get(language, language)}\n"
+        f"Language: write the outline in {lang_names.get(language, language)} — UNLESS the "
+        f"description explicitly asks for another language (e.g. \"write in English\", \"用英文写\"), "
+        f"in which case follow that request.\n"
     )
     if prefs.get("focus_areas"):
         user_prompt += f"Focus areas: {', '.join(prefs['focus_areas'])}\n"
@@ -181,7 +185,9 @@ def write_chapter(
         f"Book: \"{outline.get('title', 'Untitled')}\" — {outline.get('subtitle', '')}\n"
         f"Total chapters: {len(outline.get('chapters', []))}\n"
         f"Writing style: {style}\n"
-        f"Language: {lang_names.get(language, language)}\n"
+        f"Language: write this chapter in the SAME language as the outline below (its titles "
+        f"and summaries) — that is the book's language, regardless of the language of these "
+        f"instructions.\n"
     )
 
     if previous_summaries:

--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -420,7 +420,9 @@ function WritingProgress({
           {/* Red, specific failure point + Retry only — matches production
               (no read/chat/share on failure). */}
           <div className="canvas-done-label" style={{ color: "var(--error-color, #e55)" }}>
-            Writing failed at chapter {done + 1} of {total}
+            {done >= total
+              ? "Writing failed while finalizing the book"
+              : `Writing failed at chapter ${done + 1} of ${total}`}
           </div>
           {status?.error && <p className="canvas-error">{status.error}</p>}
           <div className="canvas-done-actions">


### PR DESCRIPTION
## Problem

The SpaceX book got written in **Chinese** even though the prompt said **"用英文写"** (write in English). Language is auto-detected from the description by a script-ratio heuristic (`detectLanguage`): a mostly-Chinese prompt → `zh`, which was then **forced** into chapter writing — overriding the explicit instruction. (The tiny word counts in the canvas were a side effect: `word_count` splits on whitespace, which Chinese barely has.)

Separately, the failed footer showed **"chapter 13 of 12"** when the post-chapters finalize/index step failed (e.g. the Gemini-credits 429), because the label assumed a chapter failure.

## Fix

**Language now follows what the user actually asked for** (`app/core/ai_writer.py`):
- `generate_outline`: the language directive **defers to an explicit request** in the description ("write in English" / "用英文写") instead of forcing the detected language. The outline reflects the real intent.
- `write_chapter`: writes each chapter in the **same language as the outline** (its titles/summaries) — so chapters always match the approved outline, not a possibly-wrong detected pref. The outline is the single source of truth; the user can change it anytime via chat.
- `refine_outline`: when the user asks to switch the book's language, the model now **rewrites the outline** in that language (previously it only "responded in the user's language" and left the outline itself unchanged).

**Accurate failure label** (`web/components/chat/BookCanvas.tsx`):
- Once all chapters are written, a finalize/index failure now reads **"Writing failed while finalizing the book"** instead of "chapter N+1 of N". The specific reason (surfaced in #223) still shows below it.

## Notes
- This fixes language for **new** books. An already-written book's chapters aren't retroactively re-languaged — the existing SpaceX book would need to be regenerated for English.
- Not changed here: the Gemini-credits **429 at indexing** is a billing issue (top up the Gemini account, then Retry) — out of scope for this PR.

## Verification
- `python -m py_compile app/core/ai_writer.py` ✅
- Frontend label gated on the feynman-web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)