### PR TITLE
Rewrite a finished book + content-aware chat (P2+P3 of chat↔preview)

### DIFF
--- a/app/core/ai_writer.py
+++ b/app/core/ai_writer.py
@@ -132,13 +132,31 @@ def refine_outline(
     current_outline: dict[str, Any],
     user_message: str,
     history: list[dict[str, str]] | None = None,
+    already_written: bool = False,
+    content_sample: str | None = None,
 ) -> tuple[dict[str, Any], str, dict[str, int]]:
     """Refine an outline based on user feedback.
 
     Returns (updated_outline, ai_response_text, usage_dict).
+
+    *already_written* marks a finished book: the chat may tweak title/subtitle but
+    must NOT try to change chapter bodies or their language by editing the outline
+    (that needs a Rewrite). *content_sample* lets the model see how the chapters
+    are actually written, so it answers honestly instead of guessing.
     """
     outline_str = json.dumps(current_outline, ensure_ascii=False, indent=2)
     system = f"{_REFINE_SYSTEM}\n\nCurrent outline:\n{outline_str}"
+    if already_written:
+        system += (
+            "\n\nIMPORTANT: this book is ALREADY fully written. You may adjust the title or "
+            "subtitle, but you CANNOT change the chapter bodies or the language they are written in "
+            "by editing this outline — that needs a full rewrite (the user can click \"Rewrite\" in "
+            "the book panel to regenerate every chapter, optionally in another language). If the user "
+            "asks to change the content or the writing language, tell them to use Rewrite; do NOT "
+            "restructure the chapters or change their language in the outline."
+        )
+        if content_sample:
+            system += f"\n\nHow the current chapters are actually written (sample):\n{content_sample}"
 
     # No grounding here: restructuring an existing outline needs no fresh web
     # research, and the Gemini google_search round-trips were the main cause of
