### PR TITLE
fix(sidebar): un-clip user menu popup when sidebar is collapsed

### DIFF
--- a/web/styles/liquid.css
+++ b/web/styles/liquid.css
@@ -872,6 +872,18 @@ body { background-color: var(--bg-home); }
   position: absolute !important;
   animation: none !important;
 }
+/* Collapsed rail: .app-sidebar is 52px wide with overflow:hidden, which clips
+ * the absolutely-positioned menu down to the rail — so the popup showed only as
+ * a sliver (e.g. over the open reader). Re-anchor it to the viewport with fixed
+ * (no transformed/contain/container ancestor exists, so it escapes the clip)
+ * and drop `right` so min-width drives the width. z-index:1000 (app.css) keeps
+ * it above page content. */
+.app-layout.sidebar-collapsed .sidebar-user-menu {
+  position: fixed !important;
+  left: 12px !important;
+  right: auto !important;
+  bottom: 60px !important;
+}
 .profile-email {
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   flex: 1; min-width: 0; color: var(--text); font-size: 13px;


### PR DESCRIPTION
## Bug

When the left sidebar is collapsed and you open the reader (or any page) and click the profile avatar at the bottom-left, the upward popup menu (name/email + Theme / Join Community / Subscription / Sign out) is clipped to a thin sliver — only the leftmost few characters of each row are visible.

## Root cause

The Liquid Glass redesign re-anchored `.sidebar-user-menu` to the sidebar via `position: absolute !important` (relative to the `position: relative` `.sidebar-user-wrap`). The menu therefore lives inside `.app-sidebar`, which has `overflow: hidden`.

- **Expanded (260px):** `left:12/right:12` → ~236px menu fits inside the rail. Fine.
- **Collapsed (52px):** the `min-width:220px` menu is clipped by the 52px rail's `overflow: hidden` → only a sliver shows.

The whole ancestor chain (`.sidebar-user-wrap → .sidebar-bottom → .app-sidebar → .app-layout → body/html`) has **no** `transform / filter / contain / container-type / will-change / perspective`, so a `position: fixed` element escapes the overflow clip and is positioned against the viewport.

## Fix

Collapsed-state-only override in `web/styles/liquid.css`: re-anchor the menu to the viewport with `position: fixed`, drop `right` so `min-width` drives the width. `z-index:1000` (app.css) keeps it above page content. **Expanded state is unchanged** (no regression risk).

```css
.app-layout.sidebar-collapsed .sidebar-user-menu {
  position: fixed !important;
  left: 12px !important;
  right: auto !important;
  bottom: 60px !important;
}
```

## Verification

Local preview not possible (`web/` has no `node_modules`). Verified by source analysis; please confirm on the Vercel preview: **collapse sidebar → open a book in the reader → click the avatar** → popup should appear fully, un-clipped, above the reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)