### PR TITLE
SEO: server-render the landing at / (was an empty 0-link shell for crawlers)

### DIFF
--- a/app/core/indexnow.py
+++ b/app/core/indexnow.py
@@ -39,6 +39,13 @@ log = logging.getLogger(__name__)
 # INDEXNOW_KEY explicitly so it's stable across deploys (rotating
 # breaks the verification file ↔ submission mapping). Dev fallback
 # is a fixed string that's not secret (anyone can pick a key).
+#
+# COUPLING: the key file is served by THIS backend, but keyLocation
+# points at feynman.wiki, where web/vercel.json rewrites the exact
+# path /<key>.txt to api.feynman.wiki. If the key ever changes, that
+# rewrite must change with it — otherwise the key file 404s on the
+# submitted host and Bing silently rejects every submission (this
+# exact failure went unnoticed from the Next cutover until 2026-07-02).
 _DEFAULT_KEY = "feynman-indexnow-2026-05-26-7f3a"
 INDEXNOW_KEY = os.getenv("INDEXNOW_KEY", _DEFAULT_KEY).strip().lower()
 

--- a/app/main.py
+++ b/app/main.py
@@ -1116,34 +1116,57 @@ def sitemap_xml():
 @app.get("/llms.txt")
 def llms_txt():
     from fastapi.responses import PlainTextResponse
