### PR TITLE
Restyle the canvas Rewrite control (was an ugly full-width pill)

### DIFF
--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -251,33 +251,43 @@ function RewriteMenu({
     }
   };
   return (
-    <div className={`canvas-share-wrap${open ? " open" : ""}`} ref={wrapRef} style={{ marginTop: 8 }}>
-      <button
-        type="button"
-        className="canvas-action-btn canvas-share-trigger"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen((o) => !o);
-        }}
-        title="Regenerate the chapters, optionally in another language"
+    // Tertiary action: a restrained centered text link under the primary
+    // Chat/Read/Share row — NOT a fourth full-width pill (rewriting is rare +
+    // expensive, so it shouldn't compete with the primary actions). The language
+    // menu reuses the share-popup (opens upward, centered on the trigger).
+    <div className="canvas-rewrite-wrap">
+      <div
+        className={`canvas-share-wrap${open ? " open" : ""}`}
+        ref={wrapRef}
+        style={{ display: "inline-block" }}
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polyline points="23 4 23 10 17 10" />
-          <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-        </svg>
-        Rewrite
-      </button>
-      <div className="canvas-share-popup">
-        {REWRITE_LANGS.map((l) => (
-          <button
-            key={l.code}
-            type="button"
-            className="canvas-share-opt"
-            onClick={() => pick(l.code, l.label)}
-          >
-            Rewrite in {l.label}
-          </button>
-        ))}
+        <button
+          type="button"
+          className="canvas-rewrite-trigger"
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpen((o) => !o);
+          }}
+          title="Regenerate every chapter, optionally in another language"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="23 4 23 10 17 10" />
+            <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+          </svg>
+          Rewrite in another language
+        </button>
+        <div className="canvas-share-popup">
+          {REWRITE_LANGS.map((l) => (
+            <button
+              key={l.code}
+              type="button"
+              className="canvas-share-opt"
+              onClick={() => pick(l.code, l.label)}
+            >
+              {l.label}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -3527,6 +3527,19 @@ html.dark .canvas-share-popup { box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
 .canvas-share-opt:hover { background: rgba(0,0,0,0.05); }
 html.dark .canvas-share-opt:hover { background: rgba(255,255,255,0.08); }
 .canvas-share-opt svg { flex-shrink: 0; color: var(--text-secondary); }
+
+/* Rewrite = a restrained TERTIARY action (heavy + rare): a subtle centered text
+   link under the primary Chat/Read/Share row, not a fourth full-width pill. */
+.canvas-rewrite-wrap { margin-top: 10px; text-align: center; }
+.canvas-rewrite-trigger {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px; border: none; background: none;
+  color: var(--text-secondary); cursor: pointer;
+  font: 500 13px/1 'Inter', sans-serif;
+  border-radius: 8px; transition: color 0.12s, background 0.12s;
+}
+.canvas-rewrite-trigger:hover { color: var(--text); background: rgba(128,128,128,0.07); }
+.canvas-rewrite-trigger svg { opacity: 0.75; }
 /* Writing progress in canvas reuses existing progress-ch styles */
 .book-canvas .writing-progress-chapters { padding: 0; }
 .book-canvas .progress-ch { padding: 8px 4px; }


### PR DESCRIPTION
## Problem

On a finished book, **"Rewrite"** rendered as a lone **full-width pill** below the Chat/Read/Share row — visually heavy and out of place for a rare, expensive action.

Cause: the trigger reused `.canvas-action-btn` (which is `flex:1`, sized to be an equal column inside the 3-up `.canvas-done-actions` row) but was rendered *outside* that flex row, so with no flex parent it stretched to 100%.

## Fix

Rewrite is now a **restrained tertiary action**: a subtle, centered text link — "↻ Rewrite in another language" — under the Chat/Read/Share row, clearly subordinate to the primary actions. The language menu is unchanged (still reuses the share-popup, which opens upward centered on the trigger); menu items are now bare language names since the trigger label already says "Rewrite in another language".

- `BookCanvas.tsx` `RewriteMenu`: new markup (`.canvas-rewrite-wrap` > inline-block `.canvas-share-wrap` > `.canvas-rewrite-trigger` + popup).
- `app.css`: `.canvas-rewrite-wrap` (centered) + `.canvas-rewrite-trigger` (muted text-link style, hover brightens).

## Verification
- Visual mockup reviewed (can't run the Next app locally; no `tsc`/preview). Gated on the feynman-web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)