### PR TITLE
Chat drives book rewrites — remove the separate Rewrite control

### DIFF
--- a/app/core/ai_writer.py
+++ b/app/core/ai_writer.py
@@ -132,31 +132,15 @@ def refine_outline(
     current_outline: dict[str, Any],
     user_message: str,
     history: list[dict[str, str]] | None = None,
-    already_written: bool = False,
-    content_sample: str | None = None,
 ) -> tuple[dict[str, Any], str, dict[str, int]]:
-    """Refine an outline based on user feedback.
+    """Refine an outline based on user feedback (OUTLINING stage only).
 
-    Returns (updated_outline, ai_response_text, usage_dict).
-
-    *already_written* marks a finished book: the chat may tweak title/subtitle but
-    must NOT try to change chapter bodies or their language by editing the outline
-    (that needs a Rewrite). *content_sample* lets the model see how the chapters
-    are actually written, so it answers honestly instead of guessing.
+    Returns (updated_outline, ai_response_text, usage_dict). A FINISHED book does
+    NOT route here — see plan_finished_book_edit (on a written book the chat ACTS:
+    regenerate / retitle / reply, instead of editing a now-frozen outline).
     """
     outline_str = json.dumps(current_outline, ensure_ascii=False, indent=2)
     system = f"{_REFINE_SYSTEM}\n\nCurrent outline:\n{outline_str}"
-    if already_written:
-        system += (
-            "\n\nIMPORTANT: this book is ALREADY fully written. You may adjust the title or "
-            "subtitle, but you CANNOT change the chapter bodies or the language they are written in "
-            "by editing this outline — that needs a full rewrite (the user can click \"Rewrite\" in "
-            "the book panel to regenerate every chapter, optionally in another language). If the user "
-            "asks to change the content or the writing language, tell them to use Rewrite; do NOT "
-            "restructure the chapters or change their language in the outline."
-        )
-        if content_sample:
-            system += f"\n\nHow the current chapters are actually written (sample):\n{content_sample}"
 
     # No grounding here: restructuring an existing outline needs no fresh web
     # research, and the Gemini google_search round-trips were the main cause of
@@ -211,6 +195,54 @@ def translate_outline(
     if not translated or "chapters" not in translated:
         raise ProviderError("Couldn't prepare the rewrite. Please try again.")
     return translated, _extract_usage(result)
+
+
+_FINISHED_EDIT_SYSTEM = (
+    "You help a user edit a book that is ALREADY fully written (every chapter has body text). "
+    "Read their latest message and decide what they want, then return ONLY a JSON object (no "
+    "markdown fences) with these keys:\n"
+    "- \"reply\": a short, friendly reply to the user, written in the user's language\n"
+    "- \"action\": one of \"rewrite\", \"retitle\", \"reply\"\n"
+    "- \"language\": ISO code (\"en\",\"zh\",\"es\",\"fr\",\"ja\",\"ko\",\"de\") — ONLY for \"rewrite\"\n"
+    "- \"title\", \"subtitle\", \"category\": the new value(s) — ONLY for \"retitle\"\n\n"
+    "Pick the action:\n"
+    "- \"rewrite\": the user wants the CHAPTER BODIES regenerated, or the book re-written in a "
+    "different LANGUAGE (e.g. \"用英文重写\", \"rewrite in English\", \"the chapters/body should be in "
+    "English\", \"redo the writing\"). Put the target language in \"language\". This regenerates EVERY "
+    "chapter, so only choose it when the user clearly wants the content or its language changed.\n"
+    "- \"retitle\": the user only wants to change the book's title, subtitle, or category. Put the "
+    "new value(s) in those fields.\n"
+    "- \"reply\": anything else (a question, a comment) — just answer in \"reply\" and change nothing.\n"
+)
+
+
+def plan_finished_book_edit(
+    current_outline: dict[str, Any],
+    user_message: str,
+    history: list[dict[str, str]] | None = None,
+    content_sample: str | None = None,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    """Interpret a chat message on a FINISHED book into an action plan, so the chat
+    itself acts (regenerate / retitle / just reply) — the left chat is the editor,
+    not a set of buttons. Returns (plan, usage); plan has {action, reply, language?,
+    title?, subtitle?, category?}. *content_sample* lets the model see how the
+    chapters are actually written so it judges a language complaint correctly.
+    """
+    outline_str = json.dumps(current_outline, ensure_ascii=False, indent=2)
+    system = f"{_FINISHED_EDIT_SYSTEM}\n\nCurrent outline:\n{outline_str}"
+    if content_sample:
+        system += f"\n\nHow the chapters are actually written (sample):\n{content_sample}"
+    result, _ = chat_with_fallback(
+        system=system, user=user_message, history=history,
+        use_grounding=False, thinking_budget=0, timeout=45, max_total_seconds=120,
+    )
+    plan = _parse_json_from_text(result.content) or {}
+    if plan.get("action") not in ("rewrite", "retitle", "reply"):
+        # Unparseable / unexpected → treat as a plain reply using the model's text.
+        plan = {"action": "reply", "reply": (result.content or "").strip()}
+    if not (plan.get("reply") or "").strip():
+        plan["reply"] = "Done."
+    return plan, _extract_usage(result)
 
 
 def write_chapter(

--- a/app/main.py
+++ b/app/main.py
@@ -132,6 +132,7 @@ from .core.url_fetch import fetch_url_as_book_text
 from .core.ai_writer import (
     all_outline_chapters_have_content,
     generate_outline,
+    plan_finished_book_edit,
     refine_outline,
     translate_outline,
     write_full_book,
@@ -5157,9 +5158,38 @@ def api_ai_book_start(payload: AIBookStartRequest, request: Request) -> dict[str
     }
 
 
+def _start_book_rewrite(
+    book: dict[str, Any], language: str, user_id: str, background_tasks: BackgroundTasks
+) -> int:
+    """Regenerate a finished book's chapters in *language*: re-language the outline
+    (title + TOC) to match, clear the old chapter bodies, and kick the writer.
+    Shared by the chat (when the user asks to rewrite/translate) and the /rewrite
+    endpoint. Raises ProviderError if the outline translation fails. Returns the
+    chapter count."""
+    translated, _usage = translate_outline(book["outline"], language)
+    update_ai_book_outline(book["id"], translated)
+    new_title = (translated.get("title") or book["title"] or "").strip()
+    if new_title:
+        rename_agent(book["agent_id"], new_title)
+    reset_ai_book_for_rewrite(book["id"], language)
+    creator_name = book.get("preferences", {}).get("creator_name", "") or _resolve_creator_name(user_id)
+    update_agent_status(book["agent_id"], "writing", {
+        "title": new_title or book["title"],
+        "is_ai_generated": True,
+        "creator_name": creator_name or "User",
+        "creator_user_id": user_id,
+    })
+    background_tasks.add_task(write_full_book, book["id"])
+    background_tasks.add_task(_revalidate_book_share, book["agent_id"])
+    return book.get("chapters_total") or len(translated.get("chapters") or [])
+
+
 @app.post("/api/ai-books/{book_id}/chat")
 def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
-    """Refine the book outline through conversation."""
+    """Edit the book through chat. While OUTLINING this refines the outline; once
+    the book is WRITTEN the chat ACTS on intent — regenerate the whole book (incl. a
+    language change), retitle it, or just reply — so the left chat is the editor and
+    there is no separate Rewrite button."""
     _check_quota(request, "chat")
     user_id = _get_user_id(request) or "anon"
 
@@ -5168,10 +5198,7 @@ def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request,
         raise HTTPException(status_code=404, detail="AI book not found")
     if book["user_id"] != user_id:
         raise HTTPException(status_code=403, detail="Access denied")
-    # In-flight states (about to write / actively writing) can't be edited — the
-    # background writer reads the outline mid-run. Any other state is editable;
-    # for an already-written book the edit is constrained to title/metadata below
-    # so it can't desync from the chapters already on disk.
+    # Can't edit mid-flight — the background writer is reading the outline.
     if book["status"] in ("confirmed", "writing"):
         raise HTTPException(status_code=409, detail="The book is being written right now — wait until it finishes, then you can edit it.")
 
@@ -5179,65 +5206,77 @@ def api_ai_book_chat(book_id: str, payload: AIBookChatRequest, request: Request,
     if payload.history:
         history = [{"role": m.role, "content": m.content} for m in payload.history]
 
-    # On a finished book, let the chat SEE how the chapters are actually written
-    # (a short sample) so it answers honestly and routes content/language changes
-    # to Rewrite instead of silently (and wrongly) re-languaging the outline.
-    already_written = book["status"] != "outlining"
-    content_sample: str | None = None
-    if already_written:
-        _content = book.get("content") or {}
-        _samples = []
-        for _ch in (book["outline"].get("chapters") or [])[:2]:
-            _body = (_content.get(str(_ch.get("number")), {}).get("content") or "").strip()
-            if _body:
-                _samples.append(_body[:200])
-        content_sample = "\n…\n".join(_samples) or None
+    # ── OUTLINING: free outline refinement ──────────────────────────────────
+    if book["status"] == "outlining":
+        try:
+            updated_outline, response_text, usage = refine_outline(
+                book["outline"], payload.message, history=history,
+            )
+        except ProviderError as exc:
+            raise HTTPException(status_code=503, detail=str(exc))
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Refinement failed: {exc}")
+        update_ai_book_outline(book_id, updated_outline)
+        new_title = (updated_outline.get("title") or book["title"] or "").strip()
+        if new_title and new_title != (book["title"] or ""):
+            rename_agent(book["agent_id"], new_title)
+        else:
+            update_agent_meta(book["agent_id"], {"title": new_title or book["title"]})
+        _track_usage(request, "ai_book", usage.get("total_tokens", 0))
+        return {"outline": updated_outline, "response": response_text, "usage": usage}
+
+    # ── WRITTEN book: the chat ACTS (rewrite / retitle / reply) ──────────────
+    # Give the model a short sample of the real chapter text so it judges a
+    # content/language complaint correctly instead of guessing from the outline.
+    _content = book.get("content") or {}
+    _samples = []
+    for _ch in (book["outline"].get("chapters") or [])[:2]:
+        _body = (_content.get(str(_ch.get("number")), {}).get("content") or "").strip()
+        if _body:
+            _samples.append(_body[:200])
+    content_sample = "\n…\n".join(_samples) or None
 
     try:
-        updated_outline, response_text, usage = refine_outline(
-            book["outline"], payload.message, history=history,
-            already_written=already_written, content_sample=content_sample,
+        plan, usage = plan_finished_book_edit(
+            book["outline"], payload.message, history=history, content_sample=content_sample,
         )
     except ProviderError as exc:
         raise HTTPException(status_code=503, detail=str(exc))
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Refinement failed: {exc}")
+        raise HTTPException(status_code=500, detail=f"Edit failed: {exc}")
 
-    # An already-written book keeps its chapter structure (content is on disk and
-    # isn't rewritten here) — only title/subtitle/category may change. An
-    # outlining book can still be restructured freely.
-    if book["status"] != "outlining":
+    action = plan.get("action")
+    reply = plan.get("reply") or "Done."
+    _track_usage(request, "ai_book", usage.get("total_tokens", 0))
+
+    if action == "rewrite":
+        # Regenerate every chapter (often in another language) — re-language the
+        # outline, clear the bodies, kick the writer. The frontend flips the canvas
+        # to live writing progress on `status:"writing"`.
+        lang = (plan.get("language") or book.get("preferences", {}).get("language") or "en").strip()
+        try:
+            total = _start_book_rewrite(book, lang, user_id, background_tasks)
+        except ProviderError as exc:
+            raise HTTPException(status_code=503, detail=str(exc))
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Rewrite failed: {exc}")
+        return {"response": reply, "status": "writing", "chapters_total": total}
+
+    if action == "retitle":
+        # Title/subtitle/category only — keep the written chapters (no rewrite).
         preserved = dict(book["outline"] or {})
         for key in ("title", "subtitle", "category"):
-            if updated_outline.get(key):
-                preserved[key] = updated_outline[key]
-        updated_outline = preserved
-
-    update_ai_book_outline(book_id, updated_outline)
-    # update_ai_book_outline syncs ai_books.title; also push the new title to the
-    # agent (agents.name + meta.title) so the library, reader, and a finished
-    # book's canvas reflect it. rename_agent keeps all three in sync — the old
-    # meta-only bump left agents.name/ai_books.title stale, so a finished book's
-    # displayed title never changed.
-    new_title = (updated_outline.get("title") or book["title"] or "").strip()
-    if new_title and new_title != (book["title"] or ""):
-        rename_agent(book["agent_id"], new_title)
-    else:
-        update_agent_meta(book["agent_id"], {"title": new_title or book["title"]})
-
-    # A published book (completed/failed/cancelled) has live SEO + share pages,
-    # and its title/subtitle/category just changed — bust the Next ISR page + ssr
-    # data cache now so the Twitter/X card's og:title/og:image don't stay stale
-    # for up to 24h. Skipped for outlining drafts (not shared yet).
-    if book["status"] != "outlining":
+            if plan.get(key):
+                preserved[key] = plan[key]
+        update_ai_book_outline(book_id, preserved)
+        new_title = (preserved.get("title") or book["title"] or "").strip()
+        if new_title and new_title != (book["title"] or ""):
+            rename_agent(book["agent_id"], new_title)
         background_tasks.add_task(_revalidate_book_share, book["agent_id"])
+        return {"response": reply, "outline": preserved}
 
-    _track_usage(request, "ai_book", usage.get("total_tokens", 0))
-    return {
-        "outline": updated_outline,
-        "response": response_text,
-        "usage": usage,
-    }
+    # action == "reply" — answer only, change nothing.
+    return {"response": reply, "outline": book["outline"]}
 
 
 @app.post("/api/ai-books/{book_id}/confirm")
@@ -5271,11 +5310,9 @@ def api_ai_book_confirm(book_id: str, request: Request, background_tasks: Backgr
 
 @app.post("/api/ai-books/{book_id}/rewrite")
 def api_ai_book_rewrite(book_id: str, payload: AIBookRewriteRequest, request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
-    """Regenerate a finished book's chapters from scratch in a target language —
-    the post-completion Rewrite flow. Re-languages the outline (title + TOC) to
-    match, clears the existing chapters, and re-runs the writer. This is how a
-    written book's CONTENT/language is changed (the chat refine only edits the
-    outline, never the bodies)."""
+    """Regenerate a finished book's chapters in a target language. The chat now
+    drives this (see api_ai_book_chat → _start_book_rewrite); this endpoint is the
+    same flow exposed directly for programmatic callers."""
     user_id = _get_user_id(request) or "anon"
     book = get_ai_book(book_id)
     if not book:
@@ -5284,36 +5321,13 @@ def api_ai_book_rewrite(book_id: str, payload: AIBookRewriteRequest, request: Re
         raise HTTPException(status_code=403, detail="Access denied")
     if book["status"] in ("confirmed", "writing"):
         raise HTTPException(status_code=409, detail="The book is being written right now — wait until it finishes.")
-
-    # Re-language the outline first so the title/TOC match the rewritten chapters
-    # (the bodies follow the outline's language when regenerated).
     try:
-        translated, usage = translate_outline(book["outline"], payload.language)
+        total = _start_book_rewrite(book, payload.language, user_id, background_tasks)
     except ProviderError as exc:
         raise HTTPException(status_code=503, detail=str(exc))
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Rewrite setup failed: {exc}")
-
-    update_ai_book_outline(book_id, translated)
-    new_title = (translated.get("title") or book["title"] or "").strip()
-    if new_title:
-        rename_agent(book["agent_id"], new_title)
-
-    # Clear the old chapters + set the target language, then kick the writer.
-    reset_ai_book_for_rewrite(book_id, payload.language)
-    creator_name = book.get("preferences", {}).get("creator_name", "") or _resolve_creator_name(user_id)
-    update_agent_status(book["agent_id"], "writing", {
-        "title": new_title or book["title"],
-        "is_ai_generated": True,
-        "creator_name": creator_name or "User",
-        "creator_user_id": user_id,
-    })
-
-    background_tasks.add_task(write_full_book, book_id)
-    background_tasks.add_task(_revalidate_book_share, book["agent_id"])
-
-    _track_usage(request, "ai_book", usage.get("total_tokens", 0))
-    return {"status": "writing", "chapters_total": book["chapters_total"]}
+    return {"status": "writing", "chapters_total": total}
 
 
 @app.post("/api/ai-books/{book_id}/cancel")

--- a/web/components/chat/BookCanvas.tsx
+++ b/web/components/chat/BookCanvas.tsx
@@ -41,7 +41,6 @@ interface BookCanvasProps {
   onConfirm: () => void;
   onCancel: () => void;
   onRetry: () => void;
-  onRewrite: (language: string) => void;
 }
 
 export default function BookCanvas({
@@ -56,7 +55,6 @@ export default function BookCanvas({
   onConfirm,
   onCancel,
   onRetry,
-  onRewrite,
 }: BookCanvasProps) {
   return (
     <aside
@@ -76,7 +74,6 @@ export default function BookCanvas({
             content={content}
             onCancel={onCancel}
             onRetry={onRetry}
-            onRewrite={onRewrite}
           />
         )}
         {error && <p className="canvas-error">{error}</p>}
@@ -208,91 +205,6 @@ function CanvasActions({ readId, title }: { readId: string; title: string }) {
   );
 }
 
-// ── Rewrite menu: regenerate the whole book in another language ──────────────
-const REWRITE_LANGS: { code: string; label: string }[] = [
-  { code: "en", label: "English" },
-  { code: "zh", label: "中文" },
-  { code: "es", label: "Español" },
-  { code: "fr", label: "Français" },
-  { code: "ja", label: "日本語" },
-  { code: "ko", label: "한국어" },
-  { code: "de", label: "Deutsch" },
-];
-
-/** "Rewrite" control on a finished book — the ONLY way to change the chapter
- *  bodies / language (chat refine edits the outline, never the written text).
- *  Picks a language → confirm → regenerate every chapter. */
-function RewriteMenu({
-  chapterCount,
-  onRewrite,
-}: {
-  chapterCount: number;
-  onRewrite: (language: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("click", onDoc);
-    return () => document.removeEventListener("click", onDoc);
-  }, [open]);
-  const pick = (code: string, label: string) => {
-    setOpen(false);
-    const n = chapterCount || 0;
-    if (
-      window.confirm(
-        `Rewrite ${n ? `all ${n} chapters` : "the book"} in ${label}? This replaces the current text and takes a few minutes.`,
-      )
-    ) {
-      onRewrite(code);
-    }
-  };
-  return (
-    // Tertiary action: a restrained centered text link under the primary
-    // Chat/Read/Share row — NOT a fourth full-width pill (rewriting is rare +
-    // expensive, so it shouldn't compete with the primary actions). The language
-    // menu reuses the share-popup (opens upward, centered on the trigger).
-    <div className="canvas-rewrite-wrap">
-      <div
-        className={`canvas-share-wrap${open ? " open" : ""}`}
-        ref={wrapRef}
-        style={{ display: "inline-block" }}
-      >
-        <button
-          type="button"
-          className="canvas-rewrite-trigger"
-          onClick={(e) => {
-            e.stopPropagation();
-            setOpen((o) => !o);
-          }}
-          title="Regenerate every chapter, optionally in another language"
-        >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="23 4 23 10 17 10" />
-            <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-          </svg>
-          Rewrite in another language
-        </button>
-        <div className="canvas-share-popup">
-          {REWRITE_LANGS.map((l) => (
-            <button
-              key={l.code}
-              type="button"
-              className="canvas-share-opt"
-              onClick={() => pick(l.code, l.label)}
-            >
-              {l.label}
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 // ── Outline accordion (port of _renderCanvasOutline) ─────────────────────────
 function OutlineView({
   outline,
@@ -392,7 +304,6 @@ function WritingProgress({
   content,
   onCancel,
   onRetry,
-  onRewrite,
 }: {
   status: BookStatus | null;
   fallbackChapters: OutlineChapter[];
@@ -400,7 +311,6 @@ function WritingProgress({
   content?: CanvasContent | null;
   onCancel: () => void;
   onRetry: () => void;
-  onRewrite: (language: string) => void;
 }) {
   const chapters = status?.outline?.chapters?.length
     ? status.outline.chapters
@@ -563,9 +473,6 @@ function WritingProgress({
           <div className="canvas-done-label">Your book is ready!</div>
           {/* Chat + Read + Share — the full production completed footer. */}
           <CanvasActions readId={readId} title={title} />
-          {/* The only way to change the written chapters / their language: a full
-              regenerate (chat refine edits the outline, not the bodies). */}
-          <RewriteMenu chapterCount={total} onRewrite={onRewrite} />
         </>
       )}
 

--- a/web/components/chat/ChatView.tsx
+++ b/web/components/chat/ChatView.tsx
@@ -1255,7 +1255,6 @@ export default function ChatView({
           onConfirm={writeBook.confirm}
           onCancel={writeBook.cancel}
           onRetry={writeBook.retry}
-          onRewrite={writeBook.rewrite}
         />
       ) : rightSidebar !== undefined ? (
         rightSidebar

--- a/web/components/chat/useWriteBook.ts
+++ b/web/components/chat/useWriteBook.ts
@@ -25,7 +25,6 @@ import {
   startBook,
   chatBook,
   confirmBook,
-  rewriteBook,
   getStatus,
   getBook,
   cancelBook,
@@ -84,8 +83,6 @@ export interface WriteBookState {
   confirm: () => Promise<void>;
   cancel: () => Promise<void>;
   retry: () => Promise<void>;
-  /** Regenerate every chapter from scratch in `language` (post-completion). */
-  rewrite: (language: string) => Promise<void>;
 }
 
 function describeError(e: unknown, fallback: string): string {
@@ -312,16 +309,30 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
         return;
       }
 
-      // Phase 2: outline exists → refine it (history = last 6 turns, like prod).
+      // Phase 2: the book exists → the chat edits it. Outlining refines the
+      // outline; a written book may be retitled, answered, or fully rewritten —
+      // the backend decides and acts (no separate Rewrite button).
       setBusy(true);
       try {
         const res = await chatBook(bookIdRef.current, message, priorHistory);
         if (genRef.current !== gen) return;
-        setOutline(res.outline);
         cbRef.current.onAssistant(res.response);
+
+        // The chat triggered a full rewrite: the backend already re-languaged the
+        // outline, cleared the bodies, and kicked the writer. Flip the canvas to
+        // live writing progress (the new chapters stream in via the poll).
+        if (res.status === "writing") {
+          const id = bookIdRef.current;
+          setBookContent(null);
+          setStatus(null);
+          setPhase("writing");
+          if (id) startPolling(id);
+          return;
+        }
+
+        if (res.outline) setOutline(res.outline);
         // A finished book's canvas shows `status.title` (not `outline.title`) and
-        // polling is stopped — so after editing it (e.g. a title fix) refetch once
-        // to surface the new title/metadata.
+        // polling is stopped — so after a retitle refetch once to surface it.
         const refetchId = bookIdRef.current;
         if (statusRef.current && refetchId) {
           try {
@@ -332,7 +343,7 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
               setBookContent(fresh.content || null);
             }
           } catch {
-            /* keep the refine result we already applied */
+            /* keep the result we already applied */
           }
         }
       } catch (err) {
@@ -344,7 +355,7 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
         if (genRef.current === gen) setBusy(false);
       }
     },
-    [busy, sessionId],
+    [busy, sessionId, startPolling],
   );
 
   // ── Confirm + poll (port of _confirmWriteBook) ─────────────────────────
@@ -399,30 +410,6 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
     }
   }, [startPolling]);
 
-  // ── Rewrite (regenerate every chapter, optionally in a new language) ──────
-  const rewrite = useCallback(
-    async (language: string) => {
-      const id = bookIdRef.current;
-      if (!id) return;
-      setError(null);
-      try {
-        await rewriteBook(id, language);
-        // Drop the old chapters so the canvas shows fresh progress, not stale
-        // bodies as "done"; the new ones repopulate when writing completes.
-        setBookContent(null);
-        setPhase("writing");
-        cbRef.current.onAssistant(
-          "Rewriting the whole book from scratch — I'll regenerate every chapter. " +
-            "You can watch the progress on the right.",
-        );
-        startPolling(id);
-      } catch (err) {
-        setError(describeError(err, "Couldn't start the rewrite. Try again."));
-      }
-    },
-    [startPolling],
-  );
-
   return {
     phase,
     outline,
@@ -437,6 +424,5 @@ export function useWriteBook(args: UseWriteBookArgs): WriteBookState {
     confirm,
     cancel,
     retry,
-    rewrite,
   };
 }

--- a/web/lib/aibooks.ts
+++ b/web/lib/aibooks.ts
@@ -50,9 +50,15 @@ export interface StartResult {
 }
 
 export interface ChatResult {
-  outline: Outline;
-  /** The assistant's reply to the refinement message. */
+  /** Updated outline (outline refine, or a finished-book retitle/reply). Absent
+   *  when the chat triggered a rewrite (the book goes back to writing). */
+  outline?: Outline;
+  /** The assistant's reply to the message. */
   response: string;
+  /** "writing" when the chat triggered a full rewrite (regenerate every chapter). */
+  status?: AiBookStatus;
+  /** Chapter count, present when a rewrite started. */
+  chaptersTotal?: number;
 }
 
 /** Normalized status, derived fields included for progress UI. */
@@ -132,17 +138,28 @@ export async function startBook(
   };
 }
 
-/** Phase 2: refine the outline conversationally. */
+/**
+ * Phase 2: edit the book through chat. While outlining this refines the outline;
+ * once written, the backend ACTS — it may retitle, just reply, or trigger a full
+ * rewrite (returns status:"writing"), so the chat is the editor (no separate button).
+ */
 export async function chatBook(
   bookId: string,
   message: string,
   history: { role: string; content: string }[] = [],
 ): Promise<ChatResult> {
-  const data = await post<{ outline: Outline; response: string }>(
-    `/api/ai-books/${encodeURIComponent(bookId)}/chat`,
-    { message, history },
-  );
-  return { outline: data.outline || {}, response: data.response || "" };
+  const data = await post<{
+    outline?: Outline;
+    response: string;
+    status?: AiBookStatus;
+    chapters_total?: number;
+  }>(`/api/ai-books/${encodeURIComponent(bookId)}/chat`, { message, history });
+  return {
+    outline: data.outline,
+    response: data.response || "",
+    status: data.status,
+    chaptersTotal: data.chapters_total,
+  };
 }
 
 /** Confirm the outline; the backend starts writing chapters in the background. */

--- a/web/styles/app.css
+++ b/web/styles/app.css
@@ -3527,19 +3527,6 @@ html.dark .canvas-share-popup { box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
 .canvas-share-opt:hover { background: rgba(0,0,0,0.05); }
 html.dark .canvas-share-opt:hover { background: rgba(255,255,255,0.08); }
 .canvas-share-opt svg { flex-shrink: 0; color: var(--text-secondary); }
-
-/* Rewrite = a restrained TERTIARY action (heavy + rare): a subtle centered text
-   link under the primary Chat/Read/Share row, not a fourth full-width pill. */
-.canvas-rewrite-wrap { margin-top: 10px; text-align: center; }
-.canvas-rewrite-trigger {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 6px 10px; border: none; background: none;
-  color: var(--text-secondary); cursor: pointer;
-  font: 500 13px/1 'Inter', sans-serif;
-  border-radius: 8px; transition: color 0.12s, background 0.12s;
-}
-.canvas-rewrite-trigger:hover { color: var(--text); background: rgba(128,128,128,0.07); }
-.canvas-rewrite-trigger svg { opacity: 0.75; }
 /* Writing progress in canvas reuses existing progress-ch styles */
 .book-canvas .writing-progress-chapters { padding: 0; }
 .book-canvas .progress-ch { padding: 8px 4px; }


### PR DESCRIPTION
## Why

The left chat is the collaborative editor. But #226 bolted a separate **"Rewrite"** control onto the canvas **and** made the chat (`refine_outline`'s "already written" path) *refuse* content/language changes and tell the user to click that button. That's backwards — if the chat punts every hard thing to its own widget, the chat is pointless. (It also misread "the body is in Chinese, I want English" as "make it Chinese," because the chat could only ever edit the outline, never the bodies.)

## What

The chat now **acts** on a finished book; the canvas is a pure preview.

**Backend** (`api_ai_book_chat` branches by state):
- **Outlining** → `refine_outline` (unchanged; reverted to outlining-only — the "use Rewrite" refusal is gone).
- **Written** → new `plan_finished_book_edit` classifies the message (LLM, given a real chapter-text sample) into `rewrite` | `retitle` | `reply`, and the endpoint acts:
  - `rewrite` → `_start_book_rewrite` (re-language the outline, clear the bodies, kick the writer) → returns `status:"writing"`.
  - `retitle` → apply title/subtitle/category, chapters preserved.
  - `reply` → just answer, change nothing.
- `/rewrite` endpoint kept as a thin programmatic entry sharing `_start_book_rewrite`.

**Frontend**:
- `chatBook` surfaces `status`; `useWriteBook.send` flips the canvas to live writing progress on `status:"writing"`.
- Removed the canvas Rewrite control (`RewriteMenu`, `REWRITE_LANGS`, `onRewrite` plumbing through BookCanvas/ChatView), `useWriteBook.rewrite`, and the dead `.canvas-rewrite-*` CSS.

So **"用英文重写" / "rewrite in English" typed in the chat** now regenerates the whole book in that language; no separate button.

## Verification
- `python -m py_compile app/core/ai_writer.py app/main.py` ✅
- No dangling `onRewrite`/`RewriteMenu`/`REWRITE_LANGS`/`writeBook.rewrite` refs; `useWriteBook` return + `BookCanvas` footer well-formed ✅
- Frontend types gated on the feynman-web build.

Note: rewriting still needs Gemini embedding credits for the final indexing step (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)