### PR TITLE
fix(landing): mobile responsive layout

### DIFF
--- a/web/components/landing/LandingPage.module.css
+++ b/web/components/landing/LandingPage.module.css
@@ -648,27 +648,42 @@
   font-weight: 500;
 }
 
-/* Responsive */
+/* Responsive — tablet */
 @media (max-width: 960px) {
+  .fullscreen {
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    padding-bottom: 48px;
+  }
+  .bgCanvas {
+    display: none;
+  }
+  .mindsToolbar {
+    display: none;
+  }
   .fgCenter {
     flex-direction: column;
-    padding: 0 16px;
-    gap: 20px;
+    padding: 48px 20px 0;
+    gap: 28px;
+    height: auto;
   }
   .heroLeft {
     flex: 0 0 auto;
+    min-width: 0;
     max-width: 100%;
     text-align: center;
   }
   .heroLeft::before {
-    inset: -30px -40px;
+    display: none;
   }
   .heroHeadline {
-    font-size: 22px;
+    font-size: 24px;
     text-align: center;
   }
   .heroSub {
     text-align: center;
+    font-size: 13px;
   }
   .heroCta {
     margin: 20px auto 0;
@@ -676,13 +691,64 @@
   .chatCard {
     flex: 0 0 auto;
     max-width: 100%;
+    width: 100%;
     height: 380px;
   }
-  .mindsToolbarBtn {
-    display: none;
+}
+
+/* Responsive — mobile */
+@media (max-width: 600px) {
+  .topbar {
+    padding: 10px 16px;
   }
-  .mindsToolbar input {
-    width: 140px;
+  .topbarBrand {
+    font-size: 15px;
+  }
+  .fgCenter {
+    padding: 32px 16px 0;
+    gap: 24px;
+  }
+  .heroHeadline {
+    font-size: 22px;
+  }
+  .heroSub {
+    font-size: 12px;
+    line-height: 1.6;
+  }
+  .heroCta {
+    padding: 10px 22px;
+    font-size: 14px;
+  }
+  .chatCard {
+    height: 340px;
+  }
+  .chatHome {
+    padding: 0 16px;
+  }
+  .greetingRow {
+    margin-bottom: 16px;
+  }
+  .greeting {
+    font-size: 22px;
+  }
+  .composerInput {
+    font-size: 14px;
+    min-height: 32px;
+  }
+  .chatComposer,
+  .chatComposerInline {
+    padding: 12px 14px 8px;
+    border-radius: 18px;
+  }
+  .starterPill {
+    font-size: 11px;
+    padding: 6px 12px;
+  }
+  .chatMessages {
+    padding: 12px 16px;
+  }
+  .chatInputArea {
+    padding: 4px 16px 8px;
   }
 }
 
@@ -1060,6 +1126,55 @@
   }
   .ctaBand {
     padding: 80px 0;
+  }
+  .softLink {
+    justify-content: center;
+  }
+}
+
+/* Below-hero mobile */
+@media (max-width: 600px) {
+  .section {
+    padding: 48px 0;
+  }
+  .sectionInner {
+    padding: 0 16px;
+  }
+  .sectionTitle {
+    font-size: 20px;
+  }
+  .bodyText {
+    font-size: 13px;
+  }
+  .mockFrame {
+    padding: 16px;
+  }
+  .constellation {
+    height: 200px;
+  }
+  .cAvatar {
+    width: 36px;
+    height: 36px;
+    font-size: 11px;
+  }
+  .cName {
+    font-size: 9px;
+  }
+  .libraryGrid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+  }
+  .libArtInitials {
+    font-size: 20px;
+  }
+  .libTitle {
+    font-size: 9px;
+  }
+  .bookChapterWords {
+    display: none;
+  }
+  .footerInner {
+    padding: 24px 16px;
   }
 }
 

--- a/web/components/landing/LandingPage.tsx
+++ b/web/components/landing/LandingPage.tsx
@@ -736,6 +736,7 @@ export function LandingPage({
   const startMindsGraph = useCallback(() => {
     const container = bgRef.current;
     if (!container) return;
+    if (window.matchMedia("(max-width: 960px)").matches) return;
 
     // Nodes from the hardcoded LP_MINDS list (legacy 1116-1122). Never throws on
     // empty data — the sim simply renders nothing.


### PR DESCRIPTION
## Summary
- Hero section was broken on mobile: `height: 100vh` + `overflow: hidden` clipped the stacked hero text + chat card, leaving only the D3 canvas background (with stray graph lines from desktop-sized clear zones)
- Hide D3 canvas graph + minds toolbar on <=960px (saves battery, removes visual noise on mobile)
- Reset `heroLeft` min-width (was 340px, overflows 375px phones)
- Add dedicated 600px phone breakpoint: tighter topbar/section padding, smaller typography, adapted greeting/composer/starters, compact library grid and constellation mock

## Test plan
- [ ] Open feynman.wiki on a phone (or Chrome DevTools mobile emulation at 375px, 390px, 414px)
- [ ] Landing page: hero text + chat card visible and properly stacked, no D3 graph artifacts
- [ ] Scroll down: all 5 feature sections readable and properly stacked
- [ ] Footer: compact padding, no horizontal overflow
- [ ] Tablet (768px): same layout, just slightly more spacing
- [ ] Desktop (1200px+): no regression — D3 graph, side-by-side layout, minds toolbar all intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)