+    # Live catalog counts (same cached COUNT(*)s as /api/stats) so this file
+    # never drifts from reality again — it shipped saying "50+ minds" while
+    # the sitemap advertised 1,400.
+    try:
+        stats = _cache_get("landing_stats", _STATS_CACHE_TTL)
+        if stats is None:
+            stats = count_landing_stats()
+            _cache_set("landing_stats", stats)
+    except Exception:
+        stats = {}
+
+    def _count_or(n, floor: int, fallback: str) -> str:
+        # Floor guards dev/empty DBs and partial outages from rendering
+        # embarrassing counts like "1 great minds".
+        return f"{n:,}" if isinstance(n, int) and n >= floor else fallback
+
+    books_n = _count_or(stats.get("books"), 100, "600+")
+    minds_n = _count_or(stats.get("minds"), 100, "1,400+")
+    symp_n = _count_or(stats.get("symposiums"), 20, "100+")
     content = f"""# Feynman
 
-> An interactive knowledge network built on the world's most important books and great minds. Chat with any book, explore topics with AI-curated sources, and discuss ideas with simulated great thinkers.
+> An interactive knowledge network built on the world's most important books and great minds. Chat with {books_n} books, talk with {minds_n} simulated great thinkers, read multi-mind symposiums, and generate new books on demand.
 
 ## About
 
 Feynman is an AI-powered study companion inspired by the Feynman learning method.
-Users can chat with books using a four-layer content system (RAG, Content Fetch, Web Search, LLM Knowledge),
-explore topics with AI-curated book discovery, and engage with 50+ simulated great minds — scholars,
+The catalog currently spans {books_n} chattable books, {minds_n} great minds, and {symp_n} symposiums.
+Users chat with books using a four-layer content system (RAG, Content Fetch, Web Search, LLM Knowledge),
+explore topics with AI-curated book discovery, and talk with simulated great minds — scholars,
 scientists, and practitioners — who automatically join conversations with relevant expertise.
 
 - [Homepage]({_SITE_URL}/): Main application — chat with books, explore topics, interact with great minds
-- [Library]({_SITE_URL}/#/library): Browse and discover books across all topics
-- [Great Minds]({_SITE_URL}/#/minds): Interactive knowledge graph of 50+ great thinkers
-- [GitHub](https://github.com/steveyeow/feynman): Open-source repository (MIT license)
+- [Library]({_SITE_URL}/library): Browse and discover books across all topics
+- [Great Minds]({_SITE_URL}/minds): Explore {minds_n} simulated great thinkers
+- [Symposiums]({_SITE_URL}/symposiums): Multi-mind debates on timeless questions
+- [GitHub](https://github.com/steveyeow/Feynman): Open-source repository (MIT license)
 
 ## What Feynman Does
 
 - **Chat with Books**: Ask questions about any book and get answers with passage-level citations [1], [2] from a four-layer RAG system
+- **Great Minds Network**: AI agents faithfully simulate {minds_n} great thinkers (Aristotle, Feynman, Adam Smith, Keynes, etc.) who join your conversations automatically
+- **Symposiums** (`/symposium/{{slug}}`): curated multi-mind debates — several great-mind agents argue a timeless question in turns, with settled positions mapped on a graph. Users can also convene their own.
 - **Topic-Driven Discovery**: Enter a topic (Psychology, Philosophy, Economics, Physics, etc.) and Feynman discovers the most relevant books via AI curation
-- **Great Minds Network**: AI agents faithfully simulate great thinkers (Aristotle, Feynman, Adam Smith, Keynes, etc.) who join your conversations automatically
 - **Cross-Book Knowledge**: Select multiple books and search across your entire library for the most relevant passages
-- **AI Book Writing**: Collaboratively outline and generate full books on any topic
+- **AI Book Writing**: outline, confirm, and generate a complete book on demand for your current needs — then chat with it like any other book
 - **Upload Custom Minds**: Create mind agents from Twitter profiles, blog URLs, or text
 - **Live AI Insights** (per entity, citation-friendly): every indexed book and great mind has a public page that aggregates AI-synthesized commentary drawn from real reader chat sessions. Located at `/book/{{id}}/insights` for books and `/mind/{{id}}/dialogues` for great minds. Only the AI agent's responses are published; user questions remain private. These pages are the canonical citable source for "what does this book say about [topic]" and "how does this thinker engage with [topic]" — applied, live, refreshed continuously, available nowhere else on the open web.
 - **Compound Q&A pages** (`/book/{{id}}/q/{{question-slug}}`): one indexable URL per popular reader question per book, with an LLM-synthesized answer grounded in the book's actual passages and `QAPage` JSON-LD.
 - **Imagined-perspective pages** (`/mind/{{id}}/on/{{topic-slug}}`): short essays of how a great-mind agent would approach a given topic, persona-grounded and labelled as imagined synthesis.
 - **Topic hub pages** (`/topic/{{topic-slug}}`): aggregations of books and minds tagged with each canonical topic, with `CollectionPage` + `ItemList` JSON-LD.
+- **Shared answers & discussions** (`/a/{{id}}`, `/discussions/{{id}}`): user-published Q&A turns and full conversations, each attributed to its book or mind.
 
 ## What Feynman Does NOT Do
 
@@ -1225,7 +1248,7 @@ The library expands through topic exploration, search, chat mentions, PDF/TXT/EP
 and community voting (books with enough upvotes get auto-indexed).
 
 ### 3. Enter Through a Mind
-50+ pre-generated AI agents simulate great thinkers across every field:
+Over a thousand pre-generated AI agents simulate great thinkers across every field:
 philosophy, physics, economics, psychology, literature, tech, startups, and more.
 From Aristotle and Richard Feynman to Marc Andreessen and Naval Ravikant.
 
@@ -1237,7 +1260,7 @@ Users can upload their own minds from Twitter profiles, blog URLs, or pasted tex
 
 - **Book Chat with Citations**: RAG-powered Q&A with passage-level source attribution
 - **AI Book Discovery**: LLM-curated book recommendations for any topic
-- **Great Minds Network**: 50+ simulated thinkers with persistent memory and auto-join
+- **Great Minds Network**: 1,000+ simulated thinkers with persistent memory and auto-join
 - **Cross-Book Search**: Query across your entire library simultaneously
 - **AI Book Writing**: Collaborative outline + full book generation
 - **Knowledge Graph**: Interactive force-directed visualization of mind connections
@@ -1286,9 +1309,9 @@ The project draws inspiration from Richard Feynman's approach to learning:
 ## Pages
 
 - [Home]({_SITE_URL}/): Main chat interface — ask about books, topics, or anything
-- [Library]({_SITE_URL}/#/library): Browse, search, and discover books
-- [Great Minds]({_SITE_URL}/#/minds): Interactive knowledge graph of great thinkers
-- [Chats]({_SITE_URL}/#/chats): Chat session history
+- [Library]({_SITE_URL}/library): Browse, search, and discover books
+- [Great Minds]({_SITE_URL}/minds): Explore the simulated great thinkers
+- [Symposiums]({_SITE_URL}/symposiums): Multi-mind debates on timeless questions
 - [Terms of Service]({_SITE_URL}/terms)
 - [Privacy Policy]({_SITE_URL}/privacy)
 
@@ -3601,18 +3624,32 @@ def api_cron_indexnow(request: Request) -> dict[str, Any]:
     from datetime import datetime, timedelta, timezone
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=26)).isoformat()
     urls: list[str] = []
-    # Recent ready agents → /book/{id}
+    # Recent ready agents → /book/{slug}. Submit the canonical slug URL only —
+    # a UUID submission makes Bing crawl a 301 hop, and slugless entities
+    # aren't in the sitemap either (same gate).
     for a in list_agents(limit=2000, lite=True):
         if a.get("status") != "ready":
             continue
         if (a.get("created_at") or "") < cutoff:
             continue
-        urls.append(f"{_SITE_URL}/book/{a['id']}")
-    # Recent minds → /mind/{id}
+        if not a.get("slug"):
+            continue
+        urls.append(f"{_SITE_URL}/book/{a['slug']}")
+    # Recent minds → /mind/{slug}
     for m in list_minds(limit=2000, lite=True):
         if (m.get("created_at") or "") < cutoff:
             continue
-        urls.append(f"{_SITE_URL}/mind/{m['id']}")
+        if not m.get("slug"):
+            continue
+        urls.append(f"{_SITE_URL}/mind/{m['slug']}")
+    # Recent symposiums → /symposium/{slug} (list_debates is slug-gated).
+    # created_at may come back as a datetime (PG) or string (SQLite); compare
+    # dates only — over-inclusion just re-pings, which IndexNow treats as a no-op.
+    from .core.db import list_debates as _list_debates
+    for d in _list_debates(limit=500):
+        if str(d.get("created_at") or "")[:10] < cutoff[:10]:
+            continue
+        urls.append(f"{_SITE_URL}/symposium/{d['slug']}")
     # Always re-ping sitemap so engines re-fetch the URL graph
     urls.append(f"{_SITE_URL}/sitemap.xml")
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import HomeOrLanding from "@/components/landing/HomeOrLanding";
 
 type SP = { [key: string]: string | string[] | undefined };
@@ -30,6 +31,23 @@ export async function generateMetadata(
   return { alternates: { canonical } };
 }
 
-export default function Page() {
-  return <HomeOrLanding />;
+export default function Page({ searchParams }: { searchParams: SP }) {
+  // Server-side mirror of HomeOrLanding's client gate, so the LANDING can be
+  // in the initial HTML. Until this, `/` server-rendered as an EMPTY shell
+  // (0 links, 0 text — the gate returned null until client auth resolved):
+  // Googlebot's most-crawled URL was a discovery dead end, and non-JS AI
+  // crawlers (GPTBot, ClaudeBot, PerplexityBot) saw a blank front door.
+  //
+  //  - chat-intent params (?book/?q/?mind/?debate) → app composer, never
+  //    the landing (same override as the client gate)
+  //  - `feynman-home` cookie (set client-side once a visitor is app-bound:
+  //    signed in or dismissed the landing) → render nothing and let the
+  //    client gate pick HOME, exactly the pre-SSR behavior — no landing
+  //    flash for returning users
+  //  - everyone else (first-time visitors AND crawlers) → full landing HTML
+  const hasChatIntent = ["book", "q", "mind", "debate"].some(
+    (k) => searchParams[k] !== undefined,
+  );
+  const appBound = cookies().has("feynman-home");
+  return <HomeOrLanding ssrLanding={!hasChatIntent && !appBound} />;
 }

--- a/web/components/landing/HomeOrLanding.tsx
+++ b/web/components/landing/HomeOrLanding.tsx
@@ -8,6 +8,22 @@ import { LandingPage } from "./LandingPage";
 
 const LANDED_KEY = "feynman-landed";
 
+// Cookie mirror of "this visitor is app-bound" (signed in, or dismissed the
+// landing). Unlike localStorage it IS visible to the server, which uses it in
+// app/page.tsx to decide whether `/` server-renders the full landing HTML
+// (crawlers + first-time visitors) or nothing (returning users — avoids a
+// landing flash before this gate picks HOME).
+const HOME_COOKIE = "feynman-home";
+
+function setHomeCookie() {
+  try {
+    document.cookie = `${HOME_COOKIE}=1; path=/; max-age=31536000; samesite=lax`;
+  } catch {
+    /* cookies blocked — the server keeps SSR-ing the landing; this gate
+       still swaps to HOME after hydration, same as pre-SSR behavior */
+  }
+}
+
 /**
  * Decides between the marketing LANDING and the app HOME at `/`.
  *
@@ -25,7 +41,13 @@ const LANDED_KEY = "feynman-landed";
  * wait for auth to resolve (`ready`) before deciding so a signed-in or
  * returning visitor never flashes the landing on first paint.
  */
-export default function HomeOrLanding() {
+export default function HomeOrLanding({
+  ssrLanding = false,
+}: {
+  /** Server verdict from app/page.tsx: no chat-intent params and no
+   *  `feynman-home` cookie → the initial HTML should be the full landing. */
+  ssrLanding?: boolean;
+}) {
   const { ready, authEnabled, user } = useAuth();
   const router = useRouter();
 
@@ -56,12 +78,22 @@ export default function HomeOrLanding() {
     }
   }, []);
 
+  // Keep the server's cookie mirror in sync: any app-bound visitor (signed in
+  // or already landed) gets the cookie so their NEXT `/` load skips the SSR
+  // landing. A signed-in visitor who doesn't have it yet (first visit after
+  // this shipped, cleared cookies) sees the landing for one paint before the
+  // gate swaps to HOME — once, then the cookie prevents it.
+  useEffect(() => {
+    if (ready && (user || landed)) setHomeCookie();
+  }, [ready, user, landed]);
+
   const markLandedAndShowHome = useCallback(() => {
     try {
       window.localStorage.setItem(LANDED_KEY, "1");
     } catch {
       /* private mode — re-render still flips to home for this session */
     }
+    setHomeCookie();
     setLanded(true);
   }, []);
 
@@ -78,13 +110,19 @@ export default function HomeOrLanding() {
     }
   }, [authEnabled, user, router, markLandedAndShowHome]);
 
-  // Before auth/localStorage resolve, render nothing (a neutral blank) rather
-  // than committing to HOME — otherwise a first-time anonymous visitor on the
-  // hosted build briefly sees the app home, then it swaps to the landing
-  // (a backwards flash). Rendering null until `ready` avoids that while still
-  // never flashing the landing to returning/auth'd users.
+  // CTA copy mirrors the legacy ternary on window.FEYNMAN_PRO (authEnabled).
+  const ctaLabel = authEnabled ? "Get Started Free" : "Start Exploring";
+
+  // Before auth/localStorage resolve, the render depends on the SERVER's
+  // verdict. When the server saw no `feynman-home` cookie and no chat-intent
+  // params (ssrLanding), render the landing — this is what puts real content
+  // and entity links in the initial HTML for crawlers, and it's also the
+  // correct first paint for a first-time anonymous visitor (no flash: the
+  // resolved gate below reaches the same answer). Otherwise render nothing
+  // (a neutral blank) rather than committing to HOME — a returning visitor
+  // must never see a backwards home→landing (or landing→home) flash.
   if (!ready || landed === null || hasChatIntent === null) {
-    return null;
+    return ssrLanding ? <LandingPage ctaLabel={ctaLabel} onCta={handleCta} /> : null;
   }
 
   // Legacy getRoute() (app.js 679-684):
@@ -95,8 +133,6 @@ export default function HomeOrLanding() {
   // login from there, so the intent survives sign-up instead of being lost here).
   const showLanding = !hasChatIntent && (authEnabled ? !user : !landed);
   if (showLanding) {
-    // CTA copy mirrors the legacy ternary on window.FEYNMAN_PRO (authEnabled).
-    const ctaLabel = authEnabled ? "Get Started Free" : "Start Exploring";
     return <LandingPage ctaLabel={ctaLabel} onCta={handleCta} />;
   }
 

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -7,6 +7,7 @@
     { "source": "/robots.txt", "destination": "https://api.feynman.wiki/robots.txt" },
     { "source": "/llms.txt", "destination": "https://api.feynman.wiki/llms.txt" },
     { "source": "/llms-full.txt", "destination": "https://api.feynman.wiki/llms-full.txt" },
+    { "source": "/feynman-indexnow-2026-05-26-7f3a.txt", "destination": "https://api.feynman.wiki/feynman-indexnow-2026-05-26-7f3a.txt" },
     { "source": "/book/:id/og.png", "destination": "https://api.feynman.wiki/book/:id/og.png" },
     { "source": "/mind/:id/og.png", "destination": "https://api.feynman.wiki/mind/:id/og.png" },
     { "source": "/share/:path*", "destination": "https://api.feynman.wiki/share/:path*" }


### PR DESCRIPTION
Follow-up to #231 (the 2026-07-02 SEO/GEO audit) — the last code-level P1.

## Problem
`HomeOrLanding` returns `null` until client auth resolves — and SSR is always in that unresolved state. So the initial HTML of `/` was 13KB with **zero `<a>` tags and zero visible text** (verified with plain curl and Googlebot UA). Consequences:
- `/` is currently the only URL Googlebot still crawls regularly (crawl stalled since the Jun-12 403 incident) — and it discovers nothing from it
- non-JS AI crawlers (GPTBot, ClaudeBot, PerplexityBot) see a blank front door

## Fix
The server (app/page.tsx) now mirrors the client gate:
- chat-intent params (`?book/?q/?mind/?debate`) → app, never the landing (same override as the client — the anonymous book-chat funnel is untouched)
- `feynman-home` cookie (set client-side once a visitor is app-bound: signed in or dismissed the landing) → render nothing and let the client gate pick HOME — the exact pre-SSR behavior, no landing flash for returning users
- everyone else — first-time visitors and crawlers — gets the **full landing in the initial HTML** (hero, #214 sections, footer links to /library /minds /symposiums). For a first-time anonymous visitor this is also what the client gate would render, so no flash, just a faster first paint.

Hydration is consistent: the unresolved client render produces the same landing markup (authEnabled starts false on both sides).

Sole transition cost: a signed-in visitor **without** the cookie (first visit after this ships, or cleared cookies) sees the landing for one paint before the gate swaps to HOME — once; the cookie then prevents it.

## Verification
- Landing itself was already SSR-safe (all `window`/`document` usage sits in effects/callbacks with guards)
- After preview/prod deploy: `curl -s https://feynman.wiki/ | grep -c '<a '` should go 0 → dozens, with `/library`, `/minds`, `/symposiums` links present; repeat with `-b feynman-home=1` to confirm returning users still get the blank shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)