@@ -167,6 +185,32 @@ def refine_outline(
         response_text = "I've updated the outline based on your feedback."
 
     return outline, response_text, _extract_usage(result)
+
+
+def translate_outline(
+    outline: dict[str, Any],
+    language: str,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    """Rewrite an outline's text into *language*, preserving structure. Used by the
+    post-completion Rewrite flow so a re-languaged book gets a matching title + TOC
+    (the chapter bodies are then regenerated to follow it). Returns (outline, usage).
+    """
+    lang_names = {"en": "English", "zh": "Chinese", "ja": "Japanese", "ko": "Korean", "es": "Spanish", "fr": "French", "de": "German"}
+    target = lang_names.get(language, language)
+    system = (
+        f"You are a professional translator. Rewrite the given book outline into {target}. "
+        "Translate the title, subtitle, and every chapter's title, summary, and key_points. "
+        "Keep the EXACT same JSON structure, the same chapter numbers, the same `category`, and "
+        "the same `estimated_words` values. Return ONLY the JSON object (no markdown fences)."
+    )
+    result, _ = chat_with_fallback(
+        system=system, user=json.dumps(outline, ensure_ascii=False, indent=2),
+        use_grounding=False, thinking_budget=0, timeout=45, max_total_seconds=120,
+    )
+    translated = _parse_json_from_text(result.content)
+    if not translated or "chapters" not in translated:
+        raise ProviderError("Couldn't prepare the rewrite. Please try again.")
+    return translated, _extract_usage(result)
 
 
 def write_chapter(

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -4430,6 +4430,23 @@ def update_ai_book_chapter(book_id: str, chapter_num: int, chapter_data: dict[st
         ), (json.dumps(content, ensure_ascii=False), written, now, book_id))
 
 
+def reset_ai_book_for_rewrite(book_id: str, language: str) -> None:
+    """Clear the written chapters and set the target language so a finished book
+    can be regenerated from scratch (the post-completion Rewrite flow). Leaves the
+    outline intact (the caller re-languages it first); status → 'writing' so the
+    background writer picks it up."""
+    now = _utcnow()
+    with get_conn() as conn:
+        row = _fetchone(conn, _q("SELECT preferences_json FROM ai_books WHERE id = ?"), (book_id,))
+        prefs = json.loads((row["preferences_json"] if row else None) or "{}")
+        prefs["language"] = language
+        prefs.pop("_write_error", None)
+        _execute(conn, _q(
+            "UPDATE ai_books SET content_json = '{}', chapters_written = 0, "
+            "preferences_json = ?, status = 'writing', updated_at = ? WHERE id = ?"
+        ), (json.dumps(prefs, ensure_ascii=False), now, book_id))
+
+
 def _row_to_ai_book(row: dict[str, Any]) -> dict[str, Any]:
     prefs = json.loads(row["preferences_json"] or "{}")
     return {

--- a/app/main.py
+++ b/app/main.py
@@ -100,6 +100,7 @@ from .core.db import (
     get_chunks_text_only,
     get_sample_chunks_text,
     list_ai_books,
+    reset_ai_book_for_rewrite,
     update_ai_book_outline,
     update_ai_book_status,
 )
@@ -132,6 +133,7 @@ from .core.ai_writer import (
     all_outline_chapters_have_content,
     generate_outline,
     refine_outline,
+    translate_outline,
     write_full_book,
 )
 
@@ -5095,6 +5097,10 @@ class AIBookChatRequest(BaseModel):
     history: list[HistoryMessage] | None = None
 
 
+class AIBookRewriteRequest(BaseModel):
+    language: str = "en"
+
+
 @app.post("/api/ai-books/start")
 def api_ai_book_start(payload: AIBookStartRequest, request: Request) -> dict[str, Any]:
     """Start a new AI book project: generate outline from description."""
@@ -5173,9 +5179,24 @@ def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request,
     if payload.history:
         history = [{"role": m.role, "content": m.content} for m in payload.history]
 
+    # On a finished book, let the chat SEE how the chapters are actually written
+    # (a short sample) so it answers honestly and routes content/language changes
+    # to Rewrite instead of silently (and wrongly) re-languaging the outline.
+    already_written = book["status"] != "outlining"
+    content_sample: str | None = None
+    if already_written:
+        _content = book.get("content") or {}
+        _samples = []
+        for _ch in (book["outline"].get("chapters") or [])[:2]:
+            _body = (_content.get(str(_ch.get("number")), {}).get("content") or "").strip()
+            if _body:
+                _samples.append(_body[:200])
+        content_sample = "\n…\n".join(_samples) or None
+
     try:
         updated_outline, response_text, usage = refine_outline(
             book["outline"], payload.message, history=history,
+            already_written=already_written, content_sample=content_sample,
         )
     except ProviderError as exc:
         raise HTTPException(status_code=503, detail=str(exc))
@@ -5245,6 +5266,53 @@ def api_ai_book_confirm(book_id: str, request: Request, background_tasks: Backgr
 
     background_tasks.add_task(write_full_book, book_id)
 
+    return {"status": "writing", "chapters_total": book["chapters_total"]}
+
+
+@app.post("/api/ai-books/{book_id}/rewrite")
+def api_ai_book_rewrite(book_id: str, payload: AIBookRewriteRequest, request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
+    """Regenerate a finished book's chapters from scratch in a target language —
+    the post-completion Rewrite flow. Re-languages the outline (title + TOC) to
+    match, clears the existing chapters, and re-runs the writer. This is how a
+    written book's CONTENT/language is changed (the chat refine only edits the
+    outline, never the bodies)."""
+    user_id = _get_user_id(request) or "anon"
+    book = get_ai_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="AI book not found")
+    if book["user_id"] != user_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if book["status"] in ("confirmed", "writing"):
+        raise HTTPException(status_code=409, detail="The book is being written right now — wait until it finishes.")
+
+    # Re-language the outline first so the title/TOC match the rewritten chapters
+    # (the bodies follow the outline's language when regenerated).
+    try:
+        translated, usage = translate_outline(book["outline"], payload.language)
+    except ProviderError as exc:
+        raise HTTPException(status_code=503, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Rewrite setup failed: {exc}")
+
+    update_ai_book_outline(book_id, translated)
+    new_title = (translated.get("title") or book["title"] or "").strip()
+    if new_title:
+        rename_agent(book["agent_id"], new_title)
+
+    # Clear the old chapters + set the target language, then kick the writer.
+    reset_ai_book_for_rewrite(book_id, payload.language)
+    creator_name = book.get("preferences", {}).get("creator_name", "") or _resolve_creator_name(user_id)
+    update_agent_status(book["agent_id"], "writing", {
+        "title": new_title or book["title"],
+        "is_ai_generated": True,
+        "creator_name": creator_name or "User",
+        "creator_user_id": user_id,
+    })
+
+    background_tasks.add_task(write_full_book, book_id)
+    background_tasks.add_task(_revalidate_book_share, book["agent_id"])
+
+    _track_usage(request, "ai_book", usage.get("total_tokens", 0))
     return {"status": "writing", "chapters_total": book["chapters_total"]}
 
 

--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -41,6 +41,7 @@ interface BookCanvasProps {
   onConfirm: () => void;
   onCancel: () => void;
   onRetry: () => void;
+  onRewrite: (language: string) => void;
 }
 
 export default function BookCanvas({
@@ -55,6 +56,7 @@ export default function BookCanvas({
   onConfirm,
   onCancel,
   onRetry,
+  onRewrite,
 }: BookCanvasProps) {
   return (
     <aside
@@ -74,6 +76,7 @@ export default function BookCanvas({
             content={content}
             onCancel={onCancel}
             onRetry={onRetry}
+            onRewrite={onRewrite}
           />
         )}
         {error && <p className="canvas-error">{error}</p>}
@@ -205,6 +208,81 @@ function CanvasActions({ readId, title }: { readId: string; title: string }) {
   );
 }
 
+// ── Rewrite menu: regenerate the whole book in another language ──────────────
+const REWRITE_LANGS: { code: string; label: string }[] = [
+  { code: "en", label: "English" },
+  { code: "zh", label: "中文" },
+  { code: "es", label: "Español" },
+  { code: "fr", label: "Français" },
+  { code: "ja", label: "日本語" },
+  { code: "ko", label: "한국어" },
+  { code: "de", label: "Deutsch" },
+];
+
+/** "Rewrite" control on a finished book — the ONLY way to change the chapter
+ *  bodies / language (chat refine edits the outline, never the written text).
+ *  Picks a language → confirm → regenerate every chapter. */
+function RewriteMenu({
+  chapterCount,
+  onRewrite,
+}: {
+  chapterCount: number;
+  onRewrite: (language: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("click", onDoc);
+    return () => document.removeEventListener("click", onDoc);
+  }, [open]);
+  const pick = (code: string, label: string) => {
+    setOpen(false);
+    const n = chapterCount || 0;
+    if (
+      window.confirm(
+        `Rewrite ${n ? `all ${n} chapters` : "the book"} in ${label}? This replaces the current text and takes a few minutes.`,
+      )
+    ) {
+      onRewrite(code);
+    }
+  };
+  return (
+    <div className={`canvas-share-wrap${open ? " open" : ""}`} ref={wrapRef} style={{ marginTop: 8 }}>
+      <button
+        type="button"
+        className="canvas-action-btn canvas-share-trigger"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        title="Regenerate the chapters, optionally in another language"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="23 4 23 10 17 10" />
+          <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+        </svg>
+        Rewrite
+      </button>
+      <div className="canvas-share-popup">
+        {REWRITE_LANGS.map((l) => (
+          <button
+            key={l.code}
+            type="button"
+            className="canvas-share-opt"
+            onClick={() => pick(l.code, l.label)}
+          >
+            Rewrite in {l.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ── Outline accordion (port of _renderCanvasOutline) ─────────────────────────
 function OutlineView({
   outline,
@@ -304,6 +382,7 @@ function WritingProgress({
   content,
   onCancel,
   onRetry,
+  onRewrite,
 }: {
   status: BookStatus | null;
   fallbackChapters: OutlineChapter[];
@@ -311,6 +390,7 @@ function WritingProgress({
   content?: CanvasContent | null;
   onCancel: () => void;
   onRetry: () => void;
+  onRewrite: (language: string) => void;
 }) {
   const chapters = status?.outline?.chapters?.length
     ? status.outline.chapters
@@ -473,6 +553,9 @@ function WritingProgress({
           <div className="canvas-done-label">Your book is ready!</div>
           {/* Chat + Read + Share — the full production completed footer. */}
           <CanvasActions readId={readId} title={title} />
+          {/* The only way to change the written chapters / their language: a full
+              regenerate (chat refine edits the outline, not the bodies). */}
+          <RewriteMenu chapterCount={total} onRewrite={onRewrite} />
         </>
       )}
 

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -1255,6 +1255,7 @@ export default function ChatView({
           onConfirm={writeBook.confirm}
           onCancel={writeBook.cancel}
           onRetry={writeBook.retry}
+          onRewrite={writeBook.rewrite}
         />
       ) : rightSidebar !== undefined ? (
         rightSidebar

--- a/web/components/chat/useWriteBook.ts
+++ b/web/components/chat/useWriteBook.ts
@@ -25,6 +25,7 @@ import {
   startBook,
   chatBook,
   confirmBook,
+  rewriteBook,
   getStatus,
   getBook,
   cancelBook,
@@ -83,6 +84,8 @@ export interface WriteBookState {
   confirm: () => Promise<void>;
   cancel: () => Promise<void>;
   retry: () => Promise<void>;
+  /** Regenerate every chapter from scratch in `language` (post-completion). */
+  rewrite: (language: string) => Promise<void>;
 }
 
 function describeError(e: unknown, fallback: string): string {
@@ -396,6 +399,30 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
     }
   }, [startPolling]);
 
+  // ── Rewrite (regenerate every chapter, optionally in a new language) ──────
+  const rewrite = useCallback(
+    async (language: string) => {
+      const id = bookIdRef.current;
+      if (!id) return;
+      setError(null);
+      try {
+        await rewriteBook(id, language);
+        // Drop the old chapters so the canvas shows fresh progress, not stale
+        // bodies as "done"; the new ones repopulate when writing completes.
+        setBookContent(null);
+        setPhase("writing");
+        cbRef.current.onAssistant(
+          "Rewriting the whole book from scratch — I'll regenerate every chapter. " +
+            "You can watch the progress on the right.",
+        );
+        startPolling(id);
+      } catch (err) {
+        setError(describeError(err, "Couldn't start the rewrite. Try again."));
+      }
+    },
+    [startPolling],
+  );
+
   return {
     phase,
     outline,
@@ -410,5 +437,6 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
     confirm,
     cancel,
     retry,
+    rewrite,
   };
 }

--- a/web/lib/aibooks.ts
+++ b/web/lib/aibooks.ts
@@ -157,6 +157,23 @@ export async function confirmBook(
 }
 
 /**
+ * Regenerate a finished book's chapters from scratch in `language` (the
+ * post-completion Rewrite flow). Re-languages the outline + clears the old
+ * chapters server-side, then re-runs the writer. Returns the writing status so
+ * the caller can resume polling.
+ */
+export async function rewriteBook(
+  bookId: string,
+  language: string,
+): Promise<{ status: AiBookStatus; chaptersTotal: number }> {
+  const data = await post<{ status: AiBookStatus; chapters_total?: number }>(
+    `/api/ai-books/${encodeURIComponent(bookId)}/rewrite`,
+    { language },
+  );
+  return { status: data.status, chaptersTotal: data.chapters_total ?? 0 };
+}
+
+/**
  * Stop an in-progress write (port of _cancelWriteBook → POST /{id}/cancel).
  * Chapters already written are kept; the book transitions to `cancelled`.
  */


### PR DESCRIPTION
Completes the coordinated **chat ↔ preview** write-book experience (P1 was #225, inline reading).

## Problem
Once a book was written, its **content/language couldn't be changed at all**: chat refine only edits the outline, the chapter bodies are frozen. Worse, the chat couldn't *see* the bodies, so it misread "the body is in Chinese" as "make it Chinese" and flipped the outline — degrading the book (Chinese title over Chinese bodies the user wanted in English).

## P2 — Rewrite (the real fix)
- **`POST /api/ai-books/{id}/rewrite` `{language}`**: re-languages the outline (`translate_outline`) so the title + TOC match, **clears the written chapters** (`reset_ai_book_for_rewrite`), and re-runs the writer in the target language (`write_chapter` follows the outline per #224). Returns to the `writing` state. Fires share-card revalidation.
- **Canvas**: a **"Rewrite"** control on a finished book → pick a language → confirm (`Rewrite all N chapters in X?`) → regenerate every chapter. `useWriteBook.rewrite()` drops the stale bodies, flips to `writing`, resumes polling → the new chapters stream in (and become inline-readable via P1).

## P3 — content-aware chat
- `refine_outline` now receives a **sample of how the chapters are actually written** + an `already_written` flag. On a finished book it (a) **won't** restructure or re-language the outline, and (b) tells the user to use **Rewrite** for content/language changes — instead of silently (and wrongly) editing the outline.

## Result (the coordinated experience)
- **Read** the book in the right panel (P1).
- **Title tweaks** via chat apply live (#211 + revalidate).
- **Content/language changes** go through **Rewrite** — chat guides you there instead of pretending to edit bodies it can't.

## Verification
- `python -m py_compile app/core/ai_writer.py app/core/db.py app/main.py` ✅
- Rewrite wired end-to-end (endpoint → `rewriteBook` → `useWriteBook.rewrite` → BookCanvas control).
- Frontend gated on the feynman-web build (empty local `node_modules`).
- Note: indexing still needs Gemini credits (separate billing issue); a rewrite re-runs writing + indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)