### PR TITLE
egress: kill the SELECT * regression behind the 250GB overage (lite=True on 4 hot paths)

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1405,7 +1405,10 @@ def list_agents(limit: int | None = None, lite: bool = False) -> list[dict[str, 
             "'description',(meta_json::jsonb)->'description',"
             "'chunk_count',(meta_json::jsonb)->'chunk_count',"
             "'creator_name',(meta_json::jsonb)->'creator_name',"
-            "'creator_user_id',(meta_json::jsonb)->'creator_user_id'"
+            "'creator_user_id',(meta_json::jsonb)->'creator_user_id',"
+            # Tiny bool the RAG retrieval split needs (pgvec vs legacy path) —
+            # letting rag.py use lite instead of the full-fat SELECT *.
+            "'pgvector_ready',(meta_json::jsonb)->'pgvector_ready'"
             ")::text AS meta_json "
             "FROM agents WHERE is_deleted = ? ORDER BY created_at DESC"
         )
@@ -2754,7 +2757,12 @@ def list_books_by_topic(topic: str, limit: int = 30) -> list[dict[str, Any]]:
     if not topic:
         return []
     out = []
-    for agent in list_agents(limit=2000):
+    # lite=True is EGRESS-CRITICAL: this runs on the /topic page render path and
+    # only reads id/name/slug/status + meta.category/author — all in the lite
+    # projection. The full-fat SELECT * here (~2000 rows × ~9KB meta_json ≈
+    # 18MB/call, hammered by crawlers) was the dominant leak behind the Aug 2026
+    # 250GB egress overage.
+    for agent in list_agents(limit=2000, lite=True):
         if agent.get("status") not in ("ready", "catalog"):
             continue
         meta = agent.get("meta") or {}
@@ -3557,7 +3565,10 @@ def list_related_books(
         })
         seen.add(agent["id"])
 
-    all_agents = list_agents(limit=2000)
+    # lite=True is EGRESS-CRITICAL: runs on the /book page render path (related
+    # sidebar) and only reads id/name/slug/type/status + meta.category/author.
+    # See list_books_by_topic for the 18MB-per-call SELECT * postmortem.
+    all_agents = list_agents(limit=2000, lite=True)
 
     if topic_lower:
         for a in all_agents:

--- a/app/core/rag.py
+++ b/app/core/rag.py
@@ -215,7 +215,9 @@ def retrieve_cross_book(query: str, top_k: int | None = None, agent_ids: list[st
     top_k = top_k or TOP_K
     embedder = pick_provider("embed")
 
-    all_agents = list_agents()
+    # lite=True: retrieval only needs id/status + meta.pgvector_ready (now in
+    # the lite projection) — not the ~9KB/row full meta_json of every agent.
+    all_agents = list_agents(lite=True)
     ready_agents = {a["id"]: a for a in all_agents if a["status"] == "ready"}
     if agent_ids:
         ready_agents = {k: v for k, v in ready_agents.items() if k in agent_ids}

--- a/app/main.py
+++ b/app/main.py
@@ -3418,7 +3418,7 @@ class SearchBookRequest(BaseModel):
 @app.post("/api/discover")
 def api_discover(payload: DiscoverRequest, request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
     _check_quota(request, "discover")
-    existing_titles = [a["name"] for a in list_agents(limit=200)]
+    existing_titles = [a["name"] for a in list_agents(limit=200, lite=True)]
     try:
         books, usage = _discover_books_for_topic(payload.topic.strip(), count=payload.count, exclude_titles=existing_titles)
     except ProviderError as exc:


### PR DESCRIPTION
## What happened

Supabase org banner: previous cycle (Jul 11–Aug 11) **exceeded 250GB egress**; current cycle already at 65GB in 5 days (~12GB/day) — with ~no users.

`pg_stat_statements` (window since Jun 10):

```
SELECT * FROM agents WHERE is_deleted=$1 ORDER BY created_at DESC LIMIT $2
→ 88,724,341 rows / 44,438 calls ≈ 1,997 rows/call ≈ ~18MB/call ≈ ~12GB/day
```

This is the #110 anti-pattern back again on two request paths that were never converted to the lite projection:
- `list_books_by_topic` — runs on every **/topic** page render
- `list_related_books` — runs on every **/book** page render (related sidebar)

Both do `list_agents(limit=2000)` = full-fat `SELECT *` including ~9KB/row `meta_json`, then read only `id/name/slug/type/status` + `meta.category/author`. The July crawler wave (IndexNow/Bing re-crawl after the Jul 2 SEO fixes) hit exactly these pages on every ISR MISS → the overage.

## Fix (SQL-layer trim, per the egress postmortem rules)

- `list_books_by_topic` + `list_related_books` → `lite=True`
- `app/core/rag.py` retrieval → `lite=True`, with `pgvector_ready` (bool) added to the lite projection so the pgvec/legacy split keeps working
- `api_discover` existing-titles read → `lite=True`

Expected: ~12GB/day → ~0.2GB/day from these paths (~50× less). SQLite/local dev unaffected (`lite` only branches under `_USE_PG`).

## Verify after deploy

`SELECT pg_stat_statements_reset()`, wait a day, confirm the `SELECT *` statement's rows-delta ≈ 0 and the lite `jsonb_build_object` statement takes over; Supabase usage page daily egress should drop to low single-digit GB → then keep falling